### PR TITLE
fix(modal): if helptext isn't set don't render it

### DIFF
--- a/src/components/BaseModal/BaseModal.js
+++ b/src/components/BaseModal/BaseModal.js
@@ -232,7 +232,7 @@ class BaseModal extends React.Component {
           'big-modal': isLarge,
         })}>
         <ModalHeader label={label} title={title} closeModal={onClose} buttonOnClick={onClose}>
-          <p className="bx--modal-content__text">{helpText}</p>
+          {helpText ? <p className="bx--modal-content__text">{helpText}</p> : null}
         </ModalHeader>
         {children ? <ModalBody>{children}</ModalBody> : null}
         {error || dataError ? (

--- a/src/components/__snapshots__/StorybookSnapshots-test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots-test.js.snap
@@ -598,9 +598,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots BaseModal big mo
           >
             Needs a lot of space to contain all the info
           </p>
-          <p
-            className="bx--modal-content__text"
-          />
           <button
             className="bx--modal-close"
             onClick={[Function]}
@@ -2090,9 +2087,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots BaseModal custom
           >
             Custom footer element
           </p>
-          <p
-            className="bx--modal-content__text"
-          />
           <button
             className="bx--modal-close"
             onClick={[Function]}
@@ -3550,9 +3544,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots BaseModal error 
           >
             Cannot communicate with server
           </p>
-          <p
-            className="bx--modal-content__text"
-          />
           <button
             className="bx--modal-close"
             onClick={[Function]}
@@ -6230,9 +6221,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots BaseModal no foo
           >
             Dialog without footer
           </p>
-          <p
-            className="bx--modal-content__text"
-          />
           <button
             className="bx--modal-close"
             onClick={[Function]}
@@ -7637,9 +7625,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots BaseModal sendin
           >
             We are submitting data to the backend
           </p>
-          <p
-            className="bx--modal-content__text"
-          />
           <button
             className="bx--modal-close"
             onClick={[Function]}
@@ -18915,9 +18900,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal basi
           >
             Gimme 3 Steps
           </p>
-          <p
-            className="bx--modal-content__text"
-          />
           <button
             className="bx--modal-close"
             onClick={[Function]}
@@ -20211,9 +20193,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal cust
           >
             Gimme 3 Steps
           </p>
-          <p
-            className="bx--modal-content__text"
-          />
           <button
             className="bx--modal-close"
             onClick={[Function]}


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- See bug 15

**Change List (commits, features, bugs, etc)**

- fix(basemodal): only render helpText if its passed

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#15

**Acceptance Test (how to verify the PR)**

- Make sure the helpText paragraph doesn't render if no helpText is passed
