### PR TITLE
feat(table): simplify pagination prop model

### DIFF
--- a/src/components/Table/Table-story.js
+++ b/src/components/Table/Table-story.js
@@ -164,7 +164,6 @@ class TablePagination extends Component {
       },
       view: {
         pagination: {
-          totalItems: tableData.length,
           pageSize: 10,
           pageSizes: [10, 20, 30],
           page: 1,

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -53,7 +53,6 @@ const propTypes = {
   view: PropTypes.shape({
     pagination: PropTypes.shape({
       pageSizes: PropTypes.arrayOf(PropTypes.number),
-      totalItems: PropTypes.number.isRequired,
       page: PropTypes.number.isRequired,
     }),
     filters: PropTypes.arrayOf(
@@ -221,7 +220,9 @@ const Table = ({ columns, data, view, actions, options }) => {
         </CarbonTable>
       </TableContainer>
 
-      {options.hasPagination ? <PaginationV2 {...view.pagination} {...actions.pagination} /> : null}
+      {options.hasPagination ? (
+        <PaginationV2 {...view.pagination} {...actions.pagination} totalItems={data.length} />
+      ) : null}
     </div>
   );
 };

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -52,6 +52,7 @@ const propTypes = {
   }),
   view: PropTypes.shape({
     pagination: PropTypes.shape({
+      pageSize: PropTypes.number,
       pageSizes: PropTypes.arrayOf(PropTypes.number),
       page: PropTypes.number.isRequired,
     }),
@@ -109,7 +110,11 @@ const propTypes = {
 const defaultProps = {
   options: {},
   view: {
-    pagination: { pageSizes: [10, 20, 30] },
+    pagination: {
+      pageSize: 10,
+      pageSizes: [10, 20, 30],
+      page: 1,
+    },
     toolbar: {},
     table: {},
   },
@@ -221,7 +226,12 @@ const Table = ({ columns, data, view, actions, options }) => {
       </TableContainer>
 
       {options.hasPagination ? (
-        <PaginationV2 {...view.pagination} {...actions.pagination} totalItems={data.length} />
+        <PaginationV2
+          {...view.pagination}
+          {...actions.pagination}
+          totalItems={data.length}
+          pageSize={view.pagination.pageSize || view.pagination.pageSizes[0]}
+        />
       ) : null}
     </div>
   );


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- We're fully encapsulating the `<Pagination/>`, so we always know the `totalItems` from the existing `data.length`.
- Same thing for the `pageSize`, we can infer if there isn't a declared `pageSize`, we can use `pageSizes[0]`

**Change List (commits, features, bugs, etc)**

- remove `totalItems` from the `<Table/>` prop model
- add updates to `pageSize(s)`
- add better default props/usages
- update story

**Acceptance Test (how to verify the PR)**

- Pagination renders/functions properly in storybook without errors.
