### PR TITLE
feat(table): only show row extra options on row hover or expansion

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -188,6 +188,14 @@ const defaultProps = {
   },
 };
 
+const RowActionsContainer = styled.div`
+  & {
+    display: flex;
+    justify-content: flex-end;
+    opacity: ${props => (props.visible ? 1 : 0)};
+  }
+`;
+
 const RowActionButton = styled(Button)`
   &&& {
     color: ${props => (props.rowexpanded ? COLORS.white : COLORS.darkGray)};
@@ -207,6 +215,13 @@ const RowActionButton = styled(Button)`
 const StyledTableExpandRow = styled(TableExpandRow)`
   &&& {
     cursor: pointer;
+    :hover {
+      td {
+        div {
+          opacity: 1;
+        }
+      }
+    }
   }
 `;
 
@@ -386,10 +401,10 @@ const Table = props => {
                   />
                 </TableCell>
               ) : null;
-              const rowActionsCell =
+              const rowActionsCell = expanded =>
                 i.rowActions && i.rowActions.length > 0 ? (
                   <TableCell key={`${i.id}-row-actions-cell`}>
-                    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <RowActionsContainer visible={expanded}>
                       {i.rowActions.map(a => (
                         <RowActionButton
                           key={`${i.id}-row-actions-button-${a.id}`}
@@ -407,7 +422,7 @@ const Table = props => {
                           {a.labelText}
                         </RowActionButton>
                       ))}
-                    </div>
+                    </RowActionsContainer>
                   </TableCell>
                 ) : null;
               const tableCells = (
@@ -416,7 +431,7 @@ const Table = props => {
                   {columns.map(col => (
                     <TableCell key={col.id}>{i.values[col.id]}</TableCell>
                   ))}
-                  {rowActionsCell}
+                  {rowActionsCell(isRowExpanded)}
                 </React.Fragment>
               );
               return options.hasRowExpansion ? (

--- a/src/components/__snapshots__/StorybookSnapshots-test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots-test.js.snap
@@ -12389,20 +12389,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
   right: 0;
 }
 
-.c4.c4.c4 {
-  color: #152935;
-}
-
-.c4.c4.c4 svg {
-  fill: #152935;
-}
-
-.c4.c4.c4:hover {
-  color: #fff;
-}
-
-.c4.c4.c4:hover svg {
-  fill: #fff;
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  opacity: 0;
 }
 
 .c5.c5.c5 {
@@ -12411,7 +12407,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
 
 .c5.c5.c5 svg {
   fill: #152935;
-  margin-left: 0;
 }
 
 .c5.c5.c5:hover {
@@ -12422,8 +12417,29 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
   fill: #fff;
 }
 
+.c6.c6.c6 {
+  color: #152935;
+}
+
+.c6.c6.c6 svg {
+  fill: #152935;
+  margin-left: 0;
+}
+
+.c6.c6.c6:hover {
+  color: #fff;
+}
+
+.c6.c6.c6:hover svg {
+  fill: #fff;
+}
+
 .c3.c3.c3 {
   cursor: pointer;
+}
+
+.c3.c3.c3:hover td div {
+  opacity: 1;
 }
 
 <div
@@ -13015,15 +13031,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -13052,7 +13063,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                       </svg>
                     </button>
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -13163,15 +13174,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -13282,15 +13288,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -13401,15 +13402,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -13438,7 +13434,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                       </svg>
                     </button>
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -13549,15 +13545,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -13586,7 +13577,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                       </svg>
                     </button>
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -13697,15 +13688,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -13734,7 +13720,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                       </svg>
                     </button>
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -13845,15 +13831,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -13882,7 +13863,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                       </svg>
                     </button>
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -13993,15 +13974,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -14112,15 +14088,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -14149,7 +14120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                       </svg>
                     </button>
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -14260,15 +14231,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c4"
                   >
                     <button
-                      className="c5 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -28420,6 +28386,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
   cursor: pointer;
 }
 
+.c0.c0.c0:hover td div {
+  opacity: 1;
+}
+
 .c1.c1.c1 {
   cursor: pointer;
 }
@@ -37233,20 +37203,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
 `;
 
 exports[`Storybook Snapshot tests and console checks Storyshots Table with row expansion and actions 1`] = `
-.c1.c1.c1 {
-  color: #152935;
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  opacity: 0;
 }
 
-.c1.c1.c1 svg {
-  fill: #152935;
-}
-
-.c1.c1.c1:hover {
-  color: #fff;
-}
-
-.c1.c1.c1:hover svg {
-  fill: #fff;
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  opacity: 1;
 }
 
 .c2.c2.c2 {
@@ -37255,7 +37233,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
 
 .c2.c2.c2 svg {
   fill: #152935;
-  margin-left: 0;
 }
 
 .c2.c2.c2:hover {
@@ -37266,20 +37243,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
   fill: #fff;
 }
 
-.c4.c4.c4 {
+.c3.c3.c3 {
+  color: #152935;
+}
+
+.c3.c3.c3 svg {
+  fill: #152935;
+  margin-left: 0;
+}
+
+.c3.c3.c3:hover {
   color: #fff;
 }
 
-.c4.c4.c4 svg {
+.c3.c3.c3:hover svg {
+  fill: #fff;
+}
+
+.c6.c6.c6 {
+  color: #fff;
+}
+
+.c6.c6.c6 svg {
   fill: #fff;
   margin-left: 0;
 }
 
-.c4.c4.c4:hover {
+.c6.c6.c6:hover {
   color: #152935;
 }
 
-.c4.c4.c4:hover svg {
+.c6.c6.c6:hover svg {
   fill: #152935;
 }
 
@@ -37287,41 +37281,45 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
   cursor: pointer;
 }
 
-.c3.c3.c3 {
+.c0.c0.c0:hover td div {
+  opacity: 1;
+}
+
+.c4.c4.c4 {
   cursor: pointer;
 }
 
-.c3.c3.c3 td {
+.c4.c4.c4 td {
   background-color: #3d70b2;
   border-color: #3d70b2;
   color: white;
   border-top: 1px solid #3d70b2;
 }
 
-.c3.c3.c3 td button svg {
+.c4.c4.c4 td button svg {
   fill: white;
 }
 
-.c3.c3.c3 td:first-of-type {
+.c4.c4.c4 td:first-of-type {
   border-left: 1px solid #3d70b2;
 }
 
-.c3.c3.c3 td:last-of-type {
+.c4.c4.c4 td:last-of-type {
   border-right: 1px solid #3d70b2;
 }
 
-.c5.c5.c5 td {
+.c7.c7.c7 td {
   background-color: inherit;
   border-left: 4px solid #3d70b2;
   border-width: 0 0 0 4px;
 }
 
-.c5.c5.c5:hover {
+.c7.c7.c7:hover {
   border: inherit;
   background-color: inherit;
 }
 
-.c5.c5.c5:hover td {
+.c7.c7.c7:hover td {
   background-color: inherit;
   border-left: solid #3d70b2;
   border-width: 0 0 0 4px;
@@ -37471,15 +37469,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -37508,7 +37501,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -37588,15 +37581,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -37630,7 +37618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
               </tr>
               <tr
-                className="bx--parent-row-v2 bx--expandable-row-v2 c3"
+                className="bx--parent-row-v2 bx--expandable-row-v2 c4"
                 data-parent-row={true}
                 id="Table-Row-row-2"
                 onClick={[Function]}
@@ -37677,15 +37665,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c5"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -37727,7 +37710,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
               </tr>
               <tr
-                className="c5"
+                className="c7"
               >
                 <td
                   colSpan={6}
@@ -37828,15 +37811,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -37916,15 +37894,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -37953,7 +37926,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -37987,7 +37960,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
               </tr>
               <tr
-                className="bx--parent-row-v2 bx--expandable-row-v2 c3"
+                className="bx--parent-row-v2 bx--expandable-row-v2 c4"
                 data-parent-row={true}
                 id="Table-Row-row-5"
                 onClick={[Function]}
@@ -38034,15 +38007,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c5"
                   >
                     <button
-                      className="c4 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c6 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -38084,7 +38052,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
               </tr>
               <tr
-                className="c5"
+                className="c7"
               >
                 <td
                   colSpan={6}
@@ -38185,15 +38153,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -38273,15 +38236,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -38361,15 +38319,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -38398,7 +38351,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -38478,15 +38431,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -38566,15 +38514,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -38654,15 +38597,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -38742,15 +38680,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -38779,7 +38712,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -38859,15 +38792,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -38947,15 +38875,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39035,15 +38958,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39123,15 +39041,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -39160,7 +39073,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39240,15 +39153,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39328,15 +39236,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -39416,15 +39319,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39504,15 +39402,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -39541,7 +39434,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39621,15 +39514,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39709,15 +39597,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39797,15 +39680,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -39885,15 +39763,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -39922,7 +39795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -40002,15 +39875,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40090,15 +39958,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40178,15 +40041,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40266,15 +40124,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -40303,7 +40156,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40383,15 +40236,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40471,15 +40319,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -40559,15 +40402,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40647,15 +40485,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -40684,7 +40517,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40764,15 +40597,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40852,15 +40680,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -40940,15 +40763,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41028,15 +40846,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -41065,7 +40878,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -41145,15 +40958,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41233,15 +41041,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41321,15 +41124,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41409,15 +41207,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -41446,7 +41239,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41526,15 +41319,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41614,15 +41402,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -41702,15 +41485,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41790,15 +41568,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -41827,7 +41600,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41907,15 +41680,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -41995,15 +41763,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42083,15 +41846,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42171,15 +41929,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -42208,7 +41961,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -42288,15 +42041,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42376,15 +42124,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42464,15 +42207,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42552,15 +42290,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -42589,7 +42322,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42669,15 +42402,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42757,15 +42485,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -42845,15 +42568,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -42933,15 +42651,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -42970,7 +42683,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43050,15 +42763,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43138,15 +42846,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43226,15 +42929,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43314,15 +43012,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -43351,7 +43044,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -43431,15 +43124,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43519,15 +43207,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43607,15 +43290,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43695,15 +43373,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -43732,7 +43405,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43812,15 +43485,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -43900,15 +43568,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -43988,15 +43651,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44076,15 +43734,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -44113,7 +43766,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44193,15 +43846,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44281,15 +43929,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44369,15 +44012,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44457,15 +44095,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -44494,7 +44127,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -44574,15 +44207,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44662,15 +44290,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44750,15 +44373,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44838,15 +44456,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -44875,7 +44488,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -44955,15 +44568,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45043,15 +44651,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -45131,15 +44734,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45219,15 +44817,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -45256,7 +44849,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45336,15 +44929,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45424,15 +45012,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45512,15 +45095,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45600,15 +45178,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -45637,7 +45210,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -45717,15 +45290,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45805,15 +45373,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45893,15 +45456,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -45981,15 +45539,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -46018,7 +45571,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46098,15 +45651,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46186,15 +45734,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -46274,15 +45817,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46362,15 +45900,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -46399,7 +45932,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46479,15 +46012,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46567,15 +46095,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46655,15 +46178,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46743,15 +46261,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c1 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="false"
                       onClick={[Function]}
@@ -46780,7 +46293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                       </svg>
                     </button>
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={true}
                       nolabel="true"
                       onClick={[Function]}
@@ -46860,15 +46373,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -46948,15 +46456,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}
@@ -47036,15 +46539,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                 </td>
                 <td>
                   <div
-                    style={
-                      Object {
-                        "display": "flex",
-                        "justifyContent": "flex-end",
-                      }
-                    }
+                    className="c1"
                   >
                     <button
-                      className="c2 bx--btn bx--btn--sm bx--btn--ghost"
+                      className="c3 bx--btn bx--btn--sm bx--btn--ghost"
                       disabled={false}
                       nolabel="true"
                       onClick={[Function]}


### PR DESCRIPTION
**Summary**

- Only show row actions on table row hover, or when the row is expanded

![image](https://user-images.githubusercontent.com/2175647/53450316-826b3680-39e1-11e9-8af5-b60a379e5660.png)

**Acceptance Test (how to verify the PR)**

- Run stateful example in storybook and verify behavior.
