### PR TITLE
feat(table): add empty state

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "styled-components": "^4.1.3"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "^0.0.1-alpha.12",
     "carbon-components": "^9.x",
     "carbon-components-react": "^6.x",
     "carbon-icons": "^7.x",

--- a/src/components/Table/Table-story.js
+++ b/src/components/Table/Table-story.js
@@ -105,6 +105,7 @@ const actions = {
   table: {
     onRowSelected: action('onRowSelected'),
     onSelectAll: action('onSelectAll'),
+    onDefaultEmptyCallToAction: action('onDefaultEmptyCallToAction'),
   },
 };
 
@@ -387,6 +388,9 @@ class StatefulTableWrapper extends Component {
         onApplyRowAction: (rowId, actionId) => {
           alert(`action "${actionId}" clicked for row "${rowId}"`); //eslint-disable-line
         },
+        onDefaultEmptyCallToAction: () => {
+          alert(`action onDefaultEmptyCallToAction clicked`); //eslint-disable-line
+        },
       },
     };
     return (
@@ -618,5 +622,12 @@ storiesOf('Table', module)
   })
   .add('with customized columns', () => <p>TODO - a couple columns selected and reordered</p>)
   .add('with no results', () => <p>TODO - empty state when filters applied and no results</p>)
-  .add('with no data', () => <p>TODO - empty state when no data provided</p>)
+  .add('with no data', () => (
+    <Table
+      columns={tableColumns}
+      data={[]}
+      actions={actions}
+      options={{ emptyMessage: 'There is no data here' }}
+    />
+  ))
   .add('is loading', () => <p>TODO - empty state when data is loading</p>);

--- a/src/components/Table/Table-story.js
+++ b/src/components/Table/Table-story.js
@@ -688,9 +688,9 @@ storiesOf('Table', module)
       view={{
         table: {
           emptyState: (
-            <div>
-              <h1>Custom empty state</h1>
-              <p>Hey, no data!</p>
+            <div key="empty-state">
+              <h1 key="empty-state-heading">Custom empty state</h1>
+              <p key="empty-state-message">Hey, no data!</p>
             </div>
           ),
         },

--- a/src/components/__snapshots__/StorybookSnapshots-test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots-test.js.snap
@@ -14941,6 +14941,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                           </span>
                           ,
                         </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
+                          </span>
+                          ,
+                        </div>
                         <button
                           className="css-1sgldz e1i4ski80"
                           onClick={[Function]}
@@ -16365,6 +16389,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                                 }
                               >
                                 onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
                                 ?
                                 :
                                  
@@ -19801,6 +19849,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                               >
                                 onSelectAll
                               </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onDefaultEmptyCallToAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                              </span>
                               }
                             </span>
                             }
@@ -20082,6 +20152,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                           </span>
                           <span>
                             bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
                           </span>
                           ,
                         </div>
@@ -21509,6 +21603,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                                 }
                               >
                                 onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
                                 ?
                                 :
                                  
@@ -25034,6 +25152,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                               >
                                 onSelectAll
                               </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onDefaultEmptyCallToAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                              </span>
                               }
                             </span>
                             }
@@ -25824,6 +25964,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                           </span>
                           <span>
                             bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
                           </span>
                           ,
                         </div>
@@ -27260,6 +27424,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -27906,6 +28094,38 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
 `;
 
 exports[`Storybook Snapshot tests and console checks Storyshots Table with no data 1`] = `
+.c0.c0.c0:hover td {
+  border: 1px solid #dfe3e6;
+  background: inherit;
+}
+
+.c0.c0.c0 .empty-table-cell--default {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: middle;
+  -webkit-justify-content: middle;
+  -ms-flex-pack: middle;
+  justify-content: middle;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 3rem;
+}
+
+.c0.c0.c0 .empty-table-cell--default svg {
+  margin: 1rem;
+}
+
+.c0.c0.c0 .empty-table-cell--default > * {
+  margin: 0.5rem;
+}
+
 <div
   className="storybook-container"
   style={
@@ -27926,9 +28146,116 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
         }
       }
     >
-      <p>
-        TODO - empty state when no data provided
-      </p>
+      <div>
+        <div
+          className="bx--data-table-v2-container"
+        >
+          <section
+            className="bx--table-toolbar"
+          >
+            <div
+              className="bx--toolbar-content"
+            >
+              <div
+                className="bx--batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                  <button
+                    className="bx--batch-summary__cancel"
+                    onClick={[Function]}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+          <table
+            className="bx--data-table-v2"
+          >
+            <thead>
+              <tr>
+                <th
+                  id="Table-Header-Column-string"
+                  scope="col"
+                  style={Object {}}
+                >
+                  String
+                </th>
+                <th
+                  id="Table-Header-Column-date"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Date
+                </th>
+                <th
+                  id="Table-Header-Column-select"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Select
+                </th>
+                <th
+                  id="Table-Header-Column-number"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Number
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                className="c0"
+              >
+                <td
+                  colSpan={4}
+                >
+                  <div
+                    className="empty-table-cell--default"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable={false}
+                      height={32}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={32}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                      />
+                    </svg>
+                    <p>
+                      There's no data here
+                    </p>
+                    <button
+                      className="bx--btn bx--btn--primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Create some data
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
     <button
       onClick={[Function]}
@@ -28060,74 +28387,776 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
               className="css-r8d96o eyvlbql0"
             >
               <div>
-                <div>
-                  <div
+                <div
+                  style={
+                    Object {
+                      "paddingLeft": 18,
+                      "paddingRight": 3,
+                    }
+                  }
+                >
+                  <span
                     style={
                       Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
+                        "color": "#444",
                       }
                     }
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      p
+                    &lt;
+                    Table
+                  </span>
+                  <span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        columns
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'string'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'String'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              …
+                            </span>
+                            <span>
+                              <br />
+                                
+                            </span>
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
                     </span>
-                    <span />
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        data
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
                     </span>
-                  </div>
-                  <div
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        actions
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                pagination
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onChange
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onChange
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                toolbar
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onApplyFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onToggleFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onClearAllFilters
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onClearAllFilters
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                …
+                              </span>
+                              <span>
+                                <br />
+                                    
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                table
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onRowSelected
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onSelectAll
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onDefaultEmptyCallToAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        options
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                emptyMessage
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              'There is no data here'
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                      <br />
+                    </span>
+                  </span>
+                  <span
                     style={
                       Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
+                        "color": "#444",
                       }
                     }
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      TODO - empty state when no data provided
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      p
-                      &gt;
-                    </span>
-                  </div>
+                    /&gt;
+                  </span>
                 </div>
               </div>
               <button
@@ -28152,6 +29181,2365 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                 </div>
               </button>
             </pre>
+          </div>
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Prop Types
+            </h1>
+            <div>
+              <h2
+                style={
+                  Object {
+                    "margin": "20px 0 0 0",
+                  }
+                }
+              >
+                "
+                Table
+                " Component
+              </h2>
+              <table
+                className="css-1uhv8nx e1vdo5380"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      property
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      propType
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      required
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      default
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      id
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        string
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        'Table'
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      DOM ID for component
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      options
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasPagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowSelection
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowExpansion
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowActions
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasFilter
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  hasPagination: false,
+  hasRowSelection: false…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Optional properties to customize how the table should be rendered
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      view
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSize
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSizes
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    number
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                page
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                totalItems
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            filters
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <span>
+                              [
+                            </span>
+                            <span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    value
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                            </span>
+                            <span>
+                              ]
+                            </span>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                activeBar
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                oneOf 'filter'
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                batchActions
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        id
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        labelText
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        icon
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        <span>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            {
+                                          </button>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                          >
+                                            ...
+                                          </button>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              width
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              height
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              viewBox
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              svgData
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              object
+                                            </span>
+                                            ,
+                                          </div>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            }
+                                          </button>
+                                        </span>
+                                        <span>
+                                           | 
+                                        </span>
+                                        <span>
+                                          string
+                                        </span>
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        iconDescription
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllIndeterminate
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                selectedIds
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    string
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                sort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    direction
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    oneOf 'NONE' | 'ASC' | 'DESC'
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                expandedRows
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        rowId
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        content
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        element
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  pagination: {
+    pageSize: 10,
+    pageSizes:…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      actions
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChange
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onClearAllFilters
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onCancelBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowExpanded
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChangeSort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  pagination: { onChange: defaultFunction('actio…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Callbacks for actions of the table, can be used to update state in wrapper component to update \`view\` props
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      columns
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <span>
+                          [
+                        </span>
+                        <span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                id
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                name
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                size
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSortable
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                filter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 30,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    placeholderText
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 30,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    options
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    <span>
+                                      [
+                                    </span>
+                                    <span>
+                                      <span>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                        >
+                                          {
+                                        </button>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                        >
+                                          ...
+                                        </button>
+                                        <div
+                                          style={
+                                            Object {
+                                              "marginLeft": 15,
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            style={
+                                              Object {
+                                                "whiteSpace": "nowrap",
+                                              }
+                                            }
+                                          >
+                                            id
+                                            
+                                            :
+                                             
+                                          </span>
+                                          <span>
+                                            string
+                                          </span>
+                                          ,
+                                        </div>
+                                        <div
+                                          style={
+                                            Object {
+                                              "marginLeft": 15,
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            style={
+                                              Object {
+                                                "whiteSpace": "nowrap",
+                                              }
+                                            }
+                                          >
+                                            text
+                                            
+                                            :
+                                             
+                                          </span>
+                                          <span>
+                                            string
+                                          </span>
+                                          ,
+                                        </div>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                        >
+                                          }
+                                        </button>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      ]
+                                    </span>
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                        </span>
+                        <span>
+                          ]
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      yes
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Specify the properties of each column in the table
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      data
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <span>
+                          [
+                        </span>
+                        <span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                id
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                values
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                object
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                rowActions
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        id
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        icon
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        labelText
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        disabled
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        bool
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                        </span>
+                        <span>
+                          ]
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      yes
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Data for the body of the table
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
@@ -34565,6 +37953,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               >
                                 onSelectAll
                               </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onDefaultEmptyCallToAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                              </span>
                               }
                             </span>
                             }
@@ -35151,6 +38561,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                           </span>
                           <span>
                             bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
                           </span>
                           ,
                         </div>
@@ -36578,6 +40012,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                 }
                               >
                                 onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
                                 ?
                                 :
                                  
@@ -48765,6 +52223,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               >
                                 onSelectAll
                               </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onDefaultEmptyCallToAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                              </span>
                               }
                             </span>
                             }
@@ -49373,6 +52853,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                           </span>
                           <span>
                             bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
                           </span>
                           ,
                         </div>
@@ -50800,6 +54304,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                 }
                               >
                                 onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
                                 ?
                                 :
                                  
@@ -53636,6 +57164,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                               >
                                 onSelectAll
                               </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onDefaultEmptyCallToAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                              </span>
                               }
                             </span>
                             }
@@ -54397,6 +57947,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                           </span>
                           <span>
                             bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
                           </span>
                           ,
                         </div>
@@ -55824,6 +59398,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                                 }
                               >
                                 onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
                                 ?
                                 :
                                  
@@ -58688,6 +62286,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                               >
                                 onSelectAll
                               </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onDefaultEmptyCallToAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
+                              </span>
                               }
                             </span>
                             }
@@ -59358,6 +62978,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                           </span>
                           <span>
                             bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            emptyTableContent
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            node
                           </span>
                           ,
                         </div>
@@ -60785,6 +64429,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                                 }
                               >
                                 onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onDefaultEmptyCallToAction
                                 ?
                                 :
                                  

--- a/src/components/__snapshots__/StorybookSnapshots-test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots-test.js.snap
@@ -32237,6 +32237,3822 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Table with no data and custom empty state 1`] = `
+.c0.c0.c0:hover td {
+  border: 1px solid #dfe3e6;
+  background: inherit;
+}
+
+.c0.c0.c0 .empty-table-cell--default {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: middle;
+  -webkit-justify-content: middle;
+  -ms-flex-pack: middle;
+  justify-content: middle;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 3rem;
+}
+
+.c0.c0.c0 .empty-table-cell--default svg {
+  margin: 1rem;
+}
+
+.c0.c0.c0 .empty-table-cell--default > * {
+  margin: 0.5rem;
+}
+
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3em",
+    }
+  }
+>
+  <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div>
+        <div
+          className="bx--data-table-v2-container"
+        >
+          <section
+            className="bx--table-toolbar"
+          >
+            <div
+              className="bx--toolbar-content"
+            >
+              <div
+                className="bx--batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                  <button
+                    className="bx--batch-summary__cancel"
+                    onClick={[Function]}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+          <table
+            className="bx--data-table-v2"
+          >
+            <thead>
+              <tr>
+                <th
+                  id="Table-Header-Column-string"
+                  scope="col"
+                  style={Object {}}
+                >
+                  String
+                </th>
+                <th
+                  id="Table-Header-Column-date"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Date
+                </th>
+                <th
+                  id="Table-Header-Column-select"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Select
+                </th>
+                <th
+                  id="Table-Header-Column-number"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Number
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                className="c0"
+              >
+                <td
+                  colSpan={4}
+                >
+                  <div>
+                    <h1>
+                      Custom empty state
+                    </h1>
+                    <p>
+                      Hey, no data!
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div
+          className="bx--pagination"
+          disabled={false}
+        >
+          <div
+            className="bx--pagination__left"
+          >
+            <span
+              className="bx--pagination__text"
+            >
+              Items per page:
+            </span>
+            <div
+              className="bx--form-item"
+            >
+              <div
+                className="bx--select bx--select--inline"
+              >
+                <label
+                  className="bx--label bx--visually-hidden"
+                  htmlFor="bx-pagination-select-7"
+                >
+                  Items per page:
+                </label>
+                <select
+                  className="bx--select-input"
+                  id="bx-pagination-select-7"
+                  onChange={[Function]}
+                  value={10}
+                >
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={10}
+                  >
+                    10
+                  </option>
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={20}
+                  >
+                    20
+                  </option>
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={30}
+                  >
+                    30
+                  </option>
+                </select>
+                <svg
+                  alt="open list of options"
+                  aria-label="open list of options"
+                  className="bx--select__arrow"
+                  fillRule="evenodd"
+                  height="5"
+                  role="img"
+                  viewBox="0 0 10 5"
+                  width="10"
+                >
+                  <title>
+                    open list of options
+                  </title>
+                  <path
+                    d="M0 0l5 4.998L10 0z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <span
+              className="bx--pagination__text"
+            >
+               |  
+              0-0 of 0 items
+            </span>
+          </div>
+          <div
+            className="bx--pagination__right bx--pagination--inline"
+          >
+            <span
+              className="bx--pagination__text"
+            >
+              1 of 1 pages
+            </span>
+            <button
+              aria-label="Backward"
+              className="bx--pagination__button bx--pagination__button--backward"
+              disabled={true}
+              onClick={[Function]}
+            >
+              <svg
+                alt="Backward"
+                aria-label="Backward"
+                className="bx--pagination__button-icon"
+                fillRule="evenodd"
+                height="12"
+                role="img"
+                viewBox="0 0 7 12"
+                width="7"
+              >
+                <title>
+                  Backward
+                </title>
+                <path
+                  d="M1.45 6.002L7 11.27l-.685.726L0 6.003 6.315 0 7 .726z"
+                />
+              </svg>
+            </button>
+            <div
+              className="bx--form-item"
+            >
+              <div
+                className="bx--select bx--select--inline"
+              >
+                <label
+                  className="bx--label bx--visually-hidden"
+                  htmlFor="bx-pagination-select-9"
+                >
+                  Items per page:
+                </label>
+                <select
+                  className="bx--select-input"
+                  id="bx-pagination-select-9"
+                  onChange={[Function]}
+                  value={1}
+                >
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={1}
+                  >
+                    1
+                  </option>
+                </select>
+                <svg
+                  alt="open list of options"
+                  aria-label="open list of options"
+                  className="bx--select__arrow"
+                  fillRule="evenodd"
+                  height="5"
+                  role="img"
+                  viewBox="0 0 10 5"
+                  width="10"
+                >
+                  <title>
+                    open list of options
+                  </title>
+                  <path
+                    d="M0 0l5 4.998L10 0z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <button
+              aria-label="Forward"
+              className="bx--pagination__button bx--pagination__button--forward"
+              disabled={true}
+              onClick={[Function]}
+            >
+              <svg
+                alt="Forward"
+                aria-label="Forward"
+                className="bx--pagination__button-icon"
+                fillRule="evenodd"
+                height="12"
+                role="img"
+                viewBox="0 0 7 12"
+                width="7"
+              >
+                <title>
+                  Forward
+                </title>
+                <path
+                  d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <button
+      onClick={[Function]}
+      style={
+        Object {
+          "background": "#28c",
+          "border": "none",
+          "borderRadius": "0 0 0 5px",
+          "color": "#fff",
+          "cursor": "pointer",
+          "display": "block",
+          "fontFamily": "sans-serif",
+          "fontSize": "12px",
+          "padding": "5px 15px",
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+        }
+      }
+      type="button"
+    >
+      Show Info
+    </button>
+    <div
+      style={
+        Object {
+          "background": "white",
+          "bottom": 0,
+          "display": "none",
+          "left": 0,
+          "overflow": "auto",
+          "padding": "0 40px",
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 99999,
+        }
+      }
+    >
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        ×
+      </button>
+      <div>
+        <div
+          style={
+            Object {
+              "WebkitFontSmoothing": "antialiased",
+              "backgroundColor": "#fff",
+              "border": "1px solid #eee",
+              "borderRadius": "2px",
+              "color": "#444",
+              "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+              "fontSize": "15px",
+              "fontWeight": 300,
+              "lineHeight": 1.45,
+              "marginBottom": "20px",
+              "marginTop": "20px",
+              "padding": "20px 40px 40px",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "borderBottom": "1px solid #eee",
+                "marginBottom": 10,
+                "paddingTop": 10,
+              }
+            }
+          >
+            <h1
+              style={
+                Object {
+                  "fontSize": "35px",
+                  "margin": 0,
+                  "padding": 0,
+                }
+              }
+            >
+              Table
+            </h1>
+            <h2
+              style={
+                Object {
+                  "fontSize": "22px",
+                  "fontWeight": 400,
+                  "margin": "0 0 10px 0",
+                  "padding": 0,
+                }
+              }
+            >
+              with no data and custom empty state
+            </h2>
+          </div>
+          
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Story Source
+            </h1>
+            <pre
+              className="css-r8d96o eyvlbql0"
+            >
+              <div>
+                <div
+                  style={
+                    Object {
+                      "paddingLeft": 18,
+                      "paddingRight": 3,
+                    }
+                  }
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    &lt;
+                    Table
+                  </span>
+                  <span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        columns
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'string'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'String'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              …
+                            </span>
+                            <span>
+                              <br />
+                                
+                            </span>
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        data
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        actions
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                pagination
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onChange
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onChange
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                toolbar
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onApplyFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onToggleFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onClearAllFilters
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onClearAllFilters
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                …
+                              </span>
+                              <span>
+                                <br />
+                                    
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                table
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onRowSelected
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onSelectAll
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onEmptyStateAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onEmptyStateAction
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        view
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                table
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  emptyState
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                &lt;div /&gt;
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        options
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                hasPagination
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#a11",
+                                }
+                              }
+                            >
+                              true
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                      <br />
+                    </span>
+                  </span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    /&gt;
+                  </span>
+                </div>
+              </div>
+              <button
+                className="css-1naocv3 eva467m0"
+                onClick={[Function]}
+              >
+                <div
+                  className="css-lvl6aa eva467m1"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 6,
+                      }
+                    }
+                  >
+                    Copied!
+                  </div>
+                  <div>
+                    Copy
+                  </div>
+                </div>
+              </button>
+            </pre>
+          </div>
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Prop Types
+            </h1>
+            <div>
+              <h2
+                style={
+                  Object {
+                    "margin": "20px 0 0 0",
+                  }
+                }
+              >
+                "
+                Table
+                " Component
+              </h2>
+              <table
+                className="css-1uhv8nx e1vdo5380"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      property
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      propType
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      required
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      default
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      id
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        string
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        'Table'
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      DOM ID for component
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      options
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasPagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowSelection
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowExpansion
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowActions
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasFilter
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  hasPagination: false,
+  hasRowSelection: false…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Optional properties to customize how the table should be rendered
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      view
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSize
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSizes
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    number
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                page
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                totalItems
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            filters
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <span>
+                              [
+                            </span>
+                            <span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    value
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                            </span>
+                            <span>
+                              ]
+                            </span>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                activeBar
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                oneOf 'filter'
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                batchActions
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        id
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        labelText
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        icon
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        <span>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            {
+                                          </button>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                          >
+                                            ...
+                                          </button>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              width
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              height
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              viewBox
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              svgData
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              object
+                                            </span>
+                                            ,
+                                          </div>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            }
+                                          </button>
+                                        </span>
+                                        <span>
+                                           | 
+                                        </span>
+                                        <span>
+                                          string
+                                        </span>
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        iconDescription
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllIndeterminate
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                selectedIds
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    string
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                sort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    direction
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    oneOf 'NONE' | 'ASC' | 'DESC'
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                expandedRows
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        rowId
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        content
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        element
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  pagination: {
+    pageSize: 10,
+    pageSizes:…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      actions
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChange
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onClearAllFilters
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onCancelBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowExpanded
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChangeSort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onEmptyStateAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  pagination: { onChange: defaultFunction('actio…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Callbacks for actions of the table, can be used to update state in wrapper component to update \`view\` props
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      columns
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <span>
+                          [
+                        </span>
+                        <span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                id
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                name
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                size
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSortable
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                filter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 30,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    placeholderText
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 30,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    options
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    <span>
+                                      [
+                                    </span>
+                                    <span>
+                                      <span>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                        >
+                                          {
+                                        </button>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                        >
+                                          ...
+                                        </button>
+                                        <div
+                                          style={
+                                            Object {
+                                              "marginLeft": 15,
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            style={
+                                              Object {
+                                                "whiteSpace": "nowrap",
+                                              }
+                                            }
+                                          >
+                                            id
+                                            
+                                            :
+                                             
+                                          </span>
+                                          <span>
+                                            string
+                                          </span>
+                                          ,
+                                        </div>
+                                        <div
+                                          style={
+                                            Object {
+                                              "marginLeft": 15,
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            style={
+                                              Object {
+                                                "whiteSpace": "nowrap",
+                                              }
+                                            }
+                                          >
+                                            text
+                                            
+                                            :
+                                             
+                                          </span>
+                                          <span>
+                                            string
+                                          </span>
+                                          ,
+                                        </div>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                        >
+                                          }
+                                        </button>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      ]
+                                    </span>
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                        </span>
+                        <span>
+                          ]
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      yes
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Specify the properties of each column in the table
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      data
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <span>
+                          [
+                        </span>
+                        <span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                id
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                values
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                object
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                rowActions
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        id
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        icon
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        labelText
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        disabled
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        bool
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                        </span>
+                        <span>
+                          ]
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      yes
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Data for the body of the table
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Table with no results 1`] = `
 .c0.c0.c0 th {
   padding-top: 0.5rem;

--- a/src/components/__snapshots__/StorybookSnapshots-test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots-test.js.snap
@@ -14941,30 +14941,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                           </span>
                           ,
                         </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
-                          </span>
-                          ,
-                        </div>
                         <button
                           className="css-1sgldz e1i4ski80"
                           onClick={[Function]}
@@ -15937,6 +15913,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -16412,7 +16537,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  
@@ -19858,7 +19983,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                                     }
                                   }
                                 >
-                                  onDefaultEmptyCallToAction
+                                  onEmptyStateAction
                                 </span>
                               </span>
                               : 
@@ -19869,7 +19994,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                               </span>
                               }
                             </span>
@@ -20152,30 +20277,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                           </span>
                           <span>
                             bool
-                          </span>
-                          ,
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
                           </span>
                           ,
                         </div>
@@ -21151,6 +21252,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -21626,7 +21876,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  
@@ -25161,7 +25411,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                                     }
                                   }
                                 >
-                                  onDefaultEmptyCallToAction
+                                  onEmptyStateAction
                                 </span>
                               </span>
                               : 
@@ -25172,7 +25422,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                               </span>
                               }
                             </span>
@@ -25964,30 +26214,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                           </span>
                           <span>
                             bool
-                          </span>
-                          ,
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
                           </span>
                           ,
                         </div>
@@ -26963,6 +27189,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -27438,7 +27813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  
@@ -28226,9 +28601,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                   >
                     <svg
                       aria-hidden={true}
-                      focusable={false}
+                      focusable="false"
                       height={32}
                       preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
                       viewBox="0 0 32 32"
                       width={32}
                       xmlns="http://www.w3.org/2000/svg"
@@ -28238,7 +28618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                       />
                     </svg>
                     <p>
-                      There's no data here
+                      There is no data
                     </p>
                     <button
                       className="bx--btn bx--btn--primary"
@@ -28254,6 +28634,191 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
               </tr>
             </tbody>
           </table>
+        </div>
+        <div
+          className="bx--pagination"
+          disabled={false}
+        >
+          <div
+            className="bx--pagination__left"
+          >
+            <span
+              className="bx--pagination__text"
+            >
+              Items per page:
+            </span>
+            <div
+              className="bx--form-item"
+            >
+              <div
+                className="bx--select bx--select--inline"
+              >
+                <label
+                  className="bx--label bx--visually-hidden"
+                  htmlFor="bx-pagination-select-6"
+                >
+                  Items per page:
+                </label>
+                <select
+                  className="bx--select-input"
+                  id="bx-pagination-select-6"
+                  onChange={[Function]}
+                  value={10}
+                >
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={10}
+                  >
+                    10
+                  </option>
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={20}
+                  >
+                    20
+                  </option>
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={30}
+                  >
+                    30
+                  </option>
+                </select>
+                <svg
+                  alt="open list of options"
+                  aria-label="open list of options"
+                  className="bx--select__arrow"
+                  fillRule="evenodd"
+                  height="5"
+                  role="img"
+                  viewBox="0 0 10 5"
+                  width="10"
+                >
+                  <title>
+                    open list of options
+                  </title>
+                  <path
+                    d="M0 0l5 4.998L10 0z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <span
+              className="bx--pagination__text"
+            >
+               |  
+              0-0 of 0 items
+            </span>
+          </div>
+          <div
+            className="bx--pagination__right bx--pagination--inline"
+          >
+            <span
+              className="bx--pagination__text"
+            >
+              1 of 1 pages
+            </span>
+            <button
+              aria-label="Backward"
+              className="bx--pagination__button bx--pagination__button--backward"
+              disabled={true}
+              onClick={[Function]}
+            >
+              <svg
+                alt="Backward"
+                aria-label="Backward"
+                className="bx--pagination__button-icon"
+                fillRule="evenodd"
+                height="12"
+                role="img"
+                viewBox="0 0 7 12"
+                width="7"
+              >
+                <title>
+                  Backward
+                </title>
+                <path
+                  d="M1.45 6.002L7 11.27l-.685.726L0 6.003 6.315 0 7 .726z"
+                />
+              </svg>
+            </button>
+            <div
+              className="bx--form-item"
+            >
+              <div
+                className="bx--select bx--select--inline"
+              >
+                <label
+                  className="bx--label bx--visually-hidden"
+                  htmlFor="bx-pagination-select-8"
+                >
+                  Items per page:
+                </label>
+                <select
+                  className="bx--select-input"
+                  id="bx-pagination-select-8"
+                  onChange={[Function]}
+                  value={1}
+                >
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={1}
+                  >
+                    1
+                  </option>
+                </select>
+                <svg
+                  alt="open list of options"
+                  aria-label="open list of options"
+                  className="bx--select__arrow"
+                  fillRule="evenodd"
+                  height="5"
+                  role="img"
+                  viewBox="0 0 10 5"
+                  width="10"
+                >
+                  <title>
+                    open list of options
+                  </title>
+                  <path
+                    d="M0 0l5 4.998L10 0z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <button
+              aria-label="Forward"
+              className="bx--pagination__button bx--pagination__button--forward"
+              disabled={true}
+              onClick={[Function]}
+            >
+              <svg
+                alt="Forward"
+                aria-label="Forward"
+                className="bx--pagination__button-icon"
+                fillRule="evenodd"
+                height="12"
+                role="img"
+                viewBox="0 0 7 12"
+                width="7"
+              >
+                <title>
+                  Forward
+                </title>
+                <path
+                  d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -29073,7 +29638,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                                     }
                                   }
                                 >
-                                  onDefaultEmptyCallToAction
+                                  onEmptyStateAction
                                 </span>
                               </span>
                               : 
@@ -29084,7 +29649,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                               </span>
                               }
                             </span>
@@ -29126,19 +29691,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                                   }
                                 }
                               >
-                                emptyMessage
+                                hasPagination
                               </span>
                             </span>
                             : 
                             <span
                               style={
                                 Object {
-                                  "color": "#22a",
-                                  "wordBreak": "break-word",
+                                  "color": "#a11",
                                 }
                               }
                             >
-                              'There is no data here'
+                              true
                             </span>
                             }
                           </span>
@@ -29419,30 +29983,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                           </span>
                           <span>
                             bool
-                          </span>
-                          ,
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
                           </span>
                           ,
                         </div>
@@ -30418,6 +30958,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -30893,7 +31582,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  
@@ -31549,6 +32238,67 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
 `;
 
 exports[`Storybook Snapshot tests and console checks Storyshots Table with no results 1`] = `
+.c0.c0.c0 th {
+  padding-top: 0.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.c1.c1.c1 {
+  border-top: none;
+}
+
+.c1.c1.c1 .bx--form-item {
+  display: table-cell;
+}
+
+.c1.c1.c1 .bx--form-item input {
+  min-width: 12.75rem;
+}
+
+.c2.c2.c2 {
+  position: relative;
+}
+
+.c2.c2.c2 input {
+  padding-right: 2.5rem;
+}
+
+.c2.c2.c2 .bx--list-box__selection {
+  right: 0;
+}
+
+.c3.c3.c3:hover td {
+  border: 1px solid #dfe3e6;
+  background: inherit;
+}
+
+.c3.c3.c3 .empty-table-cell--default {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: middle;
+  -webkit-justify-content: middle;
+  -ms-flex-pack: middle;
+  justify-content: middle;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 3rem;
+}
+
+.c3.c3.c3 .empty-table-cell--default svg {
+  margin: 1rem;
+}
+
+.c3.c3.c3 .empty-table-cell--default > * {
+  margin: 0.5rem;
+}
+
 <div
   className="storybook-container"
   style={
@@ -31569,9 +32319,543 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no re
         }
       }
     >
-      <p>
-        TODO - empty state when filters applied and no results
-      </p>
+      <div>
+        <div
+          className="bx--data-table-v2-container"
+        >
+          <section
+            className="bx--table-toolbar"
+          >
+            <div
+              className="bx--toolbar-content"
+            >
+              <div
+                className="bx--batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                  <button
+                    className="bx--batch-summary__cancel"
+                    onClick={[Function]}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Clear All Filters
+              </button>
+              <button
+                className="bx--btn--sm bx--toolbar-action"
+                onClick={[Function]}
+              >
+                <svg
+                  alt="Filter"
+                  aria-label="Filter"
+                  className="bx--toolbar-action__icon"
+                  fillRule="evenodd"
+                  height="12"
+                  role="img"
+                  viewBox="0 0 16 12"
+                  width="16"
+                >
+                  <title>
+                    Filter
+                  </title>
+                  <path
+                    d="M8.05 2a2.5 2.5 0 0 1 4.9 0H16v1h-3.05a2.5 2.5 0 0 1-4.9 0H0V2h8.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM3.05 9a2.5 2.5 0 0 1 4.9 0H16v1H7.95a2.5 2.5 0 0 1-4.9 0H0V9h3.05zm2.45 2a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </section>
+          <table
+            className="bx--data-table-v2"
+          >
+            <thead>
+              <tr>
+                <th
+                  id="Table-Header-Column-string"
+                  scope="col"
+                  style={
+                    Object {
+                      "paddingTop": 16,
+                    }
+                  }
+                >
+                  String
+                </th>
+                <th
+                  id="Table-Header-Column-date"
+                  scope="col"
+                  style={
+                    Object {
+                      "paddingTop": 16,
+                    }
+                  }
+                >
+                  Date
+                </th>
+                <th
+                  id="Table-Header-Column-select"
+                  scope="col"
+                  style={
+                    Object {
+                      "paddingTop": 16,
+                    }
+                  }
+                >
+                  Select
+                </th>
+                <th
+                  id="Table-Header-Column-number"
+                  scope="col"
+                  style={
+                    Object {
+                      "paddingTop": 16,
+                    }
+                  }
+                >
+                  Number
+                </th>
+              </tr>
+              <tr
+                className="c0"
+              >
+                <th
+                  className="c1"
+                  scope="col"
+                >
+                  <div
+                    className="bx--form-item c2"
+                  >
+                    <div
+                      className="bx--form-item"
+                    >
+                      <label
+                        className="bx--label bx--visually-hidden"
+                        htmlFor="string"
+                      >
+                        string
+                      </label>
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="string"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        placeholder="pick a string"
+                        type="text"
+                        value="something not matching"
+                      />
+                    </div>
+                    <div
+                      className="bx--list-box__selection"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      tabIndex="0"
+                      title="Clear Filter"
+                    >
+                      <svg
+                        alt="Clear Filter"
+                        aria-label="Clear Filter"
+                        fillRule="evenodd"
+                        focusable="false"
+                        height="10"
+                        role="img"
+                        viewBox="0 0 10 10"
+                        width="10"
+                      >
+                        <title>
+                          Clear Filter
+                        </title>
+                        <path
+                          d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  className="c1"
+                  scope="col"
+                >
+                  <div
+                    className="bx--form-item c2"
+                  >
+                    <div
+                      className="bx--form-item"
+                    >
+                      <label
+                        className="bx--label bx--visually-hidden"
+                        htmlFor="date"
+                      >
+                        date
+                      </label>
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="date"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        placeholder="pick a date"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </th>
+                <th
+                  className="c1"
+                  scope="col"
+                >
+                  <div
+                    aria-label="Choose an item"
+                    className="bx--form-item bx--combo-box bx--list-box bx--list-box--light"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="listbox"
+                    tabIndex="0"
+                  >
+                    <div
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="open menu"
+                      className="bx--list-box__field"
+                      data-toggle={true}
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      tabIndex="0"
+                      type="button"
+                    >
+                      <input
+                        aria-activedescendant={null}
+                        aria-autocomplete="list"
+                        aria-expanded={false}
+                        aria-label="ListBox input field"
+                        autoComplete="off"
+                        className="bx--text-input"
+                        disabled={false}
+                        id="downshift-2-input"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onKeyDown={[Function]}
+                        placeholder="pick an option"
+                        role="combobox"
+                        value=""
+                      />
+                      
+                      <div
+                        className="bx--list-box__menu-icon"
+                      >
+                        <svg
+                          alt="Open menu"
+                          aria-label="Open menu"
+                          fillRule="evenodd"
+                          focusable="false"
+                          height="5"
+                          role="img"
+                          viewBox="0 0 10 5"
+                          width="10"
+                        >
+                          <title>
+                            Open menu
+                          </title>
+                          <path
+                            d="M0 0l5 4.998L10 0z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th
+                  className="c1"
+                  scope="col"
+                >
+                  <div
+                    className="bx--form-item c2"
+                  >
+                    <div
+                      className="bx--form-item"
+                    >
+                      <label
+                        className="bx--label bx--visually-hidden"
+                        htmlFor="number"
+                      >
+                        number
+                      </label>
+                      <input
+                        className="bx--text-input bx--text__input bx--text-input--light"
+                        disabled={false}
+                        id="number"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        placeholder="pick a number"
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                className="c3"
+              >
+                <td
+                  colSpan={4}
+                >
+                  <div
+                    className="empty-table-cell--default"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={32}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={32}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                      />
+                    </svg>
+                    <p>
+                      No results match the current filters
+                    </p>
+                    <button
+                      className="bx--btn bx--btn--primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Clear all filters
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div
+          className="bx--pagination"
+          disabled={false}
+        >
+          <div
+            className="bx--pagination__left"
+          >
+            <span
+              className="bx--pagination__text"
+            >
+              Items per page:
+            </span>
+            <div
+              className="bx--form-item"
+            >
+              <div
+                className="bx--select bx--select--inline"
+              >
+                <label
+                  className="bx--label bx--visually-hidden"
+                  htmlFor="bx-pagination-select-5"
+                >
+                  Items per page:
+                </label>
+                <select
+                  className="bx--select-input"
+                  id="bx-pagination-select-5"
+                  onChange={[Function]}
+                  value={10}
+                >
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={10}
+                  >
+                    10
+                  </option>
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={20}
+                  >
+                    20
+                  </option>
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={30}
+                  >
+                    30
+                  </option>
+                </select>
+                <svg
+                  alt="open list of options"
+                  aria-label="open list of options"
+                  className="bx--select__arrow"
+                  fillRule="evenodd"
+                  height="5"
+                  role="img"
+                  viewBox="0 0 10 5"
+                  width="10"
+                >
+                  <title>
+                    open list of options
+                  </title>
+                  <path
+                    d="M0 0l5 4.998L10 0z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <span
+              className="bx--pagination__text"
+            >
+               |  
+              0-0 of 0 items
+            </span>
+          </div>
+          <div
+            className="bx--pagination__right bx--pagination--inline"
+          >
+            <span
+              className="bx--pagination__text"
+            >
+              1 of 1 pages
+            </span>
+            <button
+              aria-label="Backward"
+              className="bx--pagination__button bx--pagination__button--backward"
+              disabled={true}
+              onClick={[Function]}
+            >
+              <svg
+                alt="Backward"
+                aria-label="Backward"
+                className="bx--pagination__button-icon"
+                fillRule="evenodd"
+                height="12"
+                role="img"
+                viewBox="0 0 7 12"
+                width="7"
+              >
+                <title>
+                  Backward
+                </title>
+                <path
+                  d="M1.45 6.002L7 11.27l-.685.726L0 6.003 6.315 0 7 .726z"
+                />
+              </svg>
+            </button>
+            <div
+              className="bx--form-item"
+            >
+              <div
+                className="bx--select bx--select--inline"
+              >
+                <label
+                  className="bx--label bx--visually-hidden"
+                  htmlFor="bx-pagination-select-7"
+                >
+                  Items per page:
+                </label>
+                <select
+                  className="bx--select-input"
+                  id="bx-pagination-select-7"
+                  onChange={[Function]}
+                  value={1}
+                >
+                  <option
+                    className="bx--select-option"
+                    disabled={false}
+                    hidden={false}
+                    value={1}
+                  >
+                    1
+                  </option>
+                </select>
+                <svg
+                  alt="open list of options"
+                  aria-label="open list of options"
+                  className="bx--select__arrow"
+                  fillRule="evenodd"
+                  height="5"
+                  role="img"
+                  viewBox="0 0 10 5"
+                  width="10"
+                >
+                  <title>
+                    open list of options
+                  </title>
+                  <path
+                    d="M0 0l5 4.998L10 0z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <button
+              aria-label="Forward"
+              className="bx--pagination__button bx--pagination__button--forward"
+              disabled={true}
+              onClick={[Function]}
+            >
+              <svg
+                alt="Forward"
+                aria-label="Forward"
+                className="bx--pagination__button-icon"
+                fillRule="evenodd"
+                height="12"
+                role="img"
+                viewBox="0 0 7 12"
+                width="7"
+              >
+                <title>
+                  Forward
+                </title>
+                <path
+                  d="M5.569 5.994L0 .726.687 0l6.336 5.994-6.335 6.002L0 11.27z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
     <button
       onClick={[Function]}
@@ -31703,74 +32987,951 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no re
               className="css-r8d96o eyvlbql0"
             >
               <div>
-                <div>
-                  <div
+                <div
+                  style={
+                    Object {
+                      "paddingLeft": 18,
+                      "paddingRight": 3,
+                    }
+                  }
+                >
+                  <span
                     style={
                       Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
+                        "color": "#444",
                       }
                     }
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;
-                      p
+                    &lt;
+                    Table
+                  </span>
+                  <span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        columns
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'string'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'String'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              …
+                            </span>
+                            <span>
+                              <br />
+                                
+                            </span>
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
                     </span>
-                    <span />
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &gt;
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        data
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
                     </span>
-                  </div>
-                  <div
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        actions
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                pagination
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onChange
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onChange
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                toolbar
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onApplyFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onToggleFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onClearAllFilters
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onClearAllFilters
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                …
+                              </span>
+                              <span>
+                                <br />
+                                    
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                table
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onRowSelected
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onSelectAll
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                              </span>
+                              ,
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onEmptyStateAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onEmptyStateAction
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        view
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                filters
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              [
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  {
+                                  <span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      columnId
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'string'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      value
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'something not matching'
+                                  </span>
+                                  }
+                                </span>
+                              </span>
+                              ]
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                toolbar
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  activeBar
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#22a",
+                                    "wordBreak": "break-word",
+                                  }
+                                }
+                              >
+                                'filter'
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        options
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                hasFilter
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#a11",
+                                }
+                              }
+                            >
+                              true
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                hasPagination
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#a11",
+                                }
+                              }
+                            >
+                              true
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                      <br />
+                    </span>
+                  </span>
+                  <span
                     style={
                       Object {
-                        "paddingLeft": 33,
-                        "paddingRight": 3,
+                        "color": "#444",
                       }
                     }
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      TODO - empty state when filters applied and no results
-                    </span>
-                  </div>
-                  <div
-                    style={
-                      Object {
-                        "paddingLeft": 18,
-                        "paddingRight": 3,
-                      }
-                    }
-                  >
-                    <span
-                      style={
-                        Object {
-                          "color": "#444",
-                        }
-                      }
-                    >
-                      &lt;/
-                      p
-                      &gt;
-                    </span>
-                  </div>
+                    /&gt;
+                  </span>
                 </div>
               </div>
               <button
@@ -31795,6 +33956,2490 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no re
                 </div>
               </button>
             </pre>
+          </div>
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Prop Types
+            </h1>
+            <div>
+              <h2
+                style={
+                  Object {
+                    "margin": "20px 0 0 0",
+                  }
+                }
+              >
+                "
+                Table
+                " Component
+              </h2>
+              <table
+                className="css-1uhv8nx e1vdo5380"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      property
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      propType
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      required
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      default
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      id
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        string
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        'Table'
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      DOM ID for component
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      options
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasPagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowSelection
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowExpansion
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowActions
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasFilter
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  hasPagination: false,
+  hasRowSelection: false…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Optional properties to customize how the table should be rendered
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      view
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSize
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSizes
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    number
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                page
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                totalItems
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            filters
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <span>
+                              [
+                            </span>
+                            <span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    value
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                            </span>
+                            <span>
+                              ]
+                            </span>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                activeBar
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                oneOf 'filter'
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                batchActions
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        id
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        labelText
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        icon
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        <span>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            {
+                                          </button>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                          >
+                                            ...
+                                          </button>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              width
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              height
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              viewBox
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              svgData
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              object
+                                            </span>
+                                            ,
+                                          </div>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            }
+                                          </button>
+                                        </span>
+                                        <span>
+                                           | 
+                                        </span>
+                                        <span>
+                                          string
+                                        </span>
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        iconDescription
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllIndeterminate
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                selectedIds
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    string
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                sort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    direction
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    oneOf 'NONE' | 'ASC' | 'DESC'
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                expandedRows
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        rowId
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        content
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        element
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  pagination: {
+    pageSize: 10,
+    pageSizes:…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      actions
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChange
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onClearAllFilters
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onCancelBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowExpanded
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChangeSort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onEmptyStateAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      <span
+                        style={
+                          Object {
+                            "color": "#22a",
+                            "wordBreak": "break-word",
+                          }
+                        }
+                      >
+                        {
+  pagination: { onChange: defaultFunction('actio…
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Callbacks for actions of the table, can be used to update state in wrapper component to update \`view\` props
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      columns
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <span>
+                          [
+                        </span>
+                        <span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                id
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                name
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                size
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSortable
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                filter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 30,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    placeholderText
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 30,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    options
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    <span>
+                                      [
+                                    </span>
+                                    <span>
+                                      <span>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                        >
+                                          {
+                                        </button>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                        >
+                                          ...
+                                        </button>
+                                        <div
+                                          style={
+                                            Object {
+                                              "marginLeft": 15,
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            style={
+                                              Object {
+                                                "whiteSpace": "nowrap",
+                                              }
+                                            }
+                                          >
+                                            id
+                                            
+                                            :
+                                             
+                                          </span>
+                                          <span>
+                                            string
+                                          </span>
+                                          ,
+                                        </div>
+                                        <div
+                                          style={
+                                            Object {
+                                              "marginLeft": 15,
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            style={
+                                              Object {
+                                                "whiteSpace": "nowrap",
+                                              }
+                                            }
+                                          >
+                                            text
+                                            
+                                            :
+                                             
+                                          </span>
+                                          <span>
+                                            string
+                                          </span>
+                                          ,
+                                        </div>
+                                        <button
+                                          className="css-1sgldz e1i4ski80"
+                                          onClick={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                        >
+                                          }
+                                        </button>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      ]
+                                    </span>
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                        </span>
+                        <span>
+                          ]
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      yes
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Specify the properties of each column in the table
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      data
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <span>
+                          [
+                        </span>
+                        <span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                id
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                string
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                values
+                                
+                                :
+                                 
+                              </span>
+                              <span>
+                                object
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 15,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                rowActions
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        id
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        icon
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        labelText
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        disabled
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        bool
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                        </span>
+                        <span>
+                          ]
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      yes
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Data for the body of the table
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
@@ -37962,7 +42607,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                     }
                                   }
                                 >
-                                  onDefaultEmptyCallToAction
+                                  onEmptyStateAction
                                 </span>
                               </span>
                               : 
@@ -37973,7 +42618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                               </span>
                               }
                             </span>
@@ -38561,30 +43206,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                           </span>
                           <span>
                             bool
-                          </span>
-                          ,
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
                           </span>
                           ,
                         </div>
@@ -39560,6 +44181,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -40035,7 +44805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  
@@ -52232,7 +57002,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                     }
                                   }
                                 >
-                                  onDefaultEmptyCallToAction
+                                  onEmptyStateAction
                                 </span>
                               </span>
                               : 
@@ -52243,7 +57013,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                               </span>
                               }
                             </span>
@@ -52853,30 +57623,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                           </span>
                           <span>
                             bool
-                          </span>
-                          ,
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
                           </span>
                           ,
                         </div>
@@ -53852,6 +58598,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -54327,7 +59222,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  
@@ -57173,7 +62068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                                     }
                                   }
                                 >
-                                  onDefaultEmptyCallToAction
+                                  onEmptyStateAction
                                 </span>
                               </span>
                               : 
@@ -57184,7 +62079,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                               </span>
                               }
                             </span>
@@ -57947,30 +62842,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                           </span>
                           <span>
                             bool
-                          </span>
-                          ,
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
                           </span>
                           ,
                         </div>
@@ -58946,6 +63817,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -59421,7 +64441,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  
@@ -62295,7 +67315,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                                     }
                                   }
                                 >
-                                  onDefaultEmptyCallToAction
+                                  onEmptyStateAction
                                 </span>
                               </span>
                               : 
@@ -62306,7 +67326,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                               </span>
                               }
                             </span>
@@ -62978,30 +67998,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                           </span>
                           <span>
                             bool
-                          </span>
-                          ,
-                        </div>
-                        <div
-                          style={
-                            Object {
-                              "marginLeft": 15,
-                            }
-                          }
-                        >
-                          <span
-                            style={
-                              Object {
-                                "whiteSpace": "nowrap",
-                              }
-                            }
-                          >
-                            emptyTableContent
-                            ?
-                            :
-                             
-                          </span>
-                          <span>
-                            node
                           </span>
                           ,
                         </div>
@@ -63977,6 +68973,155 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    {
+                                  </button>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                  >
+                                    ...
+                                  </button>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      message
+                                      
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      messageWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabel
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <div
+                                    style={
+                                      Object {
+                                        "marginLeft": 15,
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      style={
+                                        Object {
+                                          "whiteSpace": "nowrap",
+                                        }
+                                      }
+                                    >
+                                      buttonLabelWithFilters
+                                      ?
+                                      :
+                                       
+                                    </span>
+                                    <span>
+                                      string
+                                    </span>
+                                    ,
+                                  </div>
+                                  <button
+                                    className="css-1sgldz e1i4ski80"
+                                    onClick={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                  >
+                                    }
+                                  </button>
+                                </span>
+                                <span>
+                                   | 
+                                </span>
+                                <span>
+                                  element
+                                </span>
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -64452,7 +69597,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                                   }
                                 }
                               >
-                                onDefaultEmptyCallToAction
+                                onEmptyStateAction
                                 ?
                                 :
                                  

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1,6 +1,7 @@
 export const COLORS = {
   superLightGray: '#f9fafb;',
   darkGray: '#152935',
+  lightGrey: '#dfe3e6',
   blue: '#3d70b2',
   errorRed: '#e62325',
   white: '#fff',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,10 +1082,23 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@carbon/icon-helpers@0.0.1-alpha.12":
+  version "0.0.1-alpha.12"
+  resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-0.0.1-alpha.12.tgz#27f1449ff8e503e42e478ca567dfa6a6b453debe"
+  integrity sha512-aWY4qjWLMPT01jP6owstwYoNn1QQhWdc4lNYNV7sMU0eRoRGV2IbpC4fsF4zHtvlpG3rH7glaTPXmSoTboVBSg==
+
 "@carbon/icon-helpers@0.0.1-alpha.28":
   version "0.0.1-alpha.28"
   resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-0.0.1-alpha.28.tgz#06b0e42c44e2fac0c3bb1be26e1c739974929121"
   integrity sha512-J5PEu/Y/Jm/CvDeTVOjf1+xkuRbHwn7CnYnhR+Fh/oNXLP6+DeXigeES+Gei72rUckGJTVLce7NOg8/VPtDVpg==
+
+"@carbon/icons-react@^0.0.1-alpha.12":
+  version "0.0.1-alpha.12"
+  resolved "https://registry.yarnpkg.com/@carbon/icons-react/-/icons-react-0.0.1-alpha.12.tgz#9cdc7846d0862838770c966a7f130953a89887a5"
+  integrity sha512-9FivY8XDubIkrccl4lBAuR5WxbS8unlhQxH3LRVEZ9m/KlNbLww3E5DLMqoTyzPD0e67WkRzTrRi/mqO/aEMGA==
+  dependencies:
+    "@carbon/icon-helpers" "0.0.1-alpha.12"
+    prop-types "^15.6.2"
 
 "@carbon/icons-react@^0.0.1-alpha.26":
   version "0.0.1-alpha.28"
@@ -1273,6 +1286,18 @@
   integrity sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==
   dependencies:
     "@emotion/memoize" "^0.6.6"
+
+"@emotion/is-prop-valid@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
+  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+  dependencies:
+    "@emotion/memoize" "0.7.1"
+
+"@emotion/memoize@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
 
 "@emotion/memoize@^0.6.6":
   version "0.6.6"
@@ -13168,12 +13193,13 @@ style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-styled-components@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.2.tgz#f8a685e3b2bcd03c5beac7f2c02bb6ad237da9b3"
-  integrity sha512-NdvWatJ2WLqZxAvto+oH0k7GAC/TlAUJTrHoXJddjbCrU6U23EmVbb9LXJBF+d6q6hH+g9nQYOWYPUeX/Vlc2w==
+styled-components@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.3.tgz#4472447208e618b57e84deaaeb6acd34a5e0fe9b"
+  integrity sha512-0quV4KnSfvq5iMtT0RzpMGl/Dg3XIxIxOl9eJpiqiq4SrAmR1l1DLzNpMzoy3DyzdXVDMJS2HzROnXscWA3SEw==
   dependencies:
-    "@emotion/is-prop-valid" "^0.6.8"
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.7.3"
     "@emotion/unitless" "^0.7.0"
     babel-plugin-styled-components ">= 1"
     css-to-react-native "^2.2.2"


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Adds an empty state to the table, configurable via a custom node if desired.

**Change List (commits, features, bugs, etc)**

- Include `@carbons/icons-react` for access to new `Bee` icon
  -  This should be our new source of truth for icons. It can live alongside existing `carbon-icons` until we fully update to Carbon v10
- Add Empty state to table
- Update stories
- Update snapshots

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#8

**Acceptance Test (how to verify the PR)**

- Storybook Stateful example should show proper empty state when all items are deleted
- Storybook `with no data` story should also properly render empty state with default action
