### PR TITLE
refactor(wizardmodal): reuse the progressindicator with interactivity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,4 +17,4 @@
 # These users own any files in the following directory at the root of
 # the repository and any of its subdirectories.
 
-* @bryancboyd @scottdickerson @davidicus @tay1orjones
+* @bryancboyd @scottdickerson @davidicus @tay1orjones @leetosc @cgirani

--- a/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { ProgressIndicator as CarbonProgressIndicator } from 'carbon-components-react';
 
 import ProgressStep from './ProgressStep';
 
+const IDPropTypes = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
 class ProgressIndicator extends Component {
   /* Display name */
   static displayName = 'ProgressIndicator';
@@ -10,10 +12,10 @@ class ProgressIndicator extends Component {
   static propTypes = {
     /** array of item objects with id and labels */
     items: PropTypes.arrayOf(
-      PropTypes.shape({ id: PropTypes.string.isRequired, label: PropTypes.string.isRequired })
+      PropTypes.shape({ id: IDPropTypes, label: PropTypes.string.isRequired })
     ).isRequired,
     /** id of current step */
-    currentItemId: PropTypes.string.isRequired,
+    currentItemId: IDPropTypes,
     /** function on click, usually to set the currentItemId */
     onClickItem: PropTypes.func,
     /** false to hide labels on non-current steps */
@@ -26,6 +28,7 @@ class ProgressIndicator extends Component {
     onClickItem: null,
     showLabels: true,
     stepWidth: 102,
+    currentItemId: null,
   };
 
   constructor(props) {
@@ -39,46 +42,18 @@ class ProgressIndicator extends Component {
     const currentStep = items.findIndex(item => item.id === currentItemId);
 
     return (
-      <ul>
-        {items.map(({ id, label }, index) => {
-          if (index === currentStep) {
-            return (
-              <ProgressStep
-                status="current"
-                key={id}
-                label={label}
-                showLabel={showLabels}
-                stepWidth={stepWidth}
-              />
-            );
-          }
-          if (index < currentStep) {
-            return (
-              <ProgressStep
-                status="complete"
-                key={id}
-                label={label}
-                showLabel={showLabels}
-                onClick={() => onClickItem(id)}
-                stepWidth={stepWidth}
-              />
-            );
-          }
-          if (index > currentStep) {
-            return (
-              <ProgressStep
-                status="incomplete"
-                key={id}
-                label={label}
-                showLabel={showLabels}
-                onClick={() => onClickItem(id)}
-                stepWidth={stepWidth}
-              />
-            );
-          }
-          return null;
-        })}
-      </ul>
+      <CarbonProgressIndicator currentIndex={currentStep}>
+        {items.map(({ id, label }) => (
+          <ProgressStep
+            key={id}
+            label={label}
+            description={label}
+            showLabel={showLabels}
+            onClick={() => onClickItem(id)}
+            stepWidth={stepWidth}
+          />
+        ))}
+      </CarbonProgressIndicator>
     );
   };
 }

--- a/src/components/ProgressIndicator/ProgressStep.jsx
+++ b/src/components/ProgressIndicator/ProgressStep.jsx
@@ -3,10 +3,25 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import classnames from 'classnames';
 
-const ProgressStep = ({ label, status, showLabel, onClick, className }) => {
+/**
+ * This is a temporary override of carbon to support clicking on the progress step
+ * It also adds the ability to hide labels and provide a custom stepWidth.  Put in a PR on the Carbon team
+ * so that most of this capability can be removed/refactored when we update to the latest Carbon.
+ * https://github.com/IBM/carbon-components-react/pull/1945
+ */
+const ProgressStep = ({
+  key,
+  label,
+  description,
+  current,
+  complete,
+  showLabel,
+  onClick,
+  className,
+}) => {
   const classNames = classnames('bx--progress-step', 'bx--progress-step--complete', className);
   const stepComplete = (
-    <li className={classNames}>
+    <li key={key} className={classNames}>
       <svg
         focusable="false"
         preserveAspectRatio="xMidYMid meet"
@@ -18,6 +33,7 @@ const ProgressStep = ({ label, status, showLabel, onClick, className }) => {
         onClick={onClick}>
         <path d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z" />
         <path d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z" />
+        <title>{description}</title>
       </svg>
       <button type="button" onClick={onClick} className="bx--progress-label">
         {showLabel ? label : null}
@@ -27,10 +43,11 @@ const ProgressStep = ({ label, status, showLabel, onClick, className }) => {
   );
 
   const stepCurrent = (
-    <li className={classNames}>
+    <li key={key} className={classNames}>
       <svg>
         <circle cx="12" cy="12" r="12" />
         <circle cx="12" cy="12" r="6" />
+        <title>{description}</title>
       </svg>
       <p className="bx--progress-label">{label}</p>
       <span className="bx--progress-line" />
@@ -38,9 +55,10 @@ const ProgressStep = ({ label, status, showLabel, onClick, className }) => {
   );
 
   const stepIncomplete = (
-    <li className={classNames}>
+    <li key={key} className={classNames}>
       <svg onClick={onClick}>
         <circle cx="12" cy="12" r="12" />
+        <title>{description}</title>
       </svg>
       <button type="button" onClick={onClick} className="bx--progress-label">
         {showLabel ? label : null}
@@ -49,20 +67,27 @@ const ProgressStep = ({ label, status, showLabel, onClick, className }) => {
     </li>
   );
 
-  if (status === 'complete') {
+  if (complete) {
     return stepComplete;
   }
-  if (status === 'current') {
+  if (current) {
     return stepCurrent;
   }
   return stepIncomplete;
 };
 
 ProgressStep.propTypes = {
-  id: PropTypes.string,
-  label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-  status: PropTypes.string,
+  key: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  current: PropTypes.bool,
+  complete: PropTypes.bool,
+  description: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  /** NEW PROPS! optionally hide Labels */
   showLabel: PropTypes.bool,
+  /** attach the click handler here */
+  onClick: PropTypes.func,
+  /** Support dynamically passing a pixel width */
+  stepWidth: PropTypes.number,
 };
 
 /* Display name */

--- a/src/components/WizardModal/WizardModal.jsx
+++ b/src/components/WizardModal/WizardModal.jsx
@@ -2,10 +2,11 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
-import { ProgressIndicator, ProgressStep, Button } from 'carbon-components-react';
+import { Button } from 'carbon-components-react';
 
 import BaseModal from '../BaseModal/BaseModal';
 import ButtonEnhanced from '../ButtonEnhanced/ButtonEnhanced';
+import ProgressIndicator from '../ProgressIndicator/ProgressIndicator';
 
 const StyledModal = styled(BaseModal)`
    {
@@ -80,6 +81,10 @@ class WizardModal extends Component {
     this.setState(state => ({ step: state.step - 1 }));
   };
 
+  handleClick = key => {
+    this.setState({ step: key });
+  };
+
   validateCurrentStep = () => {
     const { steps } = this.props;
     const { step } = this.state;
@@ -149,19 +154,17 @@ class WizardModal extends Component {
 
   render() {
     const { steps, className, ...other } = this.props;
-    const { step } = this.state;
+    // Transform object to be what Progress Indicator expects
+    const items = steps.map((step, index) => ({ id: index, label: step.label }));
+    const { step: stepIndex } = this.state;
     return (
       <StyledModal {...other} className={className} footer={this.renderFooter()}>
-        <ProgressIndicator currentIndex={step}>
-          {steps.map(eachStep => (
-            <ProgressStep
-              key={eachStep.label}
-              label={eachStep.label}
-              description={eachStep.label}
-            />
-          ))}
-        </ProgressIndicator>
-        <StyledWizardContent>{steps[step].content}</StyledWizardContent>
+        <ProgressIndicator
+          items={items}
+          currentItemId={!isNil(stepIndex) ? items[stepIndex] && items[stepIndex].id : undefined}
+          onClickItem={this.handleClick}
+        />
+        <StyledWizardContent>{steps[stepIndex].content}</StyledWizardContent>
       </StyledModal>
     );
   }

--- a/src/components/WizardModal/WizardModal.test.jsx
+++ b/src/components/WizardModal/WizardModal.test.jsx
@@ -70,8 +70,14 @@ describe('WizardModal', () => {
     // Advance to last panel should have a submit button
     wrapper.setState({ step: 2 });
 
-    // Close, Previous/Cancel and Submit buttons
-    expect(wrapper.find('button')).toHaveLength(4);
+    // Close
+    expect(wrapper.find('.bx--modal-close')).toHaveLength(1);
+
+    // Previous/Cancel
+    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(2);
+
+    // Submit button
+    expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);
 
     // Submit button should validate the last page
     wrapper.instance().handleSubmit();
@@ -89,13 +95,34 @@ describe('WizardModal', () => {
         footer={{ leftContent: 'Hi there' }}
       />
     );
-    // Close Next and Cancel
-    expect(wrapper.find('button')).toHaveLength(3);
+    // Close
+    expect(wrapper.find('.bx--modal-close')).toHaveLength(1);
+
+    // Cancel
+    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(1);
+
+    // Submit button
+    expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);
+
     // Close Next Previous and Cancel
     wrapper.setState({ step: 1 });
-    expect(wrapper.find('button')).toHaveLength(4);
+    // Close
+    expect(wrapper.find('.bx--modal-close')).toHaveLength(1);
+
+    // Previous/Cancel
+    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(2);
+
+    // Submit button
+    expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);
     // Close Previous Submit and Cancel
-    expect(wrapper.find('button')).toHaveLength(4);
+    // Close
+    expect(wrapper.find('.bx--modal-close')).toHaveLength(1);
+
+    // Previous/Cancel
+    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(2);
+
+    // Submit button
+    expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);
     wrapper.setState({ step: 2 });
   });
   test('sendingData', () => {

--- a/src/components/__snapshots__/StorybookSnapshots.test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots.test.js.snap
@@ -14083,31 +14083,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
   color: #3d70b2;
 }
 
-.c1.c1.c1 {
-  min-width: 136px;
-  width: 200;
-}
-
-.c1.c1.c1 .bx--progress-label {
-  cursor: pointer;
-}
-
-.c1.c1.c1 .bx--progress-step svg {
-  z-index: auto;
-  cursor: pointer;
-}
-
-.c1.c1.c1 button {
-  background: none;
-  margin: 0;
-  padding: 0;
-  border: none;
-  cursor: pointer;
-  font-size: 1rem;
-  text-align: left;
-  color: #5a6872;
-}
-
 <div
   className="storybook-container"
   style={
@@ -14128,7 +14103,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
         }
       }
     >
-      <ul>
+      <ul
+        className="bx--progress"
+      >
         <li
           className="bx--progress-step bx--progress-step--complete c0"
         >
@@ -14143,6 +14120,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
               cy="12"
               r="6"
             />
+            <title>
+              First step
+            </title>
           </svg>
           <p
             className="bx--progress-label"
@@ -14154,7 +14134,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
           />
         </li>
         <li
-          className="bx--progress-step bx--progress-step--complete c1"
+          className="bx--progress-step bx--progress-step--complete c0"
         >
           <svg
             onClick={[Function]}
@@ -14164,6 +14144,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
               cy="12"
               r="12"
             />
+            <title>
+              Second Step
+            </title>
           </svg>
           <button
             className="bx--progress-label"
@@ -14177,7 +14160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
           />
         </li>
         <li
-          className="bx--progress-step bx--progress-step--complete c1"
+          className="bx--progress-step bx--progress-step--complete c0"
         >
           <svg
             onClick={[Function]}
@@ -14187,6 +14170,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
               cy="12"
               r="12"
             />
+            <title>
+              Third Step
+            </title>
           </svg>
           <button
             className="bx--progress-label"
@@ -14200,7 +14186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
           />
         </li>
         <li
-          className="bx--progress-step bx--progress-step--complete c1"
+          className="bx--progress-step bx--progress-step--complete c0"
         >
           <svg
             onClick={[Function]}
@@ -14210,6 +14196,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
               cy="12"
               r="12"
             />
+            <title>
+              Fourth Step
+            </title>
           </svg>
           <button
             className="bx--progress-label"
@@ -14223,7 +14212,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
           />
         </li>
         <li
-          className="bx--progress-step bx--progress-step--complete c1"
+          className="bx--progress-step bx--progress-step--complete c0"
         >
           <svg
             onClick={[Function]}
@@ -14233,6 +14222,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
               cy="12"
               r="12"
             />
+            <title>
+              Fifth Step
+            </title>
           </svg>
           <button
             className="bx--progress-label"
@@ -14246,7 +14238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
           />
         </li>
         <li
-          className="bx--progress-step bx--progress-step--complete c1"
+          className="bx--progress-step bx--progress-step--complete c0"
         >
           <svg
             onClick={[Function]}
@@ -14256,6 +14248,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots ProgressIndicato
               cy="12"
               r="12"
             />
+            <title>
+              Sixth Step
+            </title>
           </svg>
           <button
             className="bx--progress-label"
@@ -75728,7 +75723,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal basi
   min-height: 12.5rem;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -75750,7 +75745,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal basi
   justify-content: flex-end;
 }
 
-.c3 .modal-greedy-spacer {
+.c4 .modal-greedy-spacer {
   -webkit-box-flex: 2;
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
@@ -75758,11 +75753,36 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal basi
   text-align: left;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c2.c2.c2 {
+  min-width: 136px;
+  width: 102;
+}
+
+.c2.c2.c2 .bx--progress-label {
+  cursor: pointer;
+}
+
+.c2.c2.c2 .bx--progress-step svg {
+  z-index: auto;
+  cursor: pointer;
+}
+
+.c2.c2.c2 button {
+  background: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  text-align: left;
+  color: #3d70b2;
 }
 
 .c0 .bx--progress-step {
@@ -75773,7 +75793,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal basi
   padding-top: 1rem;
 }
 
-.c2 {
+.c3 {
   padding-top: 1rem;
   padding-left: 1rem;
   padding-bottom: 7rem;
@@ -75881,7 +75901,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal basi
               className="bx--progress"
             >
               <li
-                className="bx--progress-step bx--progress-step--current"
+                className="bx--progress-step bx--progress-step--complete c2"
               >
                 <svg>
                   <circle
@@ -75908,61 +75928,69 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal basi
                 />
               </li>
               <li
-                className="bx--progress-step bx--progress-step--incomplete"
+                className="bx--progress-step bx--progress-step--complete c2"
               >
-                <svg>
-                  <title>
-                    step2
-                  </title>
+                <svg
+                  onClick={[Function]}
+                >
                   <circle
                     cx="12"
                     cy="12"
                     r="12"
                   />
+                  <title>
+                    step2
+                  </title>
                 </svg>
-                <p
+                <button
                   className="bx--progress-label"
+                  onClick={[Function]}
+                  type="button"
                 >
                   step2
-                </p>
+                </button>
                 <span
                   className="bx--progress-line"
                 />
               </li>
               <li
-                className="bx--progress-step bx--progress-step--incomplete"
+                className="bx--progress-step bx--progress-step--complete c2"
               >
-                <svg>
-                  <title>
-                    step3
-                  </title>
+                <svg
+                  onClick={[Function]}
+                >
                   <circle
                     cx="12"
                     cy="12"
                     r="12"
                   />
+                  <title>
+                    step3
+                  </title>
                 </svg>
-                <p
+                <button
                   className="bx--progress-label"
+                  onClick={[Function]}
+                  type="button"
                 >
                   step3
-                </p>
+                </button>
                 <span
                   className="bx--progress-line"
                 />
               </li>
             </ul>
             <div
-              className="c2"
+              className="c3"
             >
               page 1
             </div>
           </div>
           <div
-            className="bx--modal-footer c3"
+            className="bx--modal-footer c4"
           >
             <div
-              className="c4"
+              className="c5"
             >
               <button
                 className="bx--btn bx--btn--secondary"
@@ -77033,7 +77061,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal cust
   min-height: 12.5rem;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77055,7 +77083,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal cust
   justify-content: flex-end;
 }
 
-.c3 .modal-greedy-spacer {
+.c4 .modal-greedy-spacer {
   -webkit-box-flex: 2;
   -webkit-flex-grow: 2;
   -ms-flex-positive: 2;
@@ -77063,11 +77091,36 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal cust
   text-align: left;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c2.c2.c2 {
+  min-width: 136px;
+  width: 102;
+}
+
+.c2.c2.c2 .bx--progress-label {
+  cursor: pointer;
+}
+
+.c2.c2.c2 .bx--progress-step svg {
+  z-index: auto;
+  cursor: pointer;
+}
+
+.c2.c2.c2 button {
+  background: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  text-align: left;
+  color: #3d70b2;
 }
 
 .c0 .bx--progress-step {
@@ -77078,7 +77131,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal cust
   padding-top: 1rem;
 }
 
-.c2 {
+.c3 {
   padding-top: 1rem;
   padding-left: 1rem;
   padding-bottom: 7rem;
@@ -77186,7 +77239,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal cust
               className="bx--progress"
             >
               <li
-                className="bx--progress-step bx--progress-step--current"
+                className="bx--progress-step bx--progress-step--complete c2"
               >
                 <svg>
                   <circle
@@ -77213,61 +77266,69 @@ exports[`Storybook Snapshot tests and console checks Storyshots WizardModal cust
                 />
               </li>
               <li
-                className="bx--progress-step bx--progress-step--incomplete"
+                className="bx--progress-step bx--progress-step--complete c2"
               >
-                <svg>
-                  <title>
-                    step2
-                  </title>
+                <svg
+                  onClick={[Function]}
+                >
                   <circle
                     cx="12"
                     cy="12"
                     r="12"
                   />
+                  <title>
+                    step2
+                  </title>
                 </svg>
-                <p
+                <button
                   className="bx--progress-label"
+                  onClick={[Function]}
+                  type="button"
                 >
                   step2
-                </p>
+                </button>
                 <span
                   className="bx--progress-line"
                 />
               </li>
               <li
-                className="bx--progress-step bx--progress-step--incomplete"
+                className="bx--progress-step bx--progress-step--complete c2"
               >
-                <svg>
-                  <title>
-                    step3
-                  </title>
+                <svg
+                  onClick={[Function]}
+                >
                   <circle
                     cx="12"
                     cy="12"
                     r="12"
                   />
+                  <title>
+                    step3
+                  </title>
                 </svg>
-                <p
+                <button
                   className="bx--progress-label"
+                  onClick={[Function]}
+                  type="button"
                 >
                   step3
-                </p>
+                </button>
                 <span
                   className="bx--progress-line"
                 />
               </li>
             </ul>
             <div
-              className="c2"
+              className="c3"
             >
               page 1
             </div>
           </div>
           <div
-            className="bx--modal-footer c3"
+            className="bx--modal-footer c4"
           >
             <div
-              className="c4"
+              className="c5"
             >
               <button
                 className="bx--btn bx--btn--primary"


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**
Add interactivity to the steps of the wizardmodal.

**Change List (commits, features, bugs, etc)**

- Refactor the ProgressStep component to more easily be replaced by the Carbon one once they integrate my interactivity PR
- Refactor the WizardModal to use the ProgressIndicator/ProgressStep with Interactivity

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#NUMBER

**Acceptance Test (how to verify the PR)**

- Verify that the WizardModal can now click on the ProgressSteps to advance.
