### PR TITLE
feat(table): add quick search capability

### DIFF
--- a/src/components/HeaderMenu/__snapshots__/HeaderMenu.test.jsx.snap
+++ b/src/components/HeaderMenu/__snapshots__/HeaderMenu.test.jsx.snap
@@ -29,29 +29,25 @@ exports[`HeaderMenu testcases should render 1`] = `
         Accessibility label
         <ChevronDownGlyph
           className="bx--header__menu-arrow"
-          height={6}
+          focusable={false}
+          height={7}
           preserveAspectRatio="xMidYMid meet"
-          viewBox="0 0 10 6"
-          width={10}
+          viewBox="0 0 12 7"
+          width={12}
           xmlns="http://www.w3.org/2000/svg"
         >
           <svg
             aria-hidden={true}
             className="bx--header__menu-arrow"
-            focusable="false"
-            height={6}
+            focusable={false}
+            height={7}
             preserveAspectRatio="xMidYMid meet"
-            style={
-              Object {
-                "willChange": "transform",
-              }
-            }
-            viewBox="0 0 10 6"
-            width={10}
+            viewBox="0 0 12 7"
+            width={12}
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
+              d="M6.002 5.55L11.27 0l.726.685L6.002 7 0 .685.726 0z"
             />
           </svg>
         </ChevronDownGlyph>

--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -6,6 +6,7 @@ import {
   tablePageChange,
   tableFilterApply,
   tableFilterClear,
+  tableSearchApply,
   tableToolbarToggle,
   tableActionCancel,
   tableActionApply,
@@ -52,6 +53,7 @@ const StatefulTable = ({
       onClearAllFilters,
       onCancelBatchAction,
       onApplyBatchAction,
+      onApplySearch,
     },
     table: {
       onChangeSort,
@@ -66,42 +68,68 @@ const StatefulTable = ({
   // In addition to updating the store, I always callback to the parent in case they want to do something
   const actions = {
     pagination: {
-      onChangePage: paginationValues =>
-        dispatch(tablePageChange(paginationValues)) &&
-        callbackParent(onChangePage, paginationValues),
+      onChangePage: paginationValues => {
+        dispatch(tablePageChange(paginationValues));
+        callbackParent(onChangePage, paginationValues);
+      },
     },
     toolbar: {
-      onApplyFilter: filterValues =>
-        dispatch(tableFilterApply(filterValues)) && callbackParent(onApplyFilter, filterValues),
-      onToggleFilter: () =>
-        dispatch(tableToolbarToggle('filter')) && callbackParent(onToggleFilter, 'filter'),
-      onToggleColumnSelection: () =>
-        dispatch(tableToolbarToggle('column')) && callbackParent(onToggleColumnSelection, 'column'),
-      onClearAllFilters: () => dispatch(tableFilterClear()) && callbackParent(onClearAllFilters),
-      onCancelBatchAction: () =>
-        dispatch(tableActionCancel()) && callbackParent(onCancelBatchAction),
-      onApplyBatchAction: id =>
-        dispatch(tableActionApply(id)) && callbackParent(onApplyBatchAction, id),
+      onApplyFilter: filterValues => {
+        dispatch(tableFilterApply(filterValues));
+        callbackParent(onApplyFilter, filterValues);
+      },
+      onToggleFilter: () => {
+        dispatch(tableToolbarToggle('filter'));
+        callbackParent(onToggleFilter, 'filter');
+      },
+      onToggleColumnSelection: () => {
+        dispatch(tableToolbarToggle('column'));
+        callbackParent(onToggleColumnSelection, 'column');
+      },
+      onClearAllFilters: () => {
+        dispatch(tableFilterClear());
+        callbackParent(onClearAllFilters);
+      },
+      onCancelBatchAction: () => {
+        dispatch(tableActionCancel());
+        callbackParent(onCancelBatchAction);
+      },
+      onApplyBatchAction: id => {
+        dispatch(tableActionApply(id));
+        callbackParent(onApplyBatchAction, id);
+      },
+      onApplySearch: string => {
+        callbackParent(onApplySearch, string);
+        dispatch(tableSearchApply(string));
+      },
     },
     table: {
-      onChangeSort: column =>
-        dispatch(tableColumnSort(column)) && callbackParent(onChangeSort, column),
-      onRowSelected: (rowId, isSelected) =>
-        dispatch(tableRowSelect(rowId, isSelected)) &&
-        callbackParent(onRowSelected, rowId, isSelected),
-      onSelectAll: isSelected =>
-        dispatch(tableRowSelectAll(isSelected)) && callbackParent(onSelectAll, isSelected),
-      onRowExpanded: (rowId, isExpanded) =>
-        dispatch(tableRowExpand(rowId, isExpanded)) &&
-        callbackParent(onRowExpanded, rowId, isExpanded),
+      onChangeSort: column => {
+        dispatch(tableColumnSort(column));
+        callbackParent(onChangeSort, column);
+      },
+      onRowSelected: (rowId, isSelected) => {
+        dispatch(tableRowSelect(rowId, isSelected));
+        callbackParent(onRowSelected, rowId, isSelected);
+      },
+      onSelectAll: isSelected => {
+        dispatch(tableRowSelectAll(isSelected));
+        callbackParent(onSelectAll, isSelected);
+      },
+      onRowExpanded: (rowId, isExpanded) => {
+        dispatch(tableRowExpand(rowId, isExpanded));
+        callbackParent(onRowExpanded, rowId, isExpanded);
+      },
       onApplyRowAction: (rowId, actionId) =>
         // This action doesn't update our table state, it's up to the user
         callbackParent(onApplyRowAction, rowId, actionId),
       onEmptyStateAction: () =>
         // This action doesn't update our table state, it's up to the user
         callbackParent(onEmptyStateAction),
-      onChangeOrdering: ordering =>
-        dispatch(tableColumnOrder(ordering)) && callbackParent(onChangeOrdering, ordering),
+      onChangeOrdering: ordering => {
+        dispatch(tableColumnOrder(ordering));
+        callbackParent(onChangeOrdering, ordering);
+      },
     },
   };
   return filteredData ? (

--- a/src/components/Table/StatefulTable.test.jsx
+++ b/src/components/Table/StatefulTable.test.jsx
@@ -9,7 +9,7 @@ import { initialState } from './Table.story';
 // Need to mock the useReducer hook so the real reducer doesn't run
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
-  useReducer: () => [{ view: { table: { filteredData: [] } } }, jest.fn().mockReturnValue(true)],
+  useReducer: () => [{ view: { table: { filteredData: [] } } }, jest.fn()],
 }));
 describe('StatefulTable tests', () => {
   afterAll(() => {

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -11,6 +11,7 @@ import {
   TableDataPropTypes,
   ExpandedRowsPropTypes,
   EmptyStatePropTypes,
+  TableSearchPropTypes,
 } from './TablePropTypes';
 import TableHead from './TableHead/TableHead';
 import TableToolbar from './TableToolbar/TableToolbar';
@@ -36,6 +37,8 @@ const propTypes = {
     hasRowExpansion: PropTypes.bool,
     hasRowActions: PropTypes.bool,
     hasFilter: PropTypes.bool,
+    /** has simple search capability */
+    hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
   }),
   /** Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux see StatefulTable component for an example */
@@ -72,6 +75,8 @@ const propTypes = {
           iconDescription: PropTypes.string,
         })
       ),
+      /** Simple search state */
+      search: TableSearchPropTypes,
     }),
     table: PropTypes.shape({
       isSelectAllSelected: PropTypes.bool,
@@ -111,6 +116,8 @@ const propTypes = {
       onClearAllFilters: PropTypes.func,
       onCancelBatchAction: PropTypes.func,
       onApplyBatchAction: PropTypes.func,
+      /** Apply a search criteria to the table */
+      onApplySearch: PropTypes.func,
     }),
     table: PropTypes.shape({
       onRowSelected: PropTypes.func,
@@ -131,6 +138,7 @@ const defaultProps = baseProps => ({
     hasRowExpansion: false,
     hasRowActions: false,
     hasFilter: false,
+    hasSearch: false,
     hasColumnSelection: false,
   },
   view: {
@@ -214,13 +222,15 @@ const Table = props => {
             'onApplyBatchAction',
             'onClearAllFilters',
             'onToggleColumnSelection',
-            'onToggleFilter'
+            'onToggleFilter',
+            'onApplySearch'
           )}
-          options={pick(options, 'hasColumnSelection', 'hasFilter')}
+          options={pick(options, 'hasColumnSelection', 'hasFilter', 'hasSearch')}
           tableState={{
             totalSelected: view.table.selectedIds.length,
             totalFilters: view.filters ? view.filters.length : 0,
             batchActions: view.toolbar.batchActions,
+            search: view.toolbar.search,
           }}
         />
         <CarbonTable zebra={false}>

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -211,7 +211,6 @@ export const initialState = {
       ],
       search: {
         placeHolderText: 'My Search',
-        value: 'Starting Search',
       },
     },
   },

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -122,6 +122,7 @@ const actions = {
     onClearAllFilters: action('onClearAllFilters'),
     onCancelBatchAction: action('onCancelBatchAction'),
     onApplyBatchAction: action('onApplyBatchAction'),
+    onApplySearch: action('onApplySearch'),
   },
   table: {
     onRowSelected: action('onRowSelected'),
@@ -164,6 +165,7 @@ export const initialState = {
   })),
   options: {
     hasFilter: true,
+    hasSearch: true,
     hasPagination: true,
     hasRowSelection: true,
     hasRowExpansion: true,
@@ -207,6 +209,10 @@ export const initialState = {
           iconDescription: 'Delete',
         },
       ],
+      search: {
+        placeHolderText: 'My Search',
+        value: 'Starting Search',
+      },
     },
   },
 };
@@ -221,6 +227,14 @@ storiesOf('Table', module)
     },
   })
   .add('default', () => <Table columns={tableColumns} data={tableData} actions={actions} />)
+  .add('with simple search', () => (
+    <Table
+      columns={tableColumns}
+      data={tableData}
+      actions={actions}
+      options={{ hasSearch: true }}
+    />
+  ))
   .add('with selection and batch actions', () => (
     // TODO - batch action bar
     <Table

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -59,3 +59,8 @@ export const TableColumnsPropTypes = PropTypes.arrayOf(
     }),
   })
 );
+
+export const TableSearchPropTypes = PropTypes.shape({
+  placeHolderText: PropTypes.string,
+  value: PropTypes.string,
+});

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -3,18 +3,22 @@ import PropTypes from 'prop-types';
 import { iconGrid, iconFilter } from 'carbon-icons';
 import { DataTable, Button } from 'carbon-components-react';
 
+import { TableSearchPropTypes } from '../TablePropTypes';
+
 const {
   TableToolbar: CarbonTableToolbar,
   TableToolbarContent,
   TableToolbarAction,
   TableBatchActions,
   TableBatchAction,
+  TableToolbarSearch,
 } = DataTable;
 
 const propTypes = {
   /** global table options */
   options: PropTypes.shape({
     hasFilter: PropTypes.bool,
+    hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
   }).isRequired,
   /**
@@ -50,21 +54,30 @@ const propTypes = {
         iconDescription: PropTypes.string,
       })
     ),
+    search: TableSearchPropTypes,
   }).isRequired,
 };
 
 const TableToolbar = ({
-  options: { hasColumnSelection, hasFilter },
+  options: { hasColumnSelection, hasFilter, hasSearch },
   actions: {
     onCancelBatchAction,
     onApplyBatchAction,
     onClearAllFilters,
     onToggleColumnSelection,
     onToggleFilter,
+    onApplySearch,
   },
-  tableState: { totalSelected, totalFilters, batchActions },
+  tableState: { totalSelected, totalFilters, batchActions, search },
 }) => (
   <CarbonTableToolbar>
+    {hasSearch ? (
+      <TableToolbarSearch
+        onChange={event => onApplySearch(event.currentTarget ? event.currentTarget.value : '')}
+        {...search}
+      />
+    ) : null}
+    <TableToolbarContent />
     <TableToolbarContent>
       <TableBatchActions
         onCancel={onCancelBatchAction}

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -10,6 +10,7 @@ export const TABLE_COLUMN_ORDER = 'TABLE_COLUMN_ORDER';
 export const TABLE_ROW_SELECT = 'TABLE_ROW_SELECT';
 export const TABLE_ROW_SELECT_ALL = 'TABLE_ROW_SELECT_ALL';
 export const TABLE_ROW_EXPAND = 'TABLE_ROW_EXPAND';
+export const TABLE_SEARCH_APPLY = 'TABLE_SEARCH_APPLY';
 
 export const tableRegister = () => ({ type: TABLE_REGISTER });
 export const tablePageChange = page => ({ type: TABLE_PAGE_CHANGE, payload: page });
@@ -17,6 +18,8 @@ export const tableToolbarToggle = toolbar => ({ type: TABLE_TOOLBAR_TOGGLE, payl
 /** Apply filters */
 export const tableFilterApply = filter => ({ type: TABLE_FILTER_APPLY, payload: filter });
 export const tableFilterClear = () => ({ type: TABLE_FILTER_CLEAR });
+
+export const tableSearchApply = search => ({ type: TABLE_SEARCH_APPLY, payload: search });
 /** Table Batch Actions */
 export const tableActionCancel = () => ({ type: TABLE_ACTION_CANCEL });
 export const tableActionApply = id => ({ type: TABLE_ACTION_APPLY, payload: id });

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -1,5 +1,6 @@
 import update from 'immutability-helper';
 import isNil from 'lodash/isNil';
+import isEmpty from 'lodash/isEmpty';
 
 import { getSortedData } from '../../utils/componentUtilityFunctions';
 
@@ -21,19 +22,38 @@ import {
 
 // Little utility to filter data
 const filterData = (data, filters) =>
-  data.filter(({ values }) =>
-    // return false if a value doesn't match a valid filter
-    // TODO Currently assumes every value has a toString method, need to support filtering on custom cell contents
-    filters.reduce(
-      (acc, { columnId, value }) =>
-        acc &&
-        ((values[columnId] &&
-          values[columnId].toString &&
-          values[columnId].toString().includes(value)) ||
-          isNil(values[columnId])), // If passed an invalid column keep going)
-      true
-    )
+  filters.length === 0
+    ? data
+    : data.filter(({ values }) =>
+        // return false if a value doesn't match a valid filter
+        // TODO Currently assumes every value has a toString method, need to support filtering on custom cell contents
+        filters.reduce(
+          (acc, { columnId, value }) =>
+            acc &&
+            ((values[columnId] &&
+              values[columnId].toString &&
+              values[columnId].toString().includes(value)) ||
+              isNil(values[columnId])), // If passed an invalid column keep going)
+          true
+        )
+      );
+// Little utility to search
+const searchData = (data, searchString) =>
+  data.filter((
+    { values } // globally check row values for a match
+  ) =>
+    Object.values(values).find(value => value.toString && value.toString().includes(searchString))
   );
+
+// little utility to both sort and filter
+const filterSearchAndSort = (data, sort = {}, search = {}, filters) => {
+  const { columnId, direction } = sort;
+  const { value: searchValue } = search;
+  const filteredData = filterData(data, filters);
+  const searchedData =
+    searchValue && searchValue !== '' ? searchData(filteredData, searchValue) : filteredData;
+  return !isEmpty(sort) ? getSortedData(searchedData, columnId, direction) : searchedData;
+};
 
 export const tableReducer = (state = {}, action) => {
   switch (action.type) {
@@ -74,7 +94,12 @@ export const tableReducer = (state = {}, action) => {
           },
           table: {
             filteredData: {
-              $set: filterData(state.data, newFilters),
+              $set: filterSearchAndSort(
+                state.data,
+                state.view.table.sort,
+                state.view.toolbar.search,
+                newFilters
+              ),
             },
           },
         },
@@ -91,12 +116,24 @@ export const tableReducer = (state = {}, action) => {
           },
           table: {
             filteredData: {
-              $set: state.data,
+              $set: filterSearchAndSort(
+                state.data,
+                state.view.table.sort,
+                state.view.toolbar.search,
+                []
+              ),
             },
           },
         },
       });
-    case TABLE_SEARCH_APPLY:
+    case TABLE_SEARCH_APPLY: {
+      // Quick search should search within the filtered and sorted data
+      const data = filterSearchAndSort(
+        state.data,
+        state.view.table.sort,
+        { value: action.payload },
+        state.view.filters
+      );
       return update(state, {
         view: {
           toolbar: {
@@ -111,11 +148,12 @@ export const tableReducer = (state = {}, action) => {
           },
           table: {
             filteredData: {
-              $set: state.data,
+              $set: data,
             },
           },
         },
       });
+    }
     // Toolbar Actions
     case TABLE_TOOLBAR_TOGGLE: {
       const filterToggled = state.view.toolbar.activeBar === action.payload ? null : action.payload;
@@ -274,13 +312,16 @@ export const tableReducer = (state = {}, action) => {
     }
     // By default we need to setup our sorted and filteredData
     case TABLE_REGISTER: {
-      const { columnId, direction } = state.view.table.sort || {};
-      const filteredData = filterData(state.data, state.view.filters);
       return update(state, {
         view: {
           table: {
             filteredData: {
-              $set: columnId ? getSortedData(filteredData, columnId, direction) : filteredData,
+              $set: filterSearchAndSort(
+                state.data,
+                state.view.table.sort,
+                state.view.toolbar.search,
+                state.view.filters
+              ),
             },
           },
         },

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -16,6 +16,7 @@ import {
   TABLE_ROW_EXPAND,
   TABLE_COLUMN_ORDER,
   TABLE_REGISTER,
+  TABLE_SEARCH_APPLY,
 } from './tableActionCreators';
 
 // Little utility to filter data
@@ -84,6 +85,26 @@ export const tableReducer = (state = {}, action) => {
         view: {
           filters: {
             $set: [],
+          },
+          pagination: {
+            page: { $set: 1 },
+          },
+          table: {
+            filteredData: {
+              $set: state.data,
+            },
+          },
+        },
+      });
+    case TABLE_SEARCH_APPLY:
+      return update(state, {
+        view: {
+          toolbar: {
+            search: {
+              value: {
+                $set: action.payload,
+              },
+            },
           },
           pagination: {
             page: { $set: 1 },

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -15,6 +15,7 @@ import {
   tableRowSelect,
   tableRowSelectAll,
   tableRowExpand,
+  tableSearchApply,
 } from './tableActionCreators';
 import { initialState, tableColumns } from './Table.story';
 
@@ -63,6 +64,13 @@ describe('table reducer testcases', () => {
     test('TABLE_TOOLBAR_TOGGLE ', () => {
       const updatedState = tableReducer(initialState, tableToolbarToggle('column'));
       expect(updatedState.view.toolbar.activeBar).toEqual('column');
+    });
+    test('TABLE_SEARCH_APPLY filter should search data', () => {
+      const searchString = 'searchString';
+      const updatedState = tableReducer(initialState, tableSearchApply(searchString));
+      // Apply the search
+      expect(updatedState.view.toolbar.search.value).toEqual(searchString);
+      expect(updatedState.view.pagination.page).toEqual(1);
     });
   });
   describe('table actions', () => {

--- a/src/components/__snapshots__/StorybookSnapshots.test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots.test.js.snap
@@ -15654,6 +15654,73 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
             className="bx--table-toolbar"
           >
             <div
+              className="bx--toolbar-search-container"
+            >
+              <div
+                aria-labelledby="data-table-search-1-label"
+                className="bx--search bx--search--sm bx--search--light"
+                role="search"
+              >
+                <svg
+                  alt="Filter table"
+                  aria-label="Filter table"
+                  className="bx--search-magnifier"
+                  fillRule="evenodd"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    Filter table
+                  </title>
+                  <path
+                    d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z"
+                  />
+                </svg>
+                <label
+                  className="bx--label"
+                  htmlFor="data-table-search-1"
+                  id="data-table-search-1-label"
+                >
+                  Filter table
+                </label>
+                <input
+                  className="bx--search-input"
+                  id="data-table-search-1"
+                  onChange={[Function]}
+                  placeholder="My Search"
+                  type="text"
+                  value="Starting Search"
+                />
+                <button
+                  className="bx--search-close"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    alt="Provide a description that will be used as the title"
+                    aria-label="Provide a description that will be used as the title"
+                    fillRule="evenodd"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <title>
+                      Provide a description that will be used as the title
+                    </title>
+                    <path
+                      d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              className="bx--toolbar-content"
+            />
+            <div
               className="bx--toolbar-content"
             >
               <div
@@ -19604,7 +19671,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                                   }
                                 }
                               >
-                                hasPagination
+                                hasSearch
                               </span>
                             </span>
                             : 
@@ -19631,7 +19698,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                                   }
                                 }
                               >
-                                hasRowSelection
+                                hasPagination
                               </span>
                             </span>
                             : 
@@ -20800,6 +20867,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -21445,6 +21536,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -22230,6 +22345,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -22521,6 +22660,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -26008,6 +26150,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -26653,6 +26819,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -27438,6 +27628,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table default 1`
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -27738,6 +27952,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table is loading
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -29919,6 +30136,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table is loading
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -30564,6 +30805,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table is loading
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -31349,6 +31614,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table is loading
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -31678,6 +31967,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with custo
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -34698,6 +34990,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with custo
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -35343,6 +35659,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with custo
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -36128,6 +36468,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with custo
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -36448,6 +36812,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -39557,6 +39924,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -40202,6 +40593,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -40987,6 +41402,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with filte
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -41310,6 +41749,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -43155,6 +43597,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -43800,6 +44266,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -44585,6 +45075,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -44908,6 +45422,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -46754,6 +47271,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -47399,6 +47940,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -48184,6 +48749,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no da
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -48536,6 +49125,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no re
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -50765,6 +51357,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no re
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -51410,6 +52026,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no re
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -52195,6 +52835,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with no re
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -52494,6 +53158,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -59368,6 +60035,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -60013,6 +60704,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -60798,6 +61513,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -61143,6 +61882,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -73445,6 +74187,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -74090,6 +74856,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -74875,6 +75665,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with row e
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -75166,6 +75980,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -78361,6 +79178,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -79006,6 +79847,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -79791,6 +80656,5436 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with selec
                               </span>
                               ,
                             </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onRowExpanded
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChangeSort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyRowAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onEmptyStateAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChangeOrdering
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Callbacks for actions of the table, can be used to update state in wrapper component to update \`view\` props
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Table with simple search 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3em",
+    }
+  }
+>
+  <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+          "zIndex": 0,
+        }
+      }
+    >
+      <div
+        id="Table"
+      >
+        <div
+          className="bx--data-table-v2-container"
+        >
+          <section
+            className="bx--table-toolbar"
+          >
+            <div
+              className="bx--toolbar-search-container"
+            >
+              <div
+                aria-labelledby="data-table-search-2-label"
+                className="bx--search bx--search--sm bx--search--light"
+                role="search"
+              >
+                <svg
+                  alt="Filter table"
+                  aria-label="Filter table"
+                  className="bx--search-magnifier"
+                  fillRule="evenodd"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    Filter table
+                  </title>
+                  <path
+                    d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zm4.936-1.27l4.563 4.557-.707.708-4.563-4.558a6.5 6.5 0 1 1 .707-.707z"
+                  />
+                </svg>
+                <label
+                  className="bx--label"
+                  htmlFor="data-table-search-2"
+                  id="data-table-search-2-label"
+                >
+                  Filter table
+                </label>
+                <input
+                  className="bx--search-input"
+                  id="data-table-search-2"
+                  onChange={[Function]}
+                  placeholder="Search"
+                  type="text"
+                />
+                <button
+                  className="bx--search-close bx--search-close--hidden"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    alt="Provide a description that will be used as the title"
+                    aria-label="Provide a description that will be used as the title"
+                    fillRule="evenodd"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                  >
+                    <title>
+                      Provide a description that will be used as the title
+                    </title>
+                    <path
+                      d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              className="bx--toolbar-content"
+            />
+            <div
+              className="bx--toolbar-content"
+            >
+              <div
+                className="bx--batch-actions"
+              >
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                  <button
+                    className="bx--batch-summary__cancel"
+                    onClick={[Function]}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+          <table
+            className="bx--data-table-v2"
+          >
+            <thead>
+              <tr>
+                <th
+                  id="column-string"
+                  scope="col"
+                  style={Object {}}
+                >
+                  String
+                </th>
+                <th
+                  id="column-date"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Date
+                </th>
+                <th
+                  id="column-select"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Select
+                </th>
+                <th
+                  id="column-secretField"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Secret Information
+                </th>
+                <th
+                  id="column-number"
+                  scope="col"
+                  style={Object {}}
+                >
+                  Number
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  toyota toyota toyota 0
+                </td>
+                <td>
+                  1973-03-03T09:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  AAAAAAAAAA
+                </td>
+                <td>
+                  0
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 1
+                </td>
+                <td>
+                  1973-03-14T23:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  OewGc0QsMs
+                </td>
+                <td>
+                  1
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 2
+                </td>
+                <td>
+                  1973-04-18T16:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  c8iM4qgaYa
+                </td>
+                <td>
+                  4
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 3
+                </td>
+                <td>
+                  1973-06-15T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  qcUSWgwIkI
+                </td>
+                <td>
+                  9
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 4
+                </td>
+                <td>
+                  1973-09-04T14:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  46GYyWC0w0
+                </td>
+                <td>
+                  16
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 5
+                </td>
+                <td>
+                  1973-12-17T18:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  Ia2eQMSi8i
+                </td>
+                <td>
+                  25
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 6
+                </td>
+                <td>
+                  1974-04-24T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  W4oksCiQKQ
+                </td>
+                <td>
+                  36
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 7
+                </td>
+                <td>
+                  1974-09-21T12:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  kYaqK2y8W8
+                </td>
+                <td>
+                  49
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 8
+                </td>
+                <td>
+                  1975-03-14T03:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  y2MwmsEqiq
+                </td>
+                <td>
+                  64
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 9
+                </td>
+                <td>
+                  1975-09-26T21:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  CW82EiUYuY
+                </td>
+                <td>
+                  81
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 10
+                </td>
+                <td>
+                  1976-05-03T19:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  Q0u8gYkG6G
+                </td>
+                <td>
+                  100
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 11
+                </td>
+                <td>
+                  1977-01-01T20:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  eUgE8O0yIy
+                </td>
+                <td>
+                  121
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 12
+                </td>
+                <td>
+                  1977-09-25T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  sySKaEGgUg
+                </td>
+                <td>
+                  144
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 13
+                </td>
+                <td>
+                  1978-07-11T10:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  6SEQ24WOgO
+                </td>
+                <td>
+                  169
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 14
+                </td>
+                <td>
+                  1979-05-19T22:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  Kw0WUum6s6
+                </td>
+                <td>
+                  196
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 15
+                </td>
+                <td>
+                  1980-04-19T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  YQmcwk2o4o
+                </td>
+                <td>
+                  225
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 16
+                </td>
+                <td>
+                  1981-04-13T08:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  muYiOaIWGW
+                </td>
+                <td>
+                  256
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 17
+                </td>
+                <td>
+                  1982-04-30T07:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  0OKoqQYESE
+                </td>
+                <td>
+                  289
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 18
+                </td>
+                <td>
+                  1983-06-09T09:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  Es6uIGowew
+                </td>
+                <td>
+                  324
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 19
+                </td>
+                <td>
+                  1984-08-10T15:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  SMs0k64eqe
+                </td>
+                <td>
+                  361
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 20
+                </td>
+                <td>
+                  1985-11-05T00:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  gqe6CwKM2M
+                </td>
+                <td>
+                  400
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 21
+                </td>
+                <td>
+                  1987-02-22T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  uKQCema4E4
+                </td>
+                <td>
+                  441
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 22
+                </td>
+                <td>
+                  1988-07-04T06:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  8oCI6cqmQm
+                </td>
+                <td>
+                  484
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 23
+                </td>
+                <td>
+                  1989-12-07T02:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  MIyOYS6UcU
+                </td>
+                <td>
+                  529
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 24
+                </td>
+                <td>
+                  1991-06-04T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  amkU0IMCoC
+                </td>
+                <td>
+                  576
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 25
+                </td>
+                <td>
+                  1992-12-22T04:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  oGWaS8cu0u
+                </td>
+                <td>
+                  625
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 26
+                </td>
+                <td>
+                  1994-08-04T11:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  2kIguyscCc
+                </td>
+                <td>
+                  676
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 27
+                </td>
+                <td>
+                  1996-04-08T21:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  GE4mMo8KOK
+                </td>
+                <td>
+                  729
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 28
+                </td>
+                <td>
+                  1998-01-05T11:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  UiqsoeO2a2
+                </td>
+                <td>
+                  784
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 29
+                </td>
+                <td>
+                  1999-10-27T04:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  iCcyGUekmk
+                </td>
+                <td>
+                  841
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 30
+                </td>
+                <td>
+                  2001-09-09T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  wgO4iKuSyS
+                </td>
+                <td>
+                  900
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 31
+                </td>
+                <td>
+                  2003-08-16T02:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  AAAAAAAAAA
+                </td>
+                <td>
+                  961
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 32
+                </td>
+                <td>
+                  2005-08-14T06:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  OewGc0QsMs
+                </td>
+                <td>
+                  1024
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 33
+                </td>
+                <td>
+                  2007-09-05T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  c8iM4qgaYa
+                </td>
+                <td>
+                  1089
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 34
+                </td>
+                <td>
+                  2009-10-20T00:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  qcUSWgwIkI
+                </td>
+                <td>
+                  1156
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 35
+                </td>
+                <td>
+                  2011-12-27T15:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  46GYyWC0w0
+                </td>
+                <td>
+                  1225
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 36
+                </td>
+                <td>
+                  2014-03-28T09:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  Ia2eQMSi8i
+                </td>
+                <td>
+                  1296
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 37
+                </td>
+                <td>
+                  2016-07-20T07:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  W4oksCiQKQ
+                </td>
+                <td>
+                  1369
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 38
+                </td>
+                <td>
+                  2018-12-05T08:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  kYaqK2y8W8
+                </td>
+                <td>
+                  1444
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 39
+                </td>
+                <td>
+                  2021-05-14T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  y2MwmsEqiq
+                </td>
+                <td>
+                  1521
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 40
+                </td>
+                <td>
+                  2023-11-14T22:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  CW82EiUYuY
+                </td>
+                <td>
+                  1600
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 41
+                </td>
+                <td>
+                  2026-06-09T10:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  Q0u8gYkG6G
+                </td>
+                <td>
+                  1681
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 42
+                </td>
+                <td>
+                  2029-01-25T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  eUgE8O0yIy
+                </td>
+                <td>
+                  1764
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 43
+                </td>
+                <td>
+                  2031-10-05T20:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  sySKaEGgUg
+                </td>
+                <td>
+                  1849
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 44
+                </td>
+                <td>
+                  2034-07-08T19:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  6SEQ24WOgO
+                </td>
+                <td>
+                  1936
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 45
+                </td>
+                <td>
+                  2037-05-03T21:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  Kw0WUum6s6
+                </td>
+                <td>
+                  2025
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 46
+                </td>
+                <td>
+                  2040-03-22T03:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  YQmcwk2o4o
+                </td>
+                <td>
+                  2116
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 47
+                </td>
+                <td>
+                  2043-03-03T12:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  muYiOaIWGW
+                </td>
+                <td>
+                  2209
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 48
+                </td>
+                <td>
+                  2046-03-07T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  0OKoqQYESE
+                </td>
+                <td>
+                  2304
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 49
+                </td>
+                <td>
+                  2049-04-02T18:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  Es6uIGowew
+                </td>
+                <td>
+                  2401
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 50
+                </td>
+                <td>
+                  2052-05-22T14:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  SMs0k64eqe
+                </td>
+                <td>
+                  2500
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 51
+                </td>
+                <td>
+                  2055-08-04T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  gqe6CwKM2M
+                </td>
+                <td>
+                  2601
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 52
+                </td>
+                <td>
+                  2058-11-08T16:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  uKQCema4E4
+                </td>
+                <td>
+                  2704
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 53
+                </td>
+                <td>
+                  2062-03-07T23:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  8oCI6cqmQm
+                </td>
+                <td>
+                  2809
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 54
+                </td>
+                <td>
+                  2065-07-28T09:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  MIyOYS6UcU
+                </td>
+                <td>
+                  2916
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 55
+                </td>
+                <td>
+                  2069-01-09T23:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  amkU0IMCoC
+                </td>
+                <td>
+                  3025
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 56
+                </td>
+                <td>
+                  2072-07-17T16:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  oGWaS8cu0u
+                </td>
+                <td>
+                  3136
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 57
+                </td>
+                <td>
+                  2076-02-15T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  2kIguyscCc
+                </td>
+                <td>
+                  3249
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 58
+                </td>
+                <td>
+                  2079-10-08T14:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  GE4mMo8KOK
+                </td>
+                <td>
+                  3364
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 59
+                </td>
+                <td>
+                  2083-06-23T18:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  UiqsoeO2a2
+                </td>
+                <td>
+                  3481
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 60
+                </td>
+                <td>
+                  2087-04-01T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  iCcyGUekmk
+                </td>
+                <td>
+                  3600
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 61
+                </td>
+                <td>
+                  2091-01-30T12:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  wgO4iKuSyS
+                </td>
+                <td>
+                  3721
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 62
+                </td>
+                <td>
+                  2094-12-24T03:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  AAAAAAAAAA
+                </td>
+                <td>
+                  3844
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 63
+                </td>
+                <td>
+                  2098-12-09T21:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  OewGc0QsMs
+                </td>
+                <td>
+                  3969
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 64
+                </td>
+                <td>
+                  2102-12-19T19:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  c8iM4qgaYa
+                </td>
+                <td>
+                  4096
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 65
+                </td>
+                <td>
+                  2107-01-20T20:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  qcUSWgwIkI
+                </td>
+                <td>
+                  4225
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 66
+                </td>
+                <td>
+                  2111-03-17T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  46GYyWC0w0
+                </td>
+                <td>
+                  4356
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 67
+                </td>
+                <td>
+                  2115-06-03T10:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  Ia2eQMSi8i
+                </td>
+                <td>
+                  4489
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 68
+                </td>
+                <td>
+                  2119-09-12T22:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  W4oksCiQKQ
+                </td>
+                <td>
+                  4624
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 69
+                </td>
+                <td>
+                  2124-01-15T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  kYaqK2y8W8
+                </td>
+                <td>
+                  4761
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 70
+                </td>
+                <td>
+                  2128-06-11T08:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  y2MwmsEqiq
+                </td>
+                <td>
+                  4900
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 71
+                </td>
+                <td>
+                  2132-11-29T07:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  CW82EiUYuY
+                </td>
+                <td>
+                  5041
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 72
+                </td>
+                <td>
+                  2137-06-11T09:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  Q0u8gYkG6G
+                </td>
+                <td>
+                  5184
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 73
+                </td>
+                <td>
+                  2142-01-14T15:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  eUgE8O0yIy
+                </td>
+                <td>
+                  5329
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 74
+                </td>
+                <td>
+                  2146-09-12T00:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  sySKaEGgUg
+                </td>
+                <td>
+                  5476
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 75
+                </td>
+                <td>
+                  2151-06-02T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  6SEQ24WOgO
+                </td>
+                <td>
+                  5625
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 76
+                </td>
+                <td>
+                  2156-03-15T06:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  Kw0WUum6s6
+                </td>
+                <td>
+                  5776
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 77
+                </td>
+                <td>
+                  2161-01-19T02:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  YQmcwk2o4o
+                </td>
+                <td>
+                  5929
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 78
+                </td>
+                <td>
+                  2165-12-18T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  muYiOaIWGW
+                </td>
+                <td>
+                  6084
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 79
+                </td>
+                <td>
+                  2170-12-09T04:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  0OKoqQYESE
+                </td>
+                <td>
+                  6241
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 80
+                </td>
+                <td>
+                  2175-12-23T11:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  Es6uIGowew
+                </td>
+                <td>
+                  6400
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 81
+                </td>
+                <td>
+                  2181-01-28T21:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  SMs0k64eqe
+                </td>
+                <td>
+                  6561
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 82
+                </td>
+                <td>
+                  2186-03-30T11:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  gqe6CwKM2M
+                </td>
+                <td>
+                  6724
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 83
+                </td>
+                <td>
+                  2191-06-22T04:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  uKQCema4E4
+                </td>
+                <td>
+                  6889
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 84
+                </td>
+                <td>
+                  2196-10-06T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  8oCI6cqmQm
+                </td>
+                <td>
+                  7056
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 85
+                </td>
+                <td>
+                  2202-02-14T02:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  MIyOYS6UcU
+                </td>
+                <td>
+                  7225
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 86
+                </td>
+                <td>
+                  2207-07-17T06:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  amkU0IMCoC
+                </td>
+                <td>
+                  7396
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 87
+                </td>
+                <td>
+                  2213-01-08T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  oGWaS8cu0u
+                </td>
+                <td>
+                  7569
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 88
+                </td>
+                <td>
+                  2218-07-27T00:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  2kIguyscCc
+                </td>
+                <td>
+                  7744
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 89
+                </td>
+                <td>
+                  2224-03-05T15:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  GE4mMo8KOK
+                </td>
+                <td>
+                  7921
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  toyota toyota toyota 90
+                </td>
+                <td>
+                  2229-11-06T09:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  UiqsoeO2a2
+                </td>
+                <td>
+                  8100
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  helping whiteboard as 91
+                </td>
+                <td>
+                  2235-08-02T07:33:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  iCcyGUekmk
+                </td>
+                <td>
+                  8281
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  whiteboard can eat 92
+                </td>
+                <td>
+                  2241-05-20T08:53:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  wgO4iKuSyS
+                </td>
+                <td>
+                  8464
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  as eat scott 93
+                </td>
+                <td>
+                  2247-03-31T13:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  AAAAAAAAAA
+                </td>
+                <td>
+                  8649
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  can pinocchio whiteboard 94
+                </td>
+                <td>
+                  2253-03-03T22:13:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  OewGc0QsMs
+                </td>
+                <td>
+                  8836
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  bottle toyota bottle 95
+                </td>
+                <td>
+                  2259-02-28T10:13:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  c8iM4qgaYa
+                </td>
+                <td>
+                  9025
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  eat whiteboard pinocchio 96
+                </td>
+                <td>
+                  2265-03-19T01:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  qcUSWgwIkI
+                </td>
+                <td>
+                  9216
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  chocolate can helping 97
+                </td>
+                <td>
+                  2271-04-30T20:53:20.000Z
+                </td>
+                <td>
+                  option-B
+                </td>
+                <td>
+                  46GYyWC0w0
+                </td>
+                <td>
+                  9409
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  pinocchio eat can 98
+                </td>
+                <td>
+                  2277-07-04T19:33:20.000Z
+                </td>
+                <td>
+                  option-C
+                </td>
+                <td>
+                  Ia2eQMSi8i
+                </td>
+                <td>
+                  9604
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  scott pinocchio chocolate 99
+                </td>
+                <td>
+                  2283-10-01T21:46:40.000Z
+                </td>
+                <td>
+                  option-A
+                </td>
+                <td>
+                  W4oksCiQKQ
+                </td>
+                <td>
+                  9801
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <button
+      onClick={[Function]}
+      style={
+        Object {
+          "background": "#28c",
+          "border": "none",
+          "borderRadius": "0 0 0 5px",
+          "color": "#fff",
+          "cursor": "pointer",
+          "display": "block",
+          "fontFamily": "sans-serif",
+          "fontSize": "12px",
+          "padding": "5px 15px",
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+        }
+      }
+      type="button"
+    >
+      Show Info
+    </button>
+    <div
+      style={
+        Object {
+          "background": "white",
+          "bottom": 0,
+          "display": "none",
+          "left": 0,
+          "overflow": "auto",
+          "padding": "0 40px",
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 99999,
+        }
+      }
+    >
+      <button
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#28c",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        ×
+      </button>
+      <div>
+        <div
+          style={
+            Object {
+              "WebkitFontSmoothing": "antialiased",
+              "backgroundColor": "#fff",
+              "border": "1px solid #eee",
+              "borderRadius": "2px",
+              "color": "#444",
+              "fontFamily": "-apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", BlinkMacSystemFont, \\"Segoe UI\\", \\"Roboto\\", \\"Oxygen\\", \\"Ubuntu\\", \\"Cantarell\\", \\"Fira Sans\\", \\"Droid Sans\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", \\"Arial\\", sans-serif",
+              "fontSize": "15px",
+              "fontWeight": 300,
+              "lineHeight": 1.45,
+              "marginBottom": "20px",
+              "marginTop": "20px",
+              "padding": "20px 40px 40px",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "borderBottom": "1px solid #eee",
+                "marginBottom": 10,
+                "paddingTop": 10,
+              }
+            }
+          >
+            <h1
+              style={
+                Object {
+                  "fontSize": "35px",
+                  "margin": 0,
+                  "padding": 0,
+                }
+              }
+            >
+              Table
+            </h1>
+            <h2
+              style={
+                Object {
+                  "fontSize": "22px",
+                  "fontWeight": 400,
+                  "margin": "0 0 10px 0",
+                  "padding": 0,
+                }
+              }
+            >
+              with simple search
+            </h2>
+          </div>
+          
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Story Source
+            </h1>
+            <pre
+              className="css-r8d96o eyvlbql0"
+            >
+              <div>
+                <div
+                  style={
+                    Object {
+                      "paddingLeft": 18,
+                      "paddingRight": 3,
+                    }
+                  }
+                >
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    &lt;
+                    Table
+                  </span>
+                  <span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        columns
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'string'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'String'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Date'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    name
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'Select'
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    size
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#a11",
+                                    }
+                                  }
+                                >
+                                  1
+                                </span>
+                                ,
+                                <span>
+                                  <span>
+                                    <br />
+                                        
+                                      
+                                  </span>
+                                  …
+                                </span>
+                                <span>
+                                  <br />
+                                      
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              …
+                            </span>
+                            <span>
+                              <br />
+                                
+                            </span>
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        data
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'row-0'
+                                </span>
+                                ,
+                                <span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    values
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  {
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      string
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'toyota toyota toyota 0'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      date
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    '1973-03-03T09:46:40.000Z'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      select
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'option-A'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    …
+                                  </span>
+                                  <span>
+                                    <br />
+                                          
+                                  </span>
+                                  }
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'row-1'
+                                </span>
+                                ,
+                                <span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    values
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  {
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      string
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'helping whiteboard as 1'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      date
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    '1973-03-14T23:33:20.000Z'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      select
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'option-B'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    …
+                                  </span>
+                                  <span>
+                                    <br />
+                                          
+                                  </span>
+                                  }
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    id
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  'row-2'
+                                </span>
+                                ,
+                                <span>
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#666",
+                                      }
+                                    }
+                                  >
+                                    values
+                                  </span>
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  {
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      string
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'whiteboard can eat 2'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      date
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    '1973-04-18T16:53:20.000Z'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    <span
+                                      style={
+                                        Object {
+                                          "color": "#666",
+                                        }
+                                      }
+                                    >
+                                      select
+                                    </span>
+                                  </span>
+                                  : 
+                                  <span
+                                    style={
+                                      Object {
+                                        "color": "#22a",
+                                        "wordBreak": "break-word",
+                                      }
+                                    }
+                                  >
+                                    'option-C'
+                                  </span>
+                                  ,
+                                  <span>
+                                    <span>
+                                      <br />
+                                            
+                                        
+                                    </span>
+                                    …
+                                  </span>
+                                  <span>
+                                    <br />
+                                          
+                                  </span>
+                                  }
+                                </span>
+                                }
+                              </span>
+                            </span>
+                            ,
+                            <span>
+                              <span>
+                                <br />
+                                  
+                                  
+                              </span>
+                              …
+                            </span>
+                            <span>
+                              <br />
+                                
+                            </span>
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        actions
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                pagination
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onChangePage
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onChangePage
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                toolbar
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onApplyFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onToggleFilter
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onToggleColumnSelection
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onToggleColumnSelection
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                …
+                              </span>
+                              <span>
+                                <br />
+                                    
+                              </span>
+                              }
+                            </span>
+                            ,
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                table
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              {
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onRowSelected
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onRowSelected
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onSelectAll
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onSelectAll
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  onEmptyStateAction
+                                </span>
+                              </span>
+                              : 
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                onEmptyStateAction
+                              </span>
+                              ,
+                              <span>
+                                <span>
+                                  <br />
+                                      
+                                    
+                                </span>
+                                …
+                              </span>
+                              <span>
+                                <br />
+                                    
+                              </span>
+                              }
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                    <span>
+                      <span>
+                        <br />
+                          
+                      </span>
+                      <span
+                        style={Object {}}
+                      >
+                        options
+                      </span>
+                      <span>
+                        =
+                        <span
+                          style={Object {}}
+                        >
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span>
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                hasSearch
+                              </span>
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#a11",
+                                }
+                              }
+                            >
+                              true
+                            </span>
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                      <br />
+                    </span>
+                  </span>
+                  <span
+                    style={
+                      Object {
+                        "color": "#444",
+                      }
+                    }
+                  >
+                    /&gt;
+                  </span>
+                </div>
+              </div>
+              <button
+                className="css-1naocv3 eva467m0"
+                onClick={[Function]}
+              >
+                <div
+                  className="css-lvl6aa eva467m1"
+                >
+                  <div
+                    style={
+                      Object {
+                        "marginBottom": 6,
+                      }
+                    }
+                  >
+                    Copied!
+                  </div>
+                  <div>
+                    Copy
+                  </div>
+                </div>
+              </button>
+            </pre>
+          </div>
+          <div>
+            <h1
+              style={
+                Object {
+                  "borderBottom": "1px solid #EEE",
+                  "fontSize": "25px",
+                  "margin": "20px 0 0 0",
+                  "padding": "0 0 5px 0",
+                }
+              }
+            >
+              Prop Types
+            </h1>
+            <div>
+              <h2
+                style={
+                  Object {
+                    "margin": "20px 0 0 0",
+                  }
+                }
+              >
+                "
+                Table
+                " Component
+              </h2>
+              <table
+                className="css-1uhv8nx e1vdo5380"
+              >
+                <thead>
+                  <tr>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      property
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      propType
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      required
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      default
+                    </th>
+                    <th
+                      className="css-11b5gui e6fp4ir1"
+                    >
+                      description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      id
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        string
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      DOM ID for component
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      columns
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        custom
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Specify the properties of each column in the table
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      data
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        custom
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Data for the body of the table
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      expandedData
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        custom
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Expanded data for the table details
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      options
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasPagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowSelection
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowExpansion
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasRowActions
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasFilter
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            hasColumnSelection
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Optional properties to customize how the table should be rendered
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      view
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSize
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                pageSizes
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    number
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                page
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                totalItems
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                number
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            filters
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <span>
+                              [
+                            </span>
+                            <span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 15,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    value
+                                    
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                            </span>
+                            <span>
+                              ]
+                            </span>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                activeBar
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                oneOf 'filter' | 'column'
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                batchActions
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        id
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        labelText
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        icon
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        <span>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            {
+                                          </button>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                          >
+                                            ...
+                                          </button>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              width
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              height
+                                              ?
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              viewBox
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              string
+                                            </span>
+                                            ,
+                                          </div>
+                                          <div
+                                            style={
+                                              Object {
+                                                "marginLeft": 15,
+                                              }
+                                            }
+                                          >
+                                            <span
+                                              style={
+                                                Object {
+                                                  "whiteSpace": "nowrap",
+                                                }
+                                              }
+                                            >
+                                              svgData
+                                              
+                                              :
+                                               
+                                            </span>
+                                            <span>
+                                              object
+                                            </span>
+                                            ,
+                                          </div>
+                                          <button
+                                            className="css-1sgldz e1i4ski80"
+                                            onClick={[Function]}
+                                            onMouseEnter={[Function]}
+                                            onMouseLeave={[Function]}
+                                          >
+                                            }
+                                          </button>
+                                        </span>
+                                        <span>
+                                           | 
+                                        </span>
+                                        <span>
+                                          string
+                                        </span>
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        iconDescription
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            table
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllSelected
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                isSelectAllIndeterminate
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                bool
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                selectedIds
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    string
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                sort
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    columnId
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    string
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    direction
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    oneOf 'NONE' | 'ASC' | 'DESC'
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                ordering
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      {
+                                    </button>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                    >
+                                      ...
+                                    </button>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        columnId
+                                        
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        string
+                                      </span>
+                                      ,
+                                    </div>
+                                    <div
+                                      style={
+                                        Object {
+                                          "marginLeft": 15,
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        style={
+                                          Object {
+                                            "whiteSpace": "nowrap",
+                                          }
+                                        }
+                                      >
+                                        isHidden
+                                        ?
+                                        :
+                                         
+                                      </span>
+                                      <span>
+                                        bool
+                                      </span>
+                                      ,
+                                    </div>
+                                    <button
+                                      className="css-1sgldz e1i4ski80"
+                                      onClick={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                    >
+                                      }
+                                    </button>
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                expandedIds
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <span>
+                                  [
+                                </span>
+                                <span>
+                                  <span>
+                                    string
+                                  </span>
+                                </span>
+                                <span>
+                                  ]
+                                </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                emptyState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                loadingState
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  {
+                                </button>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                >
+                                  ...
+                                </button>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    isLoading
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    bool
+                                  </span>
+                                  ,
+                                </div>
+                                <div
+                                  style={
+                                    Object {
+                                      "marginLeft": 45,
+                                    }
+                                  }
+                                >
+                                  <span
+                                    style={
+                                      Object {
+                                        "whiteSpace": "nowrap",
+                                      }
+                                    }
+                                  >
+                                    rowCount
+                                    ?
+                                    :
+                                     
+                                  </span>
+                                  <span>
+                                    number
+                                  </span>
+                                  ,
+                                </div>
+                                <button
+                                  className="css-1sgldz e1i4ski80"
+                                  onClick={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  }
+                                </button>
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          }
+                        </button>
+                      </span>
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      -
+                    </td>
+                    <td
+                      className="css-11b5gui e6fp4ir0"
+                    >
+                      Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux see StatefulTable component for an example
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      actions
+                    </td>
+                    <td
+                      className="css-1qcb1f7 e6fp4ir0"
+                    >
+                      <span>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                        >
+                          {
+                        </button>
+                        <button
+                          className="css-1sgldz e1i4ski80"
+                          onClick={[Function]}
+                        >
+                          ...
+                        </button>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            pagination
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onChangePage
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              }
+                            </button>
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
+                            toolbar
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                            >
+                              {
+                            </button>
+                            <button
+                              className="css-1sgldz e1i4ski80"
+                              onClick={[Function]}
+                            >
+                              ...
+                            </button>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onToggleFilter
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onToggleColumnSelection
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onClearAllFilters
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onCancelBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplyBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
                             <button
                               className="css-1sgldz e1i4ski80"
                               onClick={[Function]}
@@ -80082,6 +86377,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
           <section
             className="bx--table-toolbar"
           >
+            <div
+              className="bx--toolbar-content"
+            />
             <div
               className="bx--toolbar-content"
             >
@@ -83148,6 +89446,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                               }
                             }
                           >
+                            hasSearch
+                            ?
+                            :
+                             
+                          </span>
+                          <span>
+                            bool
+                          </span>
+                          ,
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "marginLeft": 15,
+                            }
+                          }
+                        >
+                          <span
+                            style={
+                              Object {
+                                "whiteSpace": "nowrap",
+                              }
+                            }
+                          >
                             hasColumnSelection
                             ?
                             :
@@ -83793,6 +90115,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                                 <span>
                                   ]
                                 </span>
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                search
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                custom
                               </span>
                               ,
                             </div>
@@ -84569,6 +90915,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table with sorti
                                 }
                               >
                                 onApplyBatchAction
+                                ?
+                                :
+                                 
+                              </span>
+                              <span>
+                                func
+                              </span>
+                              ,
+                            </div>
+                            <div
+                              style={
+                                Object {
+                                  "marginLeft": 30,
+                                }
+                              }
+                            >
+                              <span
+                                style={
+                                  Object {
+                                    "whiteSpace": "nowrap",
+                                  }
+                                }
+                              >
+                                onApplySearch
                                 ?
                                 :
                                  

--- a/src/components/__snapshots__/StorybookSnapshots.test.js.snap
+++ b/src/components/__snapshots__/StorybookSnapshots.test.js.snap
@@ -15691,10 +15691,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Table Stateful E
                   onChange={[Function]}
                   placeholder="My Search"
                   type="text"
-                  value="Starting Search"
                 />
                 <button
-                  className="bx--search-close"
+                  className="bx--search-close bx--search-close--hidden"
                   onClick={[Function]}
                   type="button"
                 >


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Use options.hasSearch to enable a simple quick search in both the presentation layer and stateful table layer

![image](https://user-images.githubusercontent.com/6663002/53996537-63b22180-40fe-11e9-8b76-049d187e6cf8.png)

**Change List (commits, features, bugs, etc)**

- feat(tableReducer): add new action and reducer for simple search
- feat(Table): Add simple search

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#52

**Acceptance Test (how to verify the PR)**

- Test the new quick search box in the Stateful Table story
