### PR TITLE
feat(table): split out table reducer functionality

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -154,7 +154,7 @@ const defaultProps = baseProps => ({
       batchActions: [],
     },
     table: {
-      expandedRows: [],
+      expandedIds: [],
       isSelectAllSelected: false,
       selectedIds: [],
       sort: {},

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -52,6 +52,7 @@ const StyledExpansionTableRow = styled(TableRow)`
       background-color: inherit;
       border-left: 4px solid ${COLORS.blue};
       border-width: 0 0 0 4px;
+      padding: 0;
     }
     :hover {
       border: inherit;

--- a/src/components/Table/baseTableReducer.js
+++ b/src/components/Table/baseTableReducer.js
@@ -1,0 +1,226 @@
+import update from 'immutability-helper';
+
+import {
+  TABLE_PAGE_CHANGE,
+  TABLE_FILTER_APPLY,
+  TABLE_TOOLBAR_TOGGLE,
+  TABLE_FILTER_CLEAR,
+  TABLE_ACTION_CANCEL,
+  TABLE_ACTION_APPLY,
+  TABLE_COLUMN_SORT,
+  TABLE_ROW_SELECT,
+  TABLE_ROW_SELECT_ALL,
+  TABLE_ROW_EXPAND,
+  TABLE_COLUMN_ORDER,
+  TABLE_SEARCH_APPLY,
+} from './tableActionCreators';
+
+export const baseTableReducer = (state = {}, action) => {
+  switch (action.type) {
+    // Page Actions
+    case TABLE_PAGE_CHANGE: {
+      const { pageSize: currentPageSize, totalItems, page: currentPage } = state.view.pagination;
+      const { page, pageSize } = action.payload;
+      const isPageSizeChange = pageSize && currentPageSize !== pageSize;
+      const isPageChange = page !== currentPage && page <= totalItems / pageSize;
+      const newPagination = isPageSizeChange
+        ? {
+            ...state.view.pagination,
+            ...action.payload,
+            page: 1,
+          }
+        : isPageChange
+        ? {
+            ...state.view.pagination,
+            ...action.payload,
+          }
+        : state.view.pagination;
+      const result = update(state, {
+        view: {
+          pagination: {
+            $set: newPagination,
+          },
+        },
+      });
+      return result;
+    }
+    // Filter Actions
+    case TABLE_FILTER_APPLY: {
+      const newFilters = Object.entries(action.payload)
+        .map(([key, value]) =>
+          value !== ''
+            ? {
+                columnId: key,
+                value,
+              }
+            : null
+        )
+        .filter(i => i);
+
+      return update(state, {
+        view: {
+          filters: {
+            $set: newFilters,
+          },
+          pagination: {
+            page: { $set: 1 },
+          },
+        },
+      });
+    }
+    case TABLE_FILTER_CLEAR:
+      return update(state, {
+        view: {
+          filters: {
+            $set: [],
+          },
+          pagination: {
+            page: { $set: 1 },
+          },
+        },
+      });
+    case TABLE_SEARCH_APPLY: {
+      return update(state, {
+        view: {
+          toolbar: {
+            search: {
+              value: {
+                $set: action.payload,
+              },
+            },
+          },
+          pagination: {
+            page: { $set: 1 },
+          },
+        },
+      });
+    }
+    // Toolbar Actions
+    case TABLE_TOOLBAR_TOGGLE: {
+      const filterToggled = state.view.toolbar.activeBar === action.payload ? null : action.payload;
+      return update(state, {
+        view: {
+          toolbar: {
+            activeBar: {
+              $set: filterToggled,
+            },
+          },
+        },
+      });
+    }
+    // Batch Actions
+    case TABLE_ACTION_CANCEL:
+      return update(state, {
+        view: {
+          table: {
+            selectedIds: { $set: [] },
+            isSelectAllSelected: { $set: false },
+            isSelectAllIndeterminate: { $set: false },
+          },
+        },
+      });
+    case TABLE_ACTION_APPLY: {
+      return update(state, {
+        view: {
+          table: {
+            selectedIds: { $set: [] },
+            isSelectAllSelected: { $set: false },
+            isSelectAllIndeterminate: { $set: false },
+          },
+        },
+      });
+    }
+    // Column operations
+    case TABLE_COLUMN_SORT: {
+      // TODO should check that columnId actually is valid
+      const columnId = action.payload;
+      const sorts = ['NONE', 'ASC', 'DESC'];
+      const currentSort = state.view.table.sort;
+      const currentSortDir =
+        currentSort && currentSort.columnId === columnId ? state.view.table.sort.direction : 'NONE';
+      const nextSortDir = sorts[(sorts.findIndex(i => i === currentSortDir) + 1) % sorts.length];
+      return update(state, {
+        view: {
+          table: {
+            sort: {
+              $set:
+                nextSortDir === 'NONE'
+                  ? undefined
+                  : {
+                      columnId: action.payload,
+                      direction: nextSortDir,
+                    },
+            },
+          },
+        },
+      });
+    }
+    case TABLE_COLUMN_ORDER:
+      return update(state, {
+        view: {
+          table: {
+            ordering: { $set: action.payload },
+          },
+        },
+      });
+    // Row operations
+    case TABLE_ROW_SELECT: {
+      const { rowId, isSelected } = action.payload;
+      const isClearing = !isSelected && state.view.table.selectedIds.length <= 1;
+      const isSelectingAll =
+        isSelected && state.view.table.selectedIds.length + 1 === state.data.length;
+      return update(state, {
+        view: {
+          table: {
+            selectedIds: {
+              $set: isSelected
+                ? state.view.table.selectedIds.concat([rowId])
+                : state.view.table.selectedIds.filter(i => i !== rowId),
+            },
+            isSelectAllIndeterminate: {
+              $set: !(isClearing || isSelectingAll),
+            },
+            isSelectAllSelected: {
+              $set: isSelectingAll,
+            },
+          },
+        },
+      });
+    }
+    case TABLE_ROW_SELECT_ALL: {
+      const { isSelected } = action.payload;
+      return update(state, {
+        view: {
+          table: {
+            isSelectAllSelected: {
+              $set: isSelected,
+            },
+            //
+            selectedIds: {
+              $set: isSelected ? state.data.map(i => i.id) : [],
+            },
+            isSelectAllIndeterminate: {
+              $set: false,
+            },
+          },
+        },
+      });
+    }
+    case TABLE_ROW_EXPAND: {
+      const { rowId, isExpanded } = action.payload;
+      return update(state, {
+        view: {
+          table: {
+            expandedIds: {
+              $set: isExpanded
+                ? state.view.table.expandedIds.concat([rowId])
+                : state.view.table.expandedIds.filter(i => i !== rowId),
+            },
+          },
+        },
+      });
+    }
+    default:
+      return state;
+  }
+};

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -9,8 +9,11 @@ export const TABLE_COLUMN_SORT = 'TABLE_COLUMN_SORT';
 export const TABLE_COLUMN_ORDER = 'TABLE_COLUMN_ORDER';
 export const TABLE_ROW_SELECT = 'TABLE_ROW_SELECT';
 export const TABLE_ROW_SELECT_ALL = 'TABLE_ROW_SELECT_ALL';
+export const TABLE_ROW_CLICK = 'TABLE_ROW_CLICK';
 export const TABLE_ROW_EXPAND = 'TABLE_ROW_EXPAND';
+export const TABLE_ROW_ACTION_APPLY = 'TABLE_ROW_ACTION_APPLY';
 export const TABLE_SEARCH_APPLY = 'TABLE_SEARCH_APPLY';
+export const TABLE_EMPTY_STATE_ACTION = 'TABLE_EMPTY_STATE_ACTION';
 
 export const tableRegister = () => ({ type: TABLE_REGISTER });
 export const tablePageChange = page => ({ type: TABLE_PAGE_CHANGE, payload: page });
@@ -26,6 +29,8 @@ export const tableActionApply = id => ({ type: TABLE_ACTION_APPLY, payload: id }
 /** Table column actions */
 export const tableColumnSort = column => ({ type: TABLE_COLUMN_SORT, payload: column });
 export const tableColumnOrder = ordering => ({ type: TABLE_COLUMN_ORDER, payload: ordering });
+/** Table empty state action */
+export const tableEmptyStateAction = () => ({ type: TABLE_EMPTY_STATE_ACTION });
 
 /** Select a row of the table */
 export const tableRowSelect = (rowId, isSelected) => ({
@@ -37,7 +42,15 @@ export const tableRowSelectAll = isSelected => ({
   type: TABLE_ROW_SELECT_ALL,
   payload: { isSelected },
 });
+export const tableRowClick = rowId => ({
+  type: TABLE_ROW_CLICK,
+  payload: { rowId },
+});
 export const tableRowExpand = (rowId, isExpanded) => ({
   type: TABLE_ROW_EXPAND,
   payload: { rowId, isExpanded },
+});
+export const tableRowActionApply = (rowId, actionId) => ({
+  type: TABLE_ROW_ACTION_APPLY,
+  payload: { rowId, actionId },
 });

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -27,15 +27,15 @@ export const tableActionApply = id => ({ type: TABLE_ACTION_APPLY, payload: id }
 export const tableColumnSort = column => ({ type: TABLE_COLUMN_SORT, payload: column });
 export const tableColumnOrder = ordering => ({ type: TABLE_COLUMN_ORDER, payload: ordering });
 
-/** Select a row of the table, we actually need you to also pass along the filtered Data to determine if this is the last row */
-export const tableRowSelect = (rowId, isSelected, filteredData) => ({
+/** Select a row of the table */
+export const tableRowSelect = (rowId, isSelected) => ({
   type: TABLE_ROW_SELECT,
-  payload: { rowId, isSelected, filteredData },
+  payload: { rowId, isSelected },
 });
 /** Select all the currently filtered rows of the table */
-export const tableRowSelectAll = (isSelected, filteredData) => ({
+export const tableRowSelectAll = isSelected => ({
   type: TABLE_ROW_SELECT_ALL,
-  payload: { isSelected, filteredData },
+  payload: { isSelected },
 });
 export const tableRowExpand = (rowId, isExpanded) => ({
   type: TABLE_ROW_EXPAND,

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -19,6 +19,7 @@ import {
   TABLE_REGISTER,
   TABLE_SEARCH_APPLY,
 } from './tableActionCreators';
+import { baseTableReducer } from './baseTableReducer';
 
 // Little utility to filter data
 const filterData = (data, filters) =>
@@ -58,19 +59,8 @@ const filterSearchAndSort = (data, sort = {}, search = {}, filters) => {
 export const tableReducer = (state = {}, action) => {
   switch (action.type) {
     // Page Actions
-    case TABLE_PAGE_CHANGE: {
-      const { pageSize, totalItems, page: currentPage } = state.view.pagination;
-      const { page } = action.payload;
-      return page !== currentPage && page <= totalItems / pageSize
-        ? update(state, {
-            view: {
-              pagination: {
-                $merge: action.payload,
-              },
-            },
-          })
-        : state;
-    }
+    case TABLE_PAGE_CHANGE:
+      return baseTableReducer(state, action);
     // Filter Actions
     case TABLE_FILTER_APPLY: {
       const newFilters = Object.entries(action.payload)
@@ -84,48 +74,42 @@ export const tableReducer = (state = {}, action) => {
         )
         .filter(i => i);
 
-      return update(state, {
-        view: {
-          filters: {
-            $set: newFilters,
-          },
-          pagination: {
-            page: { $set: 1 },
-          },
-          table: {
-            filteredData: {
-              $set: filterSearchAndSort(
-                state.data,
-                state.view.table.sort,
-                state.view.toolbar.search,
-                newFilters
-              ),
+      return baseTableReducer(
+        update(state, {
+          view: {
+            table: {
+              filteredData: {
+                $set: filterSearchAndSort(
+                  state.data,
+                  state.view.table.sort,
+                  state.view.toolbar.search,
+                  newFilters
+                ),
+              },
             },
           },
-        },
-      });
+        }),
+        action
+      );
     }
     case TABLE_FILTER_CLEAR:
-      return update(state, {
-        view: {
-          filters: {
-            $set: [],
-          },
-          pagination: {
-            page: { $set: 1 },
-          },
-          table: {
-            filteredData: {
-              $set: filterSearchAndSort(
-                state.data,
-                state.view.table.sort,
-                state.view.toolbar.search,
-                []
-              ),
+      return baseTableReducer(
+        update(state, {
+          view: {
+            table: {
+              filteredData: {
+                $set: filterSearchAndSort(
+                  state.data,
+                  state.view.table.sort,
+                  state.view.toolbar.search,
+                  []
+                ),
+              },
             },
           },
-        },
-      });
+        }),
+        action
+      );
     case TABLE_SEARCH_APPLY: {
       // Quick search should search within the filtered and sorted data
       const data = filterSearchAndSort(
@@ -134,79 +118,47 @@ export const tableReducer = (state = {}, action) => {
         { value: action.payload },
         state.view.filters
       );
-      return update(state, {
-        view: {
-          toolbar: {
-            search: {
-              value: {
-                $set: action.payload,
-              },
-            },
-          },
-          pagination: {
-            page: { $set: 1 },
-          },
-          table: {
-            filteredData: {
-              $set: data,
-            },
-          },
-        },
-      });
-    }
-    // Toolbar Actions
-    case TABLE_TOOLBAR_TOGGLE: {
-      const filterToggled = state.view.toolbar.activeBar === action.payload ? null : action.payload;
-      return update(state, {
-        view: {
-          toolbar: {
-            activeBar: {
-              $set: filterToggled,
-            },
-          },
-        },
-      });
-    }
-    // Batch Actions
-    case TABLE_ACTION_CANCEL:
-      return update(state, {
-        view: {
-          table: {
-            selectedIds: { $set: [] },
-            isSelectAllSelected: { $set: false },
-            isSelectAllIndeterminate: { $set: false },
-          },
-        },
-      });
-    case TABLE_ACTION_APPLY: {
-      const { filteredData } = state.view.table;
-      const data = filteredData || state.data;
-      // No matter what clear selections
-      const clearedSelections = update(state, {
-        view: {
-          table: {
-            selectedIds: { $set: [] },
-            isSelectAllSelected: { $set: false },
-            isSelectAllIndeterminate: { $set: false },
-          },
-        },
-      });
-      // only update the data and filtered data if deleted
-      if (action.payload === 'delete') {
-        return update(clearedSelections, {
-          data: {
-            $set: state.data.filter(i => !state.view.table.selectedIds.includes(i.id)),
-          },
+      return baseTableReducer(
+        update(state, {
           view: {
             table: {
               filteredData: {
-                $set: data.filter(i => !state.view.table.selectedIds.includes(i.id)),
+                $set: data,
               },
             },
           },
-        });
+        }),
+        action
+      );
+    }
+    // Toolbar Actions
+    case TABLE_TOOLBAR_TOGGLE:
+      return baseTableReducer(state, action);
+    // Batch Actions
+    case TABLE_ACTION_CANCEL:
+      return baseTableReducer(state, action);
+    case TABLE_ACTION_APPLY: {
+      const { filteredData } = state.view.table;
+      const data = filteredData || state.data;
+      // only update the data and filtered data if deleted
+      if (action.payload === 'delete') {
+        return baseTableReducer(
+          update(state, {
+            data: {
+              $set: state.data.filter(i => !state.view.table.selectedIds.includes(i.id)),
+            },
+            view: {
+              table: {
+                filteredData: {
+                  $set: data.filter(i => !state.view.table.selectedIds.includes(i.id)),
+                },
+              },
+            },
+          }),
+          action
+        );
       }
-      return clearedSelections;
+      return baseTableReducer(state, action);
     }
     // Column operations
     case TABLE_COLUMN_SORT: {
@@ -217,99 +169,38 @@ export const tableReducer = (state = {}, action) => {
       const currentSortDir =
         currentSort && currentSort.columnId === columnId ? state.view.table.sort.direction : 'NONE';
       const nextSortDir = sorts[(sorts.findIndex(i => i === currentSortDir) + 1) % sorts.length];
-      return update(state, {
-        view: {
-          table: {
-            sort: {
-              $set:
-                nextSortDir === 'NONE'
-                  ? undefined
-                  : {
-                      columnId: action.payload,
-                      direction: nextSortDir,
-                    },
-            },
-            filteredData: {
-              $set:
-                nextSortDir !== 'NONE'
-                  ? getSortedData(
-                      state.view.table.filteredData || state.data,
-                      columnId,
-                      nextSortDir
-                    )
-                  : filterData(state.data, state.view.filters), // reset to original filters
+      return baseTableReducer(
+        update(state, {
+          view: {
+            table: {
+              filteredData: {
+                $set:
+                  nextSortDir !== 'NONE'
+                    ? getSortedData(
+                        state.view.table.filteredData || state.data,
+                        columnId,
+                        nextSortDir
+                      )
+                    : filterData(state.data, state.view.filters), // reset to original filters
+              },
             },
           },
-        },
-      });
+        }),
+        action
+      );
     }
     case TABLE_COLUMN_ORDER:
-      return update(state, {
-        view: {
-          table: {
-            ordering: { $set: action.payload },
-          },
-        },
-      });
-    // Row operations
+      return baseTableReducer(state, action);
     case TABLE_ROW_SELECT: {
-      const { rowId, isSelected } = action.payload;
-      const { filteredData } = state.view.table;
-      const data = filteredData || state.data;
-      const isClearing = !isSelected && state.view.table.selectedIds.length <= 1;
-      const isSelectingAll = isSelected && state.view.table.selectedIds.length + 1 === data.length;
-      return update(state, {
-        view: {
-          table: {
-            selectedIds: {
-              $set: isSelected
-                ? state.view.table.selectedIds.concat([rowId])
-                : state.view.table.selectedIds.filter(i => i !== rowId),
-            },
-            isSelectAllIndeterminate: {
-              $set: !(isClearing || isSelectingAll),
-            },
-            isSelectAllSelected: {
-              $set: isSelectingAll,
-            },
-          },
-        },
-      });
+      const data = state.view.table.filteredData || state.data;
+      return baseTableReducer({ ...state, data }, action);
     }
     case TABLE_ROW_SELECT_ALL: {
-      const { filteredData } = state.view.table;
-      const data = filteredData || state.data;
-      const { isSelected } = action.payload;
-      return update(state, {
-        view: {
-          table: {
-            isSelectAllSelected: {
-              $set: isSelected,
-            },
-            selectedIds: {
-              $set: isSelected && data ? data.map(i => i.id) : [],
-            },
-            isSelectAllIndeterminate: {
-              $set: false,
-            },
-          },
-        },
-      });
+      const data = state.view.table.filteredData || state.data;
+      return baseTableReducer({ ...state, data }, action);
     }
-    case TABLE_ROW_EXPAND: {
-      const { rowId, isExpanded } = action.payload;
-      return update(state, {
-        view: {
-          table: {
-            expandedIds: {
-              $set: isExpanded
-                ? state.view.table.expandedIds.concat([rowId])
-                : state.view.table.expandedIds.filter(i => i !== rowId),
-            },
-          },
-        },
-      });
-    }
+    case TABLE_ROW_EXPAND:
+      return baseTableReducer(state, action);
     // By default we need to setup our sorted and filteredData
     case TABLE_REGISTER: {
       return update(state, {

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -52,11 +52,11 @@ describe('table reducer testcases', () => {
   });
   describe('pagination tests', () => {
     test('TABLE_PAGE_CHANGE ', () => {
-      const updatedState = tableReducer(initialState, tablePageChange({ page: 3 }));
+      const updatedState = tableReducer(initialState, tablePageChange({ page: 3, pageSize: 10 }));
       expect(updatedState.view.pagination.page).toEqual(3);
     });
     test('TABLE_PAGE_CHANGE with invalid page', () => {
-      const updatedState = tableReducer(initialState, tablePageChange({ page: 65 }));
+      const updatedState = tableReducer(initialState, tablePageChange({ page: 65, pageSize: 10 }));
       expect(updatedState.view.pagination.page).toEqual(1);
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -8,5 +8,6 @@ export TableBody from './components/Table/TableBody/TableBody';
 export TableToolbar from './components/Table/TableToolbar/TableToolbar';
 export EmptyTable from './components/Table/EmptyTable/EmptyTable';
 export TableSkeletonWithHeaders from './components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders';
+export { baseTableReducer } from './components/Table/baseTableReducer';
 export { tableReducer } from './components/Table/tableReducer';
 export * as tableActions from './components/Table/tableActionCreators';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,13 +2717,6 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
   integrity sha1-ri1acpR38onWDdf5amMUoi3Wwio=
 
-attr-accept@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
-  integrity sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==
-  dependencies:
-    core-js "^2.5.0"
-
 autoprefixer@^9.3.1, autoprefixer@^9.4.4:
   version "9.4.4"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.4.tgz#40c42b335bdb22efe8cd80389ca82ffb5e32d68d"


### PR DESCRIPTION
**Summary**

- Split out the exported table reducer into two:
  - *baseTableReducer* contains all simple view logic (everything but sorting, filtering, searching)
  - *tableReducer* handles sorting/filtering/searching, and passes actions down to baseTableReducer

**Change List (commits, features, bugs, etc)**

(see commits in PR)

**Related Issues**

n/a

**Acceptance Test (how to verify the PR)**

- Verify stateful component behaves as expected.
