### PR TITLE
fix(table): correct usage of useEffect for stateful table

### DIFF
--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -33,9 +33,12 @@ const StatefulTable = ({
 }) => {
   const [state, dispatch] = useReducer(tableReducer, { data: initialData, view: initialState });
   // Need to initially sort and filter the tables data
-  useEffect(() => {
-    dispatch(tableRegister());
-  }, initialData);
+  useEffect(
+    () => {
+      dispatch(tableRegister());
+    },
+    [initialData]
+  );
 
   const {
     view,


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Fixes if consumers have empty array of data that is updated with real data array, which currently causes a `Warning: The final argument passed to useEffect changed size between renders. The order and size of this array must remain constant.`