### PR TITLE
fix(table): table won't render if data in row for a column is undefined

### DIFF
--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -45,4 +45,21 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowClicked).toHaveBeenCalled();
     expect(mockActions.onRowExpanded).not.toHaveBeenCalled();
   });
+  test('verify rendering with undefined column', () => {
+    const tableRowPropsWithUndefined = {
+      tableId: 'tableId',
+      totalColumns: 1,
+      id: 'tableRow',
+      columns: [{ id: 'col1' }, { id: 'col2' }],
+      children: { col1: 'value1', col2: undefined },
+    };
+    const wrapper = mount(
+      <TableBodyRow
+        options={{ hasRowExpansion: true }}
+        tableActions={mockActions}
+        {...tableRowPropsWithUndefined}
+      />
+    );
+    console.log(wrapper.debug());
+  });
 });

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -5,7 +5,11 @@ const propTypes = {
   children: PropTypes.node,
 };
 
-const TableCellRenderer = ({ children = null }) =>
+const defaultProps = {
+  children: null,
+};
+
+const TableCellRenderer = ({ children }) =>
   typeof children === 'string' || typeof children === 'number' ? (
     <span title={children}>{children}</span>
   ) : (
@@ -13,5 +17,6 @@ const TableCellRenderer = ({ children = null }) =>
   );
 
 TableCellRenderer.propTypes = propTypes;
+TableCellRenderer.defaultProps = defaultProps;
 
 export default TableCellRenderer;

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
-const TableCellRenderer = ({ children }) =>
+const TableCellRenderer = ({ children = null }) =>
   typeof children === 'string' || typeof children === 'number' ? (
     <span title={children}>{children}</span>
   ) : (


### PR DESCRIPTION
**Summary**

- Allow `undefined` to be passed as column data for a row.  Example:

```
{
  id: 'row-1',
  values: {
    'column1': 42,
    'column2': undefined,
    'column3': 'abc'
  }
}
```

**Change List (commits, features, bugs, etc)**

(see commit list)