### PR TITLE
fix(statefultable): tableRegister action should dispatch payload with latest data

### DIFF
--- a/src/components/BaseModal/BaseModal.jsx
+++ b/src/components/BaseModal/BaseModal.jsx
@@ -98,6 +98,63 @@ const StyledButtons = styled.div`
   }
 `;
 
+export const BaseModalPropTypes = {
+  /** Header Props
+   * label: goes on top of the dialog
+   * title: Heading of the dialog
+   * helpText, additional information will stay at the top of the screen when scrolling dialog content
+   */
+  header: PropTypes.shape({
+    label: PropTypes.string,
+    title: PropTypes.string,
+    helpText: PropTypes.node,
+  }),
+  /** Content to render inside Modal */
+  children: PropTypes.node,
+  /** Footer Props
+   * Either supply your own footer element or supply an object with button labels and submit handlers and we will make a footer with two buttons for you
+   */
+  footer: PropTypes.oneOfType([
+    PropTypes.element.isRequired,
+    PropTypes.shape({
+      primaryButtonLabel: PropTypes.node,
+      secondaryButtonLabel: PropTypes.node,
+    }),
+  ]),
+  /** NEW PROP: Type of dialog, affects colors, styles of dialog */
+  type: PropTypes.oneOf(['warn', 'normal']),
+  /** NEW PROP: Whether this particular dialog needs to be very large */
+  isLarge: PropTypes.bool,
+
+  /** REDUXDIALOG: Should the dialog be open or not */
+  open: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  /**  REDUXDIALOG: Close the dialog */
+  onClose: PropTypes.func.isRequired,
+
+  /**  REDUXDIALOG: Clear the currently shown dataError, triggered if the user closes the ErrorNotification */
+  onClearDialogErrors: PropTypes.func,
+
+  /** REDUXDIALOG: Is data currently being sent to the backend */
+  sendingData: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  /** REDUXDIALOG: Is my data actively loading? */
+  isFetchingData: PropTypes.bool,
+  /** REDUXDIALOG: Details about the current dataError */
+  dataError: PropTypes.string,
+
+  /** REDUXFORM: Form Error Details */
+  error: PropTypes.string,
+  /** REDUXFORM: Did the form submission fail */
+  submitFailed: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  /** REDUXFORM: Is the form currently invalid */
+  invalid: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
+  /**  REDUXFORM: Clear the currently shown error (from form), triggered if the user closes the ErrorNotification */
+  clearSubmitErrors: PropTypes.func,
+  /** REDUXFORM: Callback to submit the dialog/form */
+  onSubmit: PropTypes.func,
+  /** ability to add translation string to close icon */
+  iconDescription: PropTypes.string,
+};
+
 /**
  * Renders a carbon modal dialog.  This dialog adds these additional features on top of the base carbon dialog:
  *  adds header.helpText prop to explain dialog
@@ -113,62 +170,7 @@ const StyledButtons = styled.div`
  * REDUXFORM or REDUXDIALOG
  */
 class BaseModal extends React.Component {
-  static propTypes = {
-    /** Header Props
-     * label: goes on top of the dialog
-     * title: Heading of the dialog
-     * helpText, additional information will stay at the top of the screen when scrolling dialog content
-     */
-    header: PropTypes.shape({
-      label: PropTypes.string,
-      title: PropTypes.string,
-      helpText: PropTypes.node,
-    }),
-    /** Content to render inside Modal */
-    children: PropTypes.node,
-    /** Footer Props
-     * Either supply your own footer element or supply an object with button labels and submit handlers and we will make a footer with two buttons for you
-     */
-    footer: PropTypes.oneOfType([
-      PropTypes.element.isRequired,
-      PropTypes.shape({
-        primaryButtonLabel: PropTypes.node,
-        secondaryButtonLabel: PropTypes.node,
-      }),
-    ]),
-    /** NEW PROP: Type of dialog, affects colors, styles of dialog */
-    type: PropTypes.oneOf(['warn', 'normal']),
-    /** NEW PROP: Whether this particular dialog needs to be very large */
-    isLarge: PropTypes.bool,
-
-    /** REDUXDIALOG: Should the dialog be open or not */
-    open: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
-    /**  REDUXDIALOG: Close the dialog */
-    onClose: PropTypes.func.isRequired,
-
-    /**  REDUXDIALOG: Clear the currently shown dataError, triggered if the user closes the ErrorNotification */
-    onClearDialogErrors: PropTypes.func,
-
-    /** REDUXDIALOG: Is data currently being sent to the backend */
-    sendingData: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-    /** REDUXDIALOG: Is my data actively loading? */
-    isFetchingData: PropTypes.bool,
-    /** REDUXDIALOG: Details about the current dataError */
-    dataError: PropTypes.string,
-
-    /** REDUXFORM: Form Error Details */
-    error: PropTypes.string,
-    /** REDUXFORM: Did the form submission fail */
-    submitFailed: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
-    /** REDUXFORM: Is the form currently invalid */
-    invalid: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
-    /**  REDUXFORM: Clear the currently shown error (from form), triggered if the user closes the ErrorNotification */
-    clearSubmitErrors: PropTypes.func,
-    /** REDUXFORM: Callback to submit the dialog/form */
-    onSubmit: PropTypes.func,
-    /** ability to add translation string to close icon */
-    iconDescription: PropTypes.string,
-  };
+  static propTypes = BaseModalPropTypes;
 
   static defaultProps = {
     open: true,

--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -35,7 +35,7 @@ const StatefulTable = ({
   // Need to initially sort and filter the tables data
   useEffect(
     () => {
-      dispatch(tableRegister());
+      dispatch(tableRegister(initialData));
     },
     [initialData]
   );

--- a/src/components/Table/StatefulTable.test.jsx
+++ b/src/components/Table/StatefulTable.test.jsx
@@ -2,22 +2,43 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import StatefulTable from './StatefulTable';
+import EmptyTable from './EmptyTable/EmptyTable';
 import Table from './Table';
 import { mockActions } from './Table.test';
 import { initialState } from './Table.story';
 
+let mockDispatch;
 // Need to mock the useReducer hook so the real reducer doesn't run
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
-  useReducer: () => [{ view: { table: { filteredData: [] } } }, jest.fn()],
+  useReducer: () => [{ view: { table: { filteredData: [] } } }, mockDispatch],
 }));
 describe('StatefulTable tests', () => {
   afterAll(() => {
     jest.resetModules();
   });
+  beforeEach(() => {
+    mockDispatch = jest.fn();
+  });
   test('check renders nested table', () => {
     const statefulTable = mount(<StatefulTable {...initialState} actions={mockActions} />);
     expect(statefulTable.find(Table)).toHaveLength(1);
+  });
+  test('async data load', () => {
+    // Need the real reducer to fire
+    const statefulTable = mount(
+      <StatefulTable {...initialState} data={[]} actions={mockActions} />
+    );
+    // First table is empty
+    expect(statefulTable.find(EmptyTable)).toHaveLength(1);
+    // First we're called by empty array
+    expect(mockDispatch).toHaveBeenCalledWith({ payload: [], type: 'TABLE_REGISTER' });
+    statefulTable.setProps({ data: initialState.data });
+    // Then table dispatches another item with the real data
+    expect(mockDispatch).toHaveBeenCalledWith({
+      payload: initialState.data,
+      type: 'TABLE_REGISTER',
+    });
   });
   test('check callbacks are propagated up!', () => {
     const statefulTable = mount(<StatefulTable {...initialState} actions={mockActions} />);

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -15,7 +15,7 @@ export const TABLE_ROW_ACTION_APPLY = 'TABLE_ROW_ACTION_APPLY';
 export const TABLE_SEARCH_APPLY = 'TABLE_SEARCH_APPLY';
 export const TABLE_EMPTY_STATE_ACTION = 'TABLE_EMPTY_STATE_ACTION';
 
-export const tableRegister = () => ({ type: TABLE_REGISTER });
+export const tableRegister = data => ({ type: TABLE_REGISTER, payload: data });
 export const tablePageChange = page => ({ type: TABLE_PAGE_CHANGE, payload: page });
 export const tableToolbarToggle = toolbar => ({ type: TABLE_TOOLBAR_TOGGLE, payload: toolbar });
 /** Apply filters */

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -202,18 +202,28 @@ export const tableReducer = (state = {}, action) => {
     }
     case TABLE_ROW_EXPAND:
       return baseTableReducer(state, action);
-    // By default we need to setup our sorted and filteredData
+    // By default we need to setup our sorted and filteredData and turn off the loading state
     case TABLE_REGISTER: {
+      const updatedData = action.payload || state.data;
       return update(state, {
         view: {
+          data: {
+            $set: updatedData,
+          },
           table: {
             filteredData: {
               $set: filterSearchAndSort(
-                state.data,
+                updatedData,
                 get(state, 'view.table.sort'),
                 get(state, 'view.toolbar.search'),
                 get(state, 'view.filters')
               ),
+            },
+            loadingState: {
+              $set: {
+                isLoading: false,
+                rowCount: updatedData ? updatedData.length : 0,
+              },
             },
           },
         },

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -131,7 +131,8 @@ describe('table reducer testcases', () => {
       );
 
       const tableSortedNone = tableReducer(tableSortedDesc, sortColumnAction);
-      const filteredTable = tableReducer(initialState, tableRegister());
+      const filteredTable = tableReducer(initialState, tableRegister(initialState.data));
+
       expect(tableSortedNone.view.table.sort).toBeUndefined();
       // Data should no longer be sorted but should be filtered
       expect(filteredTable.view.table.filteredData).toEqual(
@@ -198,7 +199,8 @@ describe('table reducer testcases', () => {
     test('REGISTER_TABLE', () => {
       // Data should be filtered once table registers
       expect(initialState.view.table.filteredData).toBeUndefined();
-      const tableWithFilteredData = tableReducer(initialState, tableRegister());
+      const tableWithFilteredData = tableReducer(initialState, tableRegister(initialState.data));
+      expect(tableWithFilteredData.data).toEqual(initialState.data);
       expect(tableWithFilteredData.view.table.filteredData.length).toBeGreaterThan(0);
       expect(tableWithFilteredData.view.table.filteredData.length).not.toEqual(
         initialState.data.length
@@ -208,13 +210,23 @@ describe('table reducer testcases', () => {
       const initialStateWithSortAndNoFilters = merge({}, omit(initialState, 'view.filters'), {
         view: { table: { sort: { columnId: 'string', direction: 'ASC' } }, filters: [] },
       });
-      const tableWithSortedData = tableReducer(initialStateWithSortAndNoFilters, tableRegister());
+      const tableWithSortedData = tableReducer(
+        initialStateWithSortAndNoFilters,
+        tableRegister(initialState.data)
+      );
+      expect(tableWithSortedData.data).toEqual(initialState.data);
       expect(tableWithSortedData.view.table.filteredData.length).toEqual(
         initialStateWithSortAndNoFilters.data.length
       );
       // But they shouldn't be equal because the order changed
       expect(tableWithSortedData.view.table.filteredData).not.toEqual(
         initialStateWithSortAndNoFilters.data
+      );
+
+      // is Loading should be set false and rowCount should be correct
+      expect(tableWithSortedData.view.table.loadingState.isLoading).toEqual(false);
+      expect(tableWithSortedData.view.table.loadingState.rowCount).toEqual(
+        initialState.data.length
       );
     });
   });


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Taylor found a bug where if you change the data passed to the table after it renders the first time, it never updates to show the new data

**Change List (commits, features, bugs, etc)**

- Fixed the tableRegister action to take the current data as a payload and update accordingly
- Added a testcase to cover this scenario

**Acceptance Test (how to verify the PR)**

- Run through the automated testcases
