### PR TITLE
fix(tablerowaction): icon proptype accepts same as carbon Button

### DIFF
--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -4,7 +4,17 @@ export const RowActionPropTypes = PropTypes.arrayOf(
   PropTypes.shape({
     /** Unique id of the action */
     id: PropTypes.string.isRequired,
-    icon: PropTypes.string,
+    /* icon ultimately gets passed through all the way to <Button>, which has this same copied proptype definition for icon */
+    icon: PropTypes.oneOfType([
+      PropTypes.shape({
+        width: PropTypes.string,
+        height: PropTypes.string,
+        viewBox: PropTypes.string.isRequired,
+        svgData: PropTypes.object.isRequired,
+      }),
+      PropTypes.string,
+      PropTypes.node,
+    ]),
     disabled: PropTypes.bool,
     labelText: PropTypes.string,
     /** Action should go into the overflow menu, not be rendered inline in the row */


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

We need the ability to specify a custom icon not available in Carbon's library

- allows us to specify icons for row actions by string, object, or pass a node directly
- this is the same proptypes as defined by carbon's button, which ultimately receives these props

