### PR TITLE
fix(navigation): small fix to page styles

### DIFF
--- a/src/components/NavigationBar/NavigationBar.jsx
+++ b/src/components/NavigationBar/NavigationBar.jsx
@@ -55,6 +55,7 @@ const StyledTabChildren = styled.div`
   background: ${COLORS.superLightGray};
   padding-left: ${PADDING.horizontalWrapPadding};
   padding-right: ${PADDING.horizontalWrapPadding};
+  min-height: 100vh;
 `;
 
 const StyledActions = styled.div`

--- a/src/styles/styles.js
+++ b/src/styles/styles.js
@@ -1,5 +1,5 @@
 export const COLORS = {
-  superLightGray: '#f9fafb;',
+  superLightGray: '#f9fafb',
   darkGray: '#152935',
   darkGrayHover: '#2d3f48',
   gray: '#5a6872',


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- the navigation area wasn't extending the tab content all the way down to the bottom of the screen, leading to a color mismatch

**Acceptance Test (how to verify the PR)**

- Test the navigation bar fixtures and notice the tab content color should now extend down to the bottom of the screen and not map to the content
