### PR TITLE
docs(scrolling): add pagination to horizontal scrolling storybook

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -4,6 +4,7 @@ import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import { PaginationV2, DataTable } from 'carbon-components-react';
 import get from 'lodash/get';
+import styled from 'styled-components';
 
 import { defaultFunction } from '../../utils/componentUtilityFunctions';
 
@@ -22,6 +23,12 @@ import TableSkeletonWithHeaders from './TableSkeletonWithHeaders/TableSkeletonWi
 import TableBody from './TableBody/TableBody';
 
 const { Table: CarbonTable, TableContainer } = DataTable;
+
+const StyledTableContainer = styled(TableContainer)`
+  &&& {
+    width: calc(100% + 1.5rem); /* save enough space for full tablesize*/
+  }
+`;
 
 const propTypes = {
   /** DOM ID for component */
@@ -282,7 +289,7 @@ const Table = props => {
           ...pick(view.toolbar, 'batchActions', 'search', 'activeBar'),
         }}
       />
-      <TableContainer>
+      <StyledTableContainer>
         <CarbonTable {...others}>
           <TableHead
             {...others}
@@ -356,7 +363,7 @@ const Table = props => {
             />
           )}
         </CarbonTable>
-      </TableContainer>
+      </StyledTableContainer>
 
       {options.hasPagination && !view.table.loadingState.isLoading ? ( // don't show pagination row while loading
         <PaginationV2

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -4,7 +4,6 @@ import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import { PaginationV2, DataTable } from 'carbon-components-react';
 import get from 'lodash/get';
-import styled from 'styled-components';
 
 import { defaultFunction } from '../../utils/componentUtilityFunctions';
 
@@ -23,12 +22,6 @@ import TableSkeletonWithHeaders from './TableSkeletonWithHeaders/TableSkeletonWi
 import TableBody from './TableBody/TableBody';
 
 const { Table: CarbonTable, TableContainer } = DataTable;
-
-const StyledTableContainer = styled(TableContainer)`
-  &&& {
-    width: calc(100% + 1.5rem); /* save enough space for full tablesize*/
-  }
-`;
 
 const propTypes = {
   /** DOM ID for component */
@@ -289,7 +282,7 @@ const Table = props => {
           ...pick(view.toolbar, 'batchActions', 'search', 'activeBar'),
         }}
       />
-      <StyledTableContainer>
+      <TableContainer>
         <CarbonTable {...others}>
           <TableHead
             {...others}
@@ -363,7 +356,7 @@ const Table = props => {
             />
           )}
         </CarbonTable>
-      </StyledTableContainer>
+      </TableContainer>
 
       {options.hasPagination && !view.table.loadingState.isLoading ? ( // don't show pagination row while loading
         <PaginationV2

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -762,7 +762,7 @@ storiesOf('Table', module)
       <div style={{ width: '800px' }}>
         <Table
           columns={tableColumns.concat(tableColumnsConcat)}
-          options={{ hasFilter: true }}
+          options={{ hasFilter: true, hasPagination: true }}
           data={tableData}
           actions={actions}
           view={{
@@ -789,7 +789,7 @@ storiesOf('Table', module)
     return (
       <Table
         columns={tableColumns.concat(tableColumnsConcat)}
-        options={{ hasFilter: true }}
+        options={{ hasFilter: true, hasPagination: true }}
         data={tableData}
         actions={actions}
         view={{


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Just turning on pagination on the horizontal scrolling examples so we can show how that renders relative to the table container contents

