### PR TITLE
refactor(modal): update props to simplify it

### DIFF
--- a/src/components/BaseModal/BaseModal.jsx
+++ b/src/components/BaseModal/BaseModal.jsx
@@ -142,7 +142,7 @@ export const BaseModalPropTypes = {
   /** Form Error Details */
   error: PropTypes.string,
   /**  Clear the currently shown error, triggered if the user closes the ErrorNotification */
-  onClearErrors: PropTypes.func,
+  onClearError: PropTypes.func,
 
   /** Did the form submission fail */
   submitFailed: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
@@ -173,7 +173,7 @@ class BaseModal extends React.Component {
     error: null,
     isFetchingData: false,
     sendingData: null,
-    onClearErrors: null,
+    onClearError: null,
     type: null,
     footer: null,
     isLarge: false,
@@ -193,9 +193,9 @@ class BaseModal extends React.Component {
   }
 
   handleClearError = () => {
-    const { onClearErrors } = this.props;
-    if (onClearErrors) {
-      onClearErrors();
+    const { onClearError } = this.props;
+    if (onClearError) {
+      onClearError();
     }
   };
 
@@ -241,7 +241,12 @@ class BaseModal extends React.Component {
         </ModalHeader>
         {children ? <ModalBody>{children}</ModalBody> : null}
         {error ? (
-          <StyledMessageBox title={error} subtitle="" kind="error" onCloseButtonClick={onClose} />
+          <StyledMessageBox
+            title={error}
+            subtitle=""
+            kind="error"
+            onCloseButtonClick={this.handleClearError}
+          />
         ) : null}
         {footer || onSubmit ? (
           <StyledModalFooter>

--- a/src/components/BaseModal/BaseModal.jsx
+++ b/src/components/BaseModal/BaseModal.jsx
@@ -109,6 +109,9 @@ export const BaseModalPropTypes = {
     title: PropTypes.string,
     helpText: PropTypes.node,
   }),
+  /** ability to add translation string to close icon */
+  iconDescription: PropTypes.string,
+
   /** Content to render inside Modal */
   children: PropTypes.node,
   /** Footer Props
@@ -126,33 +129,27 @@ export const BaseModalPropTypes = {
   /** NEW PROP: Whether this particular dialog needs to be very large */
   isLarge: PropTypes.bool,
 
-  /** REDUXDIALOG: Should the dialog be open or not */
+  /** Should the dialog be open or not */
   open: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
-  /**  REDUXDIALOG: Close the dialog */
+  /**   Close the dialog */
   onClose: PropTypes.func.isRequired,
 
-  /**  REDUXDIALOG: Clear the currently shown dataError, triggered if the user closes the ErrorNotification */
-  onClearDialogErrors: PropTypes.func,
-
-  /** REDUXDIALOG: Is data currently being sent to the backend */
+  /**  Is data currently being sent to the backend */
   sendingData: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  /** REDUXDIALOG: Is my data actively loading? */
+  /**  Is my data actively loading? */
   isFetchingData: PropTypes.bool,
-  /** REDUXDIALOG: Details about the current dataError */
-  dataError: PropTypes.string,
 
-  /** REDUXFORM: Form Error Details */
+  /** Form Error Details */
   error: PropTypes.string,
-  /** REDUXFORM: Did the form submission fail */
+  /**  Clear the currently shown error, triggered if the user closes the ErrorNotification */
+  onClearErrors: PropTypes.func,
+
+  /** Did the form submission fail */
   submitFailed: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
-  /** REDUXFORM: Is the form currently invalid */
+  /** Is the form currently invalid */
   invalid: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
-  /**  REDUXFORM: Clear the currently shown error (from form), triggered if the user closes the ErrorNotification */
-  clearSubmitErrors: PropTypes.func,
-  /** REDUXFORM: Callback to submit the dialog/form */
+  /** Callback to submit the dialog/form */
   onSubmit: PropTypes.func,
-  /** ability to add translation string to close icon */
-  iconDescription: PropTypes.string,
 };
 
 /**
@@ -166,20 +163,17 @@ export const BaseModalPropTypes = {
  *  shows spinner on primary dialog button if sendingData prop is true
  *
  * We also prevent the dialog from closing if you click outside it.
- * This dialog can be decorated by reduxDialog HoC and/or reduxForm HoC to automatically populate the fields below marked as
- * REDUXFORM or REDUXDIALOG
+ *
  */
 class BaseModal extends React.Component {
   static propTypes = BaseModalPropTypes;
 
   static defaultProps = {
     open: true,
-    dataError: null,
     error: null,
     isFetchingData: false,
     sendingData: null,
-    clearSubmitErrors: null,
-    onClearDialogErrors: null,
+    onClearErrors: null,
     type: null,
     footer: null,
     isLarge: false,
@@ -199,12 +193,9 @@ class BaseModal extends React.Component {
   }
 
   handleClearError = () => {
-    const { clearSubmitErrors, onClearDialogErrors } = this.props;
-    if (clearSubmitErrors) {
-      clearSubmitErrors();
-    } // Clear the form errors
-    if (onClearDialogErrors) {
-      onClearDialogErrors();
+    const { onClearErrors } = this.props;
+    if (onClearErrors) {
+      onClearErrors();
     }
   };
 
@@ -215,7 +206,6 @@ class BaseModal extends React.Component {
     const {
       header,
       error,
-      dataError,
       sendingData,
       children,
       footer,
@@ -230,7 +220,6 @@ class BaseModal extends React.Component {
     } = this.props;
     const { label, title, helpText } = header;
     // First check for dataErrors as they are worse than form errors
-    const errorMessage = dataError || error;
 
     return isFetchingData ? (
       <Loading />
@@ -251,13 +240,8 @@ class BaseModal extends React.Component {
           {helpText ? <p className="bx--modal-content__text">{helpText}</p> : null}
         </ModalHeader>
         {children ? <ModalBody>{children}</ModalBody> : null}
-        {error || dataError ? (
-          <StyledMessageBox
-            title={errorMessage}
-            subtitle=""
-            kind="error"
-            onCloseButtonClick={onClose}
-          />
+        {error ? (
+          <StyledMessageBox title={error} subtitle="" kind="error" onCloseButtonClick={onClose} />
         ) : null}
         {footer || onSubmit ? (
           <StyledModalFooter>

--- a/src/components/BaseModal/BaseModal.story.jsx
+++ b/src/components/BaseModal/BaseModal.story.jsx
@@ -46,7 +46,7 @@ REDUXFORM or REDUXDIALOG`,
   .add('fetching data', () => <BaseModal isFetchingData onClose={action('close')} />)
   .add('error states', () => (
     <BaseModal
-      dataError="Error sending data to server"
+      error="Error sending data to server"
       header={{
         label: 'DataError',
         title: 'Cannot communicate with server',

--- a/src/components/BaseModal/BaseModal.story.jsx
+++ b/src/components/BaseModal/BaseModal.story.jsx
@@ -53,6 +53,7 @@ REDUXFORM or REDUXDIALOG`,
       }}
       onSubmit={action('submit')}
       onClose={action('close')}
+      onClearError={action('onClearError')}
     />
   ))
   .add('sending data', () => (

--- a/src/components/BaseModal/BaseModal.test.jsx
+++ b/src/components/BaseModal/BaseModal.test.jsx
@@ -18,9 +18,9 @@ describe('BaseModal', () => {
     expect(utilityFunctions.scrollErrorIntoView).toHaveBeenCalledTimes(1);
   });
   test('errors should be cleared', () => {
-    const onClearErrors = jest.fn();
-    const wrapper = mount(<BaseModal {...modalProps} onClearErrors={onClearErrors} />);
+    const onClearError = jest.fn();
+    const wrapper = mount(<BaseModal {...modalProps} onClearError={onClearError} />);
     wrapper.instance().handleClearError();
-    expect(onClearErrors).toHaveBeenCalledTimes(1);
+    expect(onClearError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/BaseModal/BaseModal.test.jsx
+++ b/src/components/BaseModal/BaseModal.test.jsx
@@ -18,17 +18,9 @@ describe('BaseModal', () => {
     expect(utilityFunctions.scrollErrorIntoView).toHaveBeenCalledTimes(1);
   });
   test('errors should be cleared', () => {
-    const mockClearSubmitErrors = jest.fn();
-    const mockOnClearDialogErrors = jest.fn();
-    const wrapper = mount(
-      <BaseModal
-        {...modalProps}
-        clearSubmitErrors={mockClearSubmitErrors}
-        onClearDialogErrors={mockOnClearDialogErrors}
-      />
-    );
+    const onClearErrors = jest.fn();
+    const wrapper = mount(<BaseModal {...modalProps} onClearErrors={onClearErrors} />);
     wrapper.instance().handleClearError();
-    expect(mockClearSubmitErrors).toHaveBeenCalledTimes(1);
-    expect(mockOnClearDialogErrors).toHaveBeenCalledTimes(1);
+    expect(onClearErrors).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -41,10 +41,13 @@ const filterData = (data, filters) =>
       );
 // Little utility to search
 const searchData = (data, searchString) =>
+  data.length > 0 &&
   data.filter((
     { values } // globally check row values for a match
   ) =>
-    Object.values(values).find(value => value.toString && value.toString().includes(searchString))
+    Object.values(values).find(
+      value => !isNil(value) && value.toString && value.toString().includes(searchString)
+    )
   );
 
 // little utility to both sort and filter


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- feat(basemodal): simplify error props for basemodal and fix tablereducer bug.
- feat(basemodal): Instead of taking two sets of error props only take one for base modal
- fix(tablereducer): check for null values before searching

**Acceptance Test (how to verify the PR)**

- Verify the searching of table still works and the error props still work in the basemodal
