### PR TITLE
fix(table): after initial search table is empty and clear search from empty state not working

### DIFF
--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -1,7 +1,9 @@
 import { mount } from 'enzyme';
 import React from 'react';
+import merge from 'lodash/merge';
 
 import Table from './Table';
+import EmptyTable from './EmptyTable/EmptyTable';
 
 const selectData = [
   {
@@ -93,6 +95,7 @@ export const mockActions = {
     onClearAllFilters: jest.fn(),
     onCancelBatchAction: jest.fn(),
     onApplyBatchAction: jest.fn(),
+    onApplySearch: jest.fn(),
   },
   table: {
     onRowSelected: jest.fn(),
@@ -173,5 +176,42 @@ describe('Table', () => {
     );
     wrapper.find('button#column-string').simulate('click');
     expect(mockActions.table.onChangeSort).toHaveBeenCalled();
+  });
+
+  test('custom emptystate only renders with no filters', () => {
+    const wrapper = mount(
+      <Table
+        columns={tableColumns}
+        data={[]}
+        actions={mockActions}
+        options={options}
+        view={merge({}, view, {
+          table: { emptyState: <div id="customEmptyState">emptyState</div> },
+        })}
+      />
+    );
+    // Should render the custom empty state
+    expect(wrapper.find('#customEmptyState')).toHaveLength(1);
+
+    const wrapper2 = mount(
+      <Table
+        columns={tableColumns}
+        data={[]}
+        actions={mockActions}
+        options={options}
+        view={merge({}, view, {
+          filters: [{ columnId: 'col', value: 'value' }],
+          table: { emptyState: <div id="customEmptyState">emptyState</div> },
+        })}
+      />
+    );
+    // Should not render the empty state
+    expect(wrapper2.find('#customEmptyState')).toHaveLength(0);
+
+    // Click the button and make sure the right action fires
+    const emptyTable = wrapper2.find(EmptyTable);
+    emptyTable.find('button').simulate('click');
+    expect(mockActions.toolbar.onApplySearch).toHaveBeenCalled();
+    expect(mockActions.toolbar.onClearAllFilters).toHaveBeenCalled();
   });
 });

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -42,7 +42,6 @@ export const filterData = (data, filters) =>
 // Little utility to search
 
 export const searchData = (data, searchString) =>
-  data.length > 0 &&
   data.filter((
     { values } // globally check row values for a match
   ) =>
@@ -210,10 +209,10 @@ export const tableReducer = (state = {}, action) => {
     case TABLE_REGISTER: {
       const updatedData = action.payload.data || state.data;
       return update(state, {
+        data: {
+          $set: updatedData,
+        },
         view: {
-          data: {
-            $set: updatedData,
-          },
           table: {
             filteredData: {
               $set: filterSearchAndSort(

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -23,7 +23,7 @@ import {
 import { baseTableReducer } from './baseTableReducer';
 
 // Little utility to filter data
-const filterData = (data, filters) =>
+export const filterData = (data, filters) =>
   !filters || filters.length === 0
     ? data
     : data.filter(({ values }) =>
@@ -40,15 +40,17 @@ const filterData = (data, filters) =>
         )
       );
 // Little utility to search
-const searchData = (data, searchString) =>
+export const searchData = (data, searchString) =>
   data.filter((
     { values } // globally check row values for a match
   ) =>
-    Object.values(values).find(value => value.toString && value.toString().includes(searchString))
+    Object.values(values).find(
+      value => !isNil(value) && value.toString && value.toString().includes(searchString)
+    )
   );
 
 // little utility to both sort and filter
-const filterSearchAndSort = (data, sort = {}, search = {}, filters) => {
+export const filterSearchAndSort = (data, sort = {}, search = {}, filters = []) => {
   const { columnId, direction } = sort;
   const { value: searchValue } = search;
   const filteredData = filterData(data, filters);

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -1,7 +1,7 @@
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
 
-import { tableReducer } from './tableReducer';
+import { tableReducer, filterData, searchData, filterSearchAndSort } from './tableReducer';
 import {
   tableRegister,
   tablePageChange,
@@ -234,5 +234,34 @@ describe('table reducer testcases', () => {
         initialState.data.length
       );
     });
+  });
+});
+
+describe('filter, search and sort', () => {
+  test('filterData', () => {
+    const mockData = [{ values: { number: 10, string: 'string', null: null } }];
+    const stringFilter = { columnId: 'string', value: 'string' };
+    const numberFilter = { columnId: 'number', value: 10 };
+    expect(filterData(mockData, [stringFilter])).toHaveLength(1);
+    expect(filterData(mockData, [numberFilter])).toHaveLength(1);
+  });
+
+  test('searchData', () => {
+    const mockData = [{ values: { number: 10, string: 'string', null: null } }];
+    expect(searchData(mockData, 10)).toHaveLength(1);
+    expect(searchData(mockData, 'string')).toHaveLength(1);
+  });
+
+  test('filterSearchAndSort', () => {
+    const mockData = [{ values: { number: 10, string: 'string', null: null } }];
+    expect(filterSearchAndSort(mockData)).toHaveLength(1);
+    expect(filterSearchAndSort(mockData, {}, { value: 10 })).toHaveLength(1);
+    expect(filterSearchAndSort(mockData, {}, { value: 20 })).toHaveLength(0);
+    expect(
+      filterSearchAndSort(mockData, {}, {}, [{ columnId: 'string', value: 'string' }])
+    ).toHaveLength(1);
+    expect(
+      filterSearchAndSort(mockData, {}, {}, [{ columnId: 'string', value: 'none' }])
+    ).toHaveLength(0);
   });
 });

--- a/src/utils/__tests__/componentUtilityFunctions.test.js
+++ b/src/utils/__tests__/componentUtilityFunctions.test.js
@@ -1,0 +1,20 @@
+import { getSortedData } from '../componentUtilityFunctions';
+
+const mockData = [
+  { values: { number: 10, string: 'string', null: null } },
+  { values: { number: 100, string: 'string2', null: null } },
+  { values: { number: 20, string: 'string3', null: null } },
+];
+
+describe('componentUtilityFunctions', () => {
+  test('getSortedData', () => {
+    expect(getSortedData(mockData, 'string', 'DESC')[0].values.string).toEqual('string3');
+    expect(getSortedData(mockData, 'string', 'ASC')[0].values.string).toEqual('string');
+    expect(getSortedData(mockData, 'number', 'DESC')[0].values.number).toEqual(100);
+    expect(getSortedData(mockData, 'number', 'DESC')[1].values.number).toEqual(20);
+    expect(getSortedData(mockData, 'number', 'DESC')[2].values.number).toEqual(10);
+    expect(getSortedData(mockData, 'number', 'ASC')[0].values.number).toEqual(10);
+    expect(getSortedData(mockData, 'number', 'ASC')[1].values.number).toEqual(20);
+    expect(getSortedData(mockData, 'number', 'ASC')[2].values.number).toEqual(100);
+  });
+});

--- a/src/utils/componentUtilityFunctions.js
+++ b/src/utils/componentUtilityFunctions.js
@@ -22,6 +22,7 @@ export const handleEnterKeyDown = (evt, callback) => {
 export const defaultFunction = name => () => console.info(`${name} not implemented`); //eslint-disable-line
 
 export const getSortedData = (inputData, columnId, direction) => {
+  // clone inputData because sort mutates the array
   const sortedData = inputData.map(i => i);
   return sortedData.sort((a, b) => {
     const val = direction === 'ASC' ? -1 : 1;


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- test(reducer): add testcases that confirm that sort works on numeric correctly
- fix(table): after initial search table is empty
- fix(table): should clear both search and filter from empty state

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#51

**Acceptance Test (how to verify the PR)**

- you can just run the testcases
