### PR TITLE
feat(wizardinline): add optional validation that can be executed for each step

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-dnd-html5-backend": "2.5.1",
     "react-dnd-test-backend": "^7.2.0",
     "react-transition-group": "^2.6.0",
-    "storybook-addon-rtl": "^0.2.2",
     "styled-components": "^4.1.3"
   },
   "peerDependencies": {
@@ -140,6 +139,7 @@
     "rollup-plugin-uglify": "^6.0.1",
     "sass-loader": "^7.1.0",
     "semantic-release": "^15.13.2",
+    "storybook-addon-rtl": "^0.2.2",
     "style-loader": "^0.23.1",
     "webpack": "^4.28.4",
     "whatwg-fetch": "^3.0.0"

--- a/src/components/WizardInline/StatefulWizard.test.jsx
+++ b/src/components/WizardInline/StatefulWizard.test.jsx
@@ -21,6 +21,69 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(1).simulate('click');
     expect(mockNext).toHaveBeenCalled();
   });
+  test('setItem', () => {
+    const mockSetItem = jest.fn();
+    const wrapper = mount(<StatefulWizardInline {...commonWizardProps} setItem={mockSetItem} />);
+    const progressIndicatorButtons = wrapper.find('.bx--progress-step-button');
+    expect(progressIndicatorButtons).toHaveLength(4);
+    progressIndicatorButtons.at(1).simulate('click');
+    expect(mockSetItem).toHaveBeenCalled();
+  });
+  test('error', () => {
+    const wrapper = mount(<StatefulWizardInline {...commonWizardProps} error="I'm in error" />);
+    const progressIndicatorButtons = wrapper.find('InlineNotification');
+    expect(progressIndicatorButtons).toHaveLength(1);
+  });
+  test('error clear error', () => {
+    const mockClearError = jest.fn();
+    const wrapper = mount(
+      <StatefulWizardInline
+        {...commonWizardProps}
+        error="I'm in error"
+        onClearError={mockClearError}
+      />
+    );
+    const clearErrorButton = wrapper.find('.bx--inline-notification__close-button');
+    expect(clearErrorButton).toHaveLength(1);
+    clearErrorButton.simulate('click');
+    expect(mockClearError).toHaveBeenCalled();
+  });
+  test('setItem not triggered if invalid', () => {
+    const mockSetItem = jest.fn();
+    const wrapper = mount(
+      <StatefulWizardInline
+        {...commonWizardProps}
+        currentItemId="item1"
+        items={[
+          { id: 'item1', name: 'Item1', component: <div>Item 1</div>, onValidate: () => false },
+          { id: 'item2', name: 'Item2', component: <div>Item 2</div>, onValidate: () => false },
+        ]}
+        setItem={mockSetItem}
+      />
+    );
+    const progressIndicatorButtons = wrapper.find('.bx--progress-step-button');
+    expect(progressIndicatorButtons).toHaveLength(2);
+    progressIndicatorButtons.at(1).simulate('click');
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+  test('onNext not triggered if invalid', () => {
+    const mockNext = jest.fn();
+    const wrapper = mount(
+      <StatefulWizardInline
+        {...commonWizardProps}
+        currentItemId="item1"
+        items={[
+          { id: 'item1', name: 'Item1', component: <div>Item 1</div>, onValidate: () => false },
+          { id: 'item2', name: 'Item2', component: <div>Item 2</div>, onValidate: () => false },
+        ]}
+        onNext={mockNext}
+      />
+    );
+    const cancelAndNextButtons = wrapper.find('.bx--btn');
+    expect(cancelAndNextButtons).toHaveLength(2);
+    cancelAndNextButtons.at(1).simulate('click');
+    expect(mockNext).not.toHaveBeenCalled();
+  });
   test('onClose', () => {
     const mockClose = jest.fn();
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} onClose={mockClose} />);

--- a/src/components/WizardInline/StatefulWizardInline.jsx
+++ b/src/components/WizardInline/StatefulWizardInline.jsx
@@ -10,7 +10,7 @@ const StatefulWizardInline = ({
   setItem,
   ...other
 }) => {
-  const [currentItemId, setCurrentItemId] = useState(currentItemIdProp || items[0].id);
+  const [currentItemId, setCurrentItemId] = useState(currentItemIdProp || (items && items[0].id));
   const currentItemIndex = items.findIndex(item => item.id === currentItemId);
   const nextItem = currentItemIndex < items.length - 1 ? items[currentItemIndex + 1] : undefined;
   const prevItem = currentItemIndex > 0 ? items[currentItemIndex - 1] : undefined;

--- a/src/components/WizardInline/WizardHeader/WizardHeader.jsx
+++ b/src/components/WizardInline/WizardHeader/WizardHeader.jsx
@@ -12,6 +12,7 @@ const StyledDivWizardHeader = styled.div`
 
 const StyledDivHeading = styled.div`
   min-width: 200px;
+  padding-right: 3rem;
 `;
 
 class WizardHeader extends Component {
@@ -24,8 +25,6 @@ class WizardHeader extends Component {
       PropTypes.shape({
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,
-        backLabel: PropTypes.string,
-        nextLabel: PropTypes.string,
         component: PropTypes.element.isRequired,
       })
     ).isRequired,
@@ -39,10 +38,7 @@ class WizardHeader extends Component {
     stepWidth: 136,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
+  state = {};
 
   render = () => {
     const {

--- a/src/components/WizardInline/WizardInline.jsx
+++ b/src/components/WizardInline/WizardInline.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { InlineNotification } from 'carbon-components-react';
 
 import WizardHeader from './WizardHeader/WizardHeader';
 import WizardFooter from './WizardFooter/WizardFooter';
@@ -24,6 +25,12 @@ const StyledWizardWrapper = styled.div`
 
 const StyledWizardContainer = styled.div`
   display: flex;
+`;
+
+const StyledMessageBox = styled(InlineNotification)`
+   {
+    width: 100%;
+  }
 `;
 
 const StyledFooter = styled.div`
@@ -53,6 +60,8 @@ export const propTypes = {
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       component: PropTypes.node.isRequired,
+      /** if you return false the onNext or setItem functions will not be called to change the current step */
+      onValidate: PropTypes.func,
     })
   ).isRequired,
   /** action when click next button called with no param */
@@ -85,6 +94,11 @@ export const propTypes = {
   stepWidth: PropTypes.number,
   /** is the wizard actively sending data should disable the button */
   sendingData: PropTypes.bool,
+
+  /** Form Error Details */
+  error: PropTypes.string,
+  /**  Clear the currently shown error, triggered if the user closes the ErrorNotification */
+  onClearError: PropTypes.func,
 };
 
 export const defaultProps = {
@@ -103,6 +117,8 @@ export const defaultProps = {
   cancelLabel: 'Cancel',
   submitLabel: 'Add',
   sendingData: false,
+  error: null,
+  onClearError: null,
 };
 
 const WizardInline = ({
@@ -125,11 +141,28 @@ const WizardInline = ({
   sendingData,
   stepWidth,
   className,
+  error,
+  onClearError,
 }) => {
-  const currentItemObj = items.find(({ id }) => currentItemId === id);
+  const currentItemObj = items.find(({ id }) => currentItemId === id) || items[0];
   const currentItemIndex = items.findIndex(({ id }) => currentItemId === id);
   const hasNext = currentItemIndex !== items.length - 1;
   const hasPrev = currentItemIndex !== 0;
+
+  const handleClearError = () => {
+    if (onClearError) {
+      onClearError();
+    }
+  };
+
+  const isValid = callback => {
+    if (currentItemObj && currentItemObj.onValidate) {
+      if (currentItemObj.onValidate(currentItemId)) {
+        callback();
+      } else return;
+    }
+    callback();
+  };
 
   return (
     <StyledWizardWrapper className={className}>
@@ -137,7 +170,8 @@ const WizardInline = ({
         <WizardHeader
           title={title}
           currentItemId={currentItemId}
-          setItem={setItem}
+          // only go if current step passes validation
+          setItem={id => isValid(() => setItem(id))}
           items={items}
           showLabels={showLabels}
           onClose={onClose}
@@ -150,6 +184,14 @@ const WizardInline = ({
             <WizardContent component={currentItemObj.component} />
           </div>
         </StyledWizardContainer>
+        {error ? (
+          <StyledMessageBox
+            title={error}
+            subtitle=""
+            kind="error"
+            onCloseButtonClick={handleClearError}
+          />
+        ) : null}
         <StyledFooter className={className}>
           <div className="bx--modal-footer">
             <WizardFooter
@@ -159,7 +201,8 @@ const WizardInline = ({
               hasPrev={hasPrev}
               cancelLabel={cancelLabel}
               submitLabel={submitLabel}
-              onNext={onNext}
+              // Validate before next
+              onNext={event => isValid(() => onNext(event))}
               onBack={onBack}
               onSubmit={onSubmit}
               onCancel={onClose}

--- a/src/components/WizardInline/WizardInline.jsx
+++ b/src/components/WizardInline/WizardInline.jsx
@@ -73,9 +73,9 @@ export const propTypes = {
   submitLabel: PropTypes.node,
   /** component to show in sidebar */
   sidebar: PropTypes.element,
-  /** component to show in footer. Passed to Sidebar */
+  /** component to show in footer on the left of the buttons */
   footerLeftContent: PropTypes.element,
-  /** function to go to item when click ProgressIndicator items. Passed to Footer */
+  /** function to go to item when click ProgressIndicator items. */
   setItem: PropTypes.func,
   /** show labels in Progress Indicator */
   showLabels: PropTypes.bool,

--- a/src/components/WizardInline/WizardInline.story.jsx
+++ b/src/components/WizardInline/WizardInline.story.jsx
@@ -187,6 +187,21 @@ storiesOf('WizardInline', module)
       sidebar={sidebarComponent}
     />
   ))
+  .add('with error', () => (
+    <WizardInline
+      items={itemsAndComponents}
+      onBack={action('back')}
+      onClose={action('Closed')}
+      onNext={action('next')}
+      onSubmit={action('submit')}
+      title={text('title', 'Static Wizard')}
+      currentItemId="step1"
+      setItem={action('step clicked')}
+      showLabels={boolean('showLabels', true)}
+      error="Error on the form"
+      onClearError={action('clear error')}
+    />
+  ))
   .add('Static with Footer', () => (
     <WizardInline
       items={itemsAndComponents}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export AddCard from './components/AddCard';
 export BaseModal from './components/BaseModal';
 export WizardModal from './components/WizardModal';
 export WizardInline from './components/WizardInline/WizardInline';
+export StatefulWizardInline from './components/WizardInline/StatefulWizardInline';
 export TableHead from './components/Table/TableHead/TableHead';
 export TableBody from './components/Table/TableBody/TableBody';
 export TableToolbar from './components/Table/TableToolbar/TableToolbar';


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- It's up to the consuming component to either set the new WizardInline error prop to indicate the form error to the user, or perhaps to indicate the error next to the failed form element itself.

**Acceptance Test (how to verify the PR)**

- Check the testcases which validate the step doesn't change if validate fails
- View the new example error story for WizardInline
