### PR TITLE
refactor(tilecatalog): use reducer for state management

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-dnd-html5-backend": "2.5.1",
     "react-dnd-test-backend": "^7.2.0",
     "react-transition-group": "^2.6.0",
-    "styled-components": "^4.1.3"
+    "styled-components": "^4.1.3",
+    "use-deep-compare-effect": "^1.2.0"
   },
   "peerDependencies": {
     "@carbon/icons-react": "^0.0.1-alpha.12",

--- a/src/components/TileCatalog/StatefulTileCatalog.test.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.test.jsx
@@ -84,7 +84,6 @@ describe('StatefulTileCatalog', () => {
     const newTiles = commonTileProps.tiles.slice(1, 5);
     // Back to Page 1
     wrapper.setProps({ tiles: newTiles });
-    wrapper.update();
     expect(
       wrapper
         .find('span')

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -1,0 +1,89 @@
+import { searchData } from '../Table/tableReducer';
+
+export const TILE_ACTIONS = {
+  PAGE_CHANGE: 'PAGE_CHANGE',
+  SEARCH: 'SEARCH',
+  SELECT: 'SELECT',
+  RESET: 'RESET',
+};
+
+export const determineInitialState = ({ pagination, search, selectedTileId, tiles }) => {
+  const page = pagination && pagination.page ? pagination.page : 1;
+  const pageSize = pagination && pagination.pageSize ? pagination.pageSize : 10;
+  return {
+    page,
+    pageSize,
+    searchState: search && search.value ? search.value : '',
+    selectedTileId: selectedTileId || (tiles && tiles[0] ? tiles[0].id : null),
+    tiles,
+    // filtered tiles have any search applied
+    filteredTiles: search ? searchData(tiles, search.value) : tiles,
+    startingIndex: pagination ? (page - 1) * pageSize : 0,
+    endingIndex: (pagination ? (page - 1) * pageSize + pageSize : pageSize) - 1,
+  };
+};
+
+/** here's what the state looks like
+ * 
+ *  { 
+ *  page: PropTypes.number,
+    pageSize: PropTypes.number,
+    searchState: PropTypes.string,
+    selectedTileId: PropTypes.string,
+    // original tile data
+    tiles: PropTypes.array,
+    // filtered tiles have any search applied
+    filteredTiles: PropTypes.array,
+    startingIndex: PropTypes.number,
+    endingIndex: PropTypes.number,
+  }
+ * 
+ */
+export const tileCatalogReducer = (state = {}, action) => {
+  switch (action.type) {
+    case TILE_ACTIONS.PAGE_CHANGE: {
+      const { pageSize, filteredTiles } = state;
+      const page = action.payload;
+      const startingIndex = (page - 1) * pageSize;
+      const endingIndex =
+        Math.min(
+          (page - 1) * pageSize + pageSize,
+          filteredTiles && filteredTiles.length ? filteredTiles.length : Infinity
+        ) - 1;
+
+      return {
+        ...state,
+        startingIndex,
+        endingIndex,
+        // set the selected tile id if the page changes
+        selectedTileId: filteredTiles[startingIndex] ? filteredTiles[startingIndex].id : null,
+        page,
+      };
+    }
+    case TILE_ACTIONS.SEARCH: {
+      const searchState = action.payload;
+      const { pageSize } = state;
+      const filteredTiles = searchData(state.tiles, searchState);
+      return {
+        ...state,
+        searchState,
+        filteredTiles,
+        // reset the page and indexes
+        page: 1,
+        startingIndex: 0,
+        endingIndex: (pageSize || filteredTiles.length) - 1,
+        // Set the selected tile id if the search changes the data
+        selectedTileId: filteredTiles && filteredTiles[0] ? filteredTiles[0].id : null,
+      };
+    }
+    case TILE_ACTIONS.SELECT:
+      return {
+        ...state,
+        selectedTileId: action.payload,
+      };
+    case TILE_ACTIONS.RESET:
+      return determineInitialState(action.payload);
+    default:
+      return state;
+  }
+};

--- a/src/components/TileCatalog/tileCatalogReducer.test.js
+++ b/src/components/TileCatalog/tileCatalogReducer.test.js
@@ -1,0 +1,110 @@
+import { tileCatalogReducer, TILE_ACTIONS } from './tileCatalogReducer';
+
+const longDescription = 'testDescription';
+const tileRenderFunction = jest.fn();
+
+const tiles = [
+  {
+    id: 'test1',
+    values: {
+      title: 'Test Tile with really long title that should wrap',
+      description: longDescription,
+    },
+    renderContent: tileRenderFunction,
+  },
+  {
+    id: 'test2',
+    values: { title: 'Test Tile2', description: longDescription },
+    renderContent: tileRenderFunction,
+  },
+  {
+    id: 'test3',
+    values: { title: 'Test Tile3', description: 'Tile contents' },
+    renderContent: tileRenderFunction,
+  },
+  {
+    id: 'test4',
+    values: { title: 'Test Tile4', description: longDescription },
+    renderContent: tileRenderFunction,
+  },
+  {
+    id: 'test5',
+    values: { title: 'Test Tile5', description: longDescription },
+    renderContent: tileRenderFunction,
+  },
+  {
+    id: 'test6',
+    values: { title: 'Test Tile6', description: longDescription },
+    renderContent: tileRenderFunction,
+  },
+  {
+    id: 'test7',
+    values: { title: 'Test Tile7', description: longDescription },
+    renderContent: tileRenderFunction,
+  },
+];
+
+describe('tileCatalogReducer', () => {
+  test('pageChange', () => {
+    const pageChangeAction = { type: TILE_ACTIONS.PAGE_CHANGE, payload: 2 };
+    const existingState = {
+      page: 1,
+      pageSize: 5,
+      searchState: '',
+      selectedTileId: tiles[0].id,
+      // original tile data
+      tiles,
+      // filtered tiles have any search applied
+      filteredTiles: tiles,
+      startingIndex: 0,
+      endingIndex: 5,
+    };
+
+    const newState = tileCatalogReducer(existingState, pageChangeAction);
+    expect(newState.page).toEqual(2);
+    expect(newState.selectedTileId).toEqual(tiles[5].id);
+    expect(newState.startingIndex).toEqual(5);
+    expect(newState.endingIndex).toEqual(6);
+  });
+  test('search', () => {
+    const searchAction = { type: TILE_ACTIONS.SEARCH, payload: 'Tile6' };
+    const existingState = {
+      page: 2,
+      pageSize: 5,
+      searchState: '',
+      selectedTileId: tiles[5].id,
+      // original tile data
+      tiles,
+      // filtered tiles have any search applied
+      filteredTiles: tiles,
+      startingIndex: 5,
+      endingIndex: 6,
+    };
+
+    // After search, page selectedTileId and starting and ending index should be udpated
+    const newState = tileCatalogReducer(existingState, searchAction);
+    expect(newState.searchState).toEqual('Tile6');
+    expect(newState.page).toEqual(1);
+    expect(newState.selectedTileId).toEqual('test6');
+    expect(newState.startingIndex).toEqual(0);
+    expect(newState.endingIndex).toEqual(4);
+  });
+  test('select', () => {
+    const selectAction = { type: TILE_ACTIONS.SELECT, payload: 'tile2' };
+    const existingState = {
+      page: 1,
+      pageSize: 5,
+      searchState: '',
+      selectedTileId: tiles[0].id,
+      // original tile data
+      tiles,
+      // filtered tiles have any search applied
+      filteredTiles: tiles,
+      startingIndex: 0,
+      endingIndex: 5,
+    };
+
+    const newState = tileCatalogReducer(existingState, selectAction);
+    expect(newState.selectedTileId).toEqual('tile2');
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export ResourceList from './components/ResourceList/ResourceList';
 // reusable reducers
 export { baseTableReducer } from './components/Table/baseTableReducer';
 export { tableReducer } from './components/Table/tableReducer';
+export { tileCatalogReducer } from './components/TileCatalog/tileCatalogReducer';
 export * as tableActions from './components/Table/tableActionCreators';
 // Page related helpers
 export PageHero from './components/Page/PageHero';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4663,6 +4663,11 @@ depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
+dequal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-1.0.0.tgz#41c6065e70de738541c82cdbedea5292277a017e"
+  integrity sha512-/Nd1EQbQbI9UbSHrMiKZjFLrXSnU328iQdZKPQf78XQI6C+gutkFUeoHpG5J08Ioa6HeRbRNFpSIclh1xyG0mw==
+
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -12591,6 +12596,14 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-deep-compare-effect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.2.0.tgz#41a52b3dea028c082b57e35050427b482237eb47"
+  integrity sha512-u45BDmcLgXErTR4y18bUW8j7SzrS85JMPSYKAbzPJwTs3W7+Am1L3xwDhwNEbek41qfp7yfh4B2br5hJk4Q+lA==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    dequal "^1.0.0"
 
 use@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- refactor(tilecatalog): use reducer instead of useEffect and useState for the state management.  This fixes bugs where the tilecatalog wasn't working correctly when you were on the second page

**Acceptance Test (how to verify the PR)**

- regression test the TileCatalog stories in the storybook
