### PR TITLE
fix(tilecatalog): auto select on page and search wasn't calling back to parent listener

### DIFF
--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
+import omit from 'lodash/omit';
 
 import { tileCatalogReducer, determineInitialState, TILE_ACTIONS } from './tileCatalogReducer';
 import TileCatalog, { propTypes } from './TileCatalog';
@@ -23,7 +24,7 @@ const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp
         payload: { ...props, tiles: tilesProp, search, pagination },
       });
     },
-    [tilesProp]
+    [tilesProp.map(tile => omit(tile, 'renderContent'))]
   );
 
   const {
@@ -37,7 +38,7 @@ const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp
   } = state;
 
   const handlePage = (...args) => {
-    dispatch({ type: TILE_ACTIONS.PAGE_CHANGE, payload: args });
+    dispatch({ type: TILE_ACTIONS.PAGE_CHANGE, payload: args && args[0] });
     if (onPage) {
       onPage(...args);
     }

--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -44,12 +44,33 @@ const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp
     }
   };
 
-  const handleSelection = (newSelectedTile, ...args) => {
+  const handleSelection = newSelectedTile => {
     dispatch({ type: TILE_ACTIONS.SELECT, payload: newSelectedTile });
     if (onSelection) {
-      onSelection(newSelectedTile, ...args);
+      onSelection(newSelectedTile);
     }
   };
+
+  /* I couldn't really get the reselect logic to work correctly
+  useDeepCompareEffect(
+    () => {
+      dispatch({
+        type: TILE_ACTIONS.SELECT,
+        payload:
+          selectedTileId ||
+          (filteredTiles && filteredTiles[startingIndex] ? filteredTiles[startingIndex].id : null),
+      });
+    },
+    [filteredTiles.map(tile => omit(tile, 'renderContent')), searchState, startingIndex, page]
+  );
+
+  useEffect(
+    () => {
+      onSelection(selectedTileId);
+    },
+    [selectedTileId] // eslint-disable-line
+  );
+  */
 
   const handleSearch = (event, ...args) => {
     const newSearch = event.target.value || '';

--- a/src/components/TileCatalog/StatefulTileCatalog.test.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.test.jsx
@@ -41,7 +41,7 @@ describe('StatefulTileCatalog', () => {
     const tileInput = wrapper.find('input[type="radio"]').at(0);
     tileInput.simulate('change');
     expect(mockOnSelection).toHaveBeenCalledTimes(1);
-    expect(mockOnSelection).toHaveBeenCalledWith('test1', id, expect.any(Object));
+    expect(mockOnSelection).toHaveBeenCalledWith('test1');
   });
   test('handles onPage', () => {
     const wrapper = mount(
@@ -56,6 +56,7 @@ describe('StatefulTileCatalog', () => {
   });
   test('selectedTileId', () => {
     const wrapper = mount(<StatefulTileCatalog {...commonTileProps} selectedTileId="test2" />);
+    wrapper.update();
     const selectedTile = wrapper.find('input[checked=true]');
     expect(selectedTile).toHaveLength(1);
     expect(selectedTile.prop('id')).toEqual('test2');
@@ -84,6 +85,7 @@ describe('StatefulTileCatalog', () => {
     const newTiles = commonTileProps.tiles.slice(1, 5);
     // Back to Page 1
     wrapper.setProps({ tiles: newTiles });
+    wrapper.update();
     expect(
       wrapper
         .find('span')

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -69,7 +69,7 @@ export const tileCatalogReducer = (state = {}, action) => {
         startingIndex,
         endingIndex,
         // set the selected tile id if the page changes
-        selectedTileId: filteredTiles[startingIndex] ? filteredTiles[startingIndex].id : null,
+        // selectedTileId: null,
         page,
       };
     }
@@ -86,7 +86,7 @@ export const tileCatalogReducer = (state = {}, action) => {
         startingIndex: 0,
         endingIndex: (pageSize || filteredTiles.length) - 1,
         // Set the selected tile id if the search changes the data
-        selectedTileId: filteredTiles && filteredTiles[0] ? filteredTiles[0].id : null,
+        // selectedTileId: null,
       };
     }
     case TILE_ACTIONS.SELECT:

--- a/src/components/TileCatalog/tileCatalogReducer.test.js
+++ b/src/components/TileCatalog/tileCatalogReducer.test.js
@@ -62,7 +62,7 @@ describe('tileCatalogReducer', () => {
 
     const newState = tileCatalogReducer(existingState, pageChangeAction);
     expect(newState.page).toEqual(2);
-    expect(newState.selectedTileId).toEqual(tiles[5].id);
+    // expect(newState.selectedTileId).toEqual(null);
     expect(newState.startingIndex).toEqual(5);
     expect(newState.endingIndex).toEqual(6);
   });
@@ -85,7 +85,7 @@ describe('tileCatalogReducer', () => {
     const newState = tileCatalogReducer(existingState, searchAction);
     expect(newState.searchState).toEqual('Tile6');
     expect(newState.page).toEqual(1);
-    expect(newState.selectedTileId).toEqual('test6');
+    // expect(newState.selectedTileId).toEqual(null);
     expect(newState.startingIndex).toEqual(0);
     expect(newState.endingIndex).toEqual(4);
   });


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Unfortunately the auto select behavior that I started with wasn't working because I couldn't get it to call back to the parent listener correctly.  For now we need to force the user to actually select the tile

**Acceptance Test (how to verify the PR)**

- Verify the updates to the Search and Pages story, you have to manually select the tile
