### PR TITLE
fix(tilegroup): small fix for styles to work with carbon

### DIFF
--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useEffect } from 'react';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import omit from 'lodash/omit';
 
@@ -46,9 +46,6 @@ const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp
 
   const handleSelection = newSelectedTile => {
     dispatch({ type: TILE_ACTIONS.SELECT, payload: newSelectedTile });
-    if (onSelection) {
-      onSelection(newSelectedTile);
-    }
   };
 
   /* I couldn't really get the reselect logic to work correctly
@@ -63,14 +60,15 @@ const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp
     },
     [filteredTiles.map(tile => omit(tile, 'renderContent')), searchState, startingIndex, page]
   );
-
+*/
   useEffect(
     () => {
-      onSelection(selectedTileId);
+      if (onSelection) {
+        onSelection(selectedTileId);
+      }
     },
     [selectedTileId] // eslint-disable-line
   );
-  */
 
   const handleSearch = (event, ...args) => {
     const newSearch = event.target.value || '';

--- a/src/components/TileCatalog/TileGroup.jsx
+++ b/src/components/TileCatalog/TileGroup.jsx
@@ -6,13 +6,15 @@ import styled from 'styled-components';
 import { MEDIA_QUERIES } from '../../styles/styles';
 
 const StyledTiles = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  > * {
-    flex: 1 1 33.33%;
-    min-width: 300px;
+  &&& {
+    display: flex;
+    flex-flow: row wrap;
+    > * {
+      flex: 1 1 33.33%;
+      min-width: 300px;
+    }
+    overflow-y: hidden;
   }
-  overflow-y: hidden;
 `;
 
 const StyledGreedyTile = styled(Tile)`

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -69,7 +69,7 @@ export const tileCatalogReducer = (state = {}, action) => {
         startingIndex,
         endingIndex,
         // set the selected tile id if the page changes
-        // selectedTileId: null,
+        selectedTileId: null,
         page,
       };
     }
@@ -86,7 +86,7 @@ export const tileCatalogReducer = (state = {}, action) => {
         startingIndex: 0,
         endingIndex: (pageSize || filteredTiles.length) - 1,
         // Set the selected tile id if the search changes the data
-        // selectedTileId: null,
+        selectedTileId: null,
       };
     }
     case TILE_ACTIONS.SELECT:

--- a/src/components/WizardInline/WizardInline.jsx
+++ b/src/components/WizardInline/WizardInline.jsx
@@ -18,6 +18,7 @@ const StyledWizardWrapper = styled.div`
     margin-bottom: 48px;
     max-height: 80vh;
     overflow: auto;
+    width: 100%;
   }
 
   .bx--modal-container {


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Needed to override the default carbon styles with our styled component styles so needed the extra layer of specificity
- fix(tilecatalog): need to generate selection event for initial selection
- fix(wizardinline): should take up full available width for content

**Acceptance Test (how to verify the PR)**

- It's pretty hard to test without consuming this in another project unfortunately.
