### PR TITLE
fix(wizardinline): feedback that it should stay a fixed size regardless of content

### DIFF
--- a/src/components/WizardInline/WizardInline.jsx
+++ b/src/components/WizardInline/WizardInline.jsx
@@ -24,6 +24,7 @@ const StyledWizardWrapper = styled.div`
   .bx--modal-container {
     min-width: 630px;
     max-width: 90%;
+    width: 90%;
     margin-top: 24px;
     padding-top: 32px;
     padding-bottom: 72px;


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Luke says the wizard should always stay the same size on screen regardless of content
