### PR TITLE
fix(pagehero): feedback styles too much space between the title and the content

### DIFF
--- a/src/components/Page/PageHero.jsx
+++ b/src/components/Page/PageHero.jsx
@@ -77,7 +77,7 @@ const StyledPageHero = styled.div`
 `;
 
 const StyledPageHeroWrap = styled.div`
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   margin: 0 auto;
   width: 100%;

--- a/src/components/Page/PageTitle.jsx
+++ b/src/components/Page/PageTitle.jsx
@@ -17,6 +17,7 @@ const StyledPageSection = styled.span`
 const StyledPageTitleH1 = styled.h1`
   align-items: center;
   display: flex;
+  padding-top: 1rem;
   margin-bottom: 24px;
   font-weight: 400;
   line-height: 1.25rem;


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Feedback on styles of the page hero, adjust the top padding of the title and top align all the pagehero content

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#157

**Acceptance Test (how to verify the PR)**

- Check that the Page Hero stories look good
