### PR TITLE
fix(tilecatalog): should page to the selected tile id

### DIFF
--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -9,8 +9,21 @@ import TileCatalog, { propTypes } from './TileCatalog';
  * Paging and searching happens on local state within the component
  */
 
-const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp, ...props }) => {
-  const initialState = determineInitialState({ ...props, tiles: tilesProp, search, pagination });
+const StatefulTileCatalog = ({
+  onSelection,
+  pagination,
+  search,
+  selectedTileId: selectedTileIdProp,
+  tiles: tilesProp,
+  ...props
+}) => {
+  const initialState = determineInitialState({
+    ...props,
+    selectedTileId: selectedTileIdProp,
+    tiles: tilesProp,
+    search,
+    pagination,
+  });
   const onPage = pagination && pagination.onPage;
   const onSearch = search && search.onSearch;
 
@@ -21,10 +34,16 @@ const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp
       // If we get passed a new set of tiles reset!
       dispatch({
         type: TILE_ACTIONS.RESET,
-        payload: { ...props, tiles: tilesProp, search, pagination },
+        payload: {
+          ...props,
+          selectedTileId: selectedTileIdProp,
+          tiles: tilesProp,
+          search,
+          pagination,
+        },
       });
     },
-    [tilesProp.map(tile => omit(tile, 'renderContent'))]
+    [tilesProp.map(tile => omit(tile, 'renderContent')), selectedTileIdProp]
   );
 
   const {

--- a/src/components/TileCatalog/StatefulTileCatalog.test.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.test.jsx
@@ -61,6 +61,24 @@ describe('StatefulTileCatalog', () => {
     expect(selectedTile).toHaveLength(1);
     expect(selectedTile.prop('id')).toEqual('test2');
   });
+  test('selectedTileId should change page', () => {
+    const wrapper = mount(
+      <StatefulTileCatalog
+        {...commonTileProps}
+        pagination={{ pageSize: 6, page: 1 }}
+        selectedTileId="test7"
+      />
+    );
+
+    // On page 2 because of the selectedTileId
+    expect(
+      wrapper
+        .find('span')
+        .at(1)
+        .text()
+    ).toContain('Page 2');
+  });
+
   test('tiles prop change resets page', () => {
     const wrapper = mount(
       <StatefulTileCatalog {...commonTileProps} pagination={{ pageSize: 5 }} />

--- a/src/components/TileCatalog/TileCatalog.story.jsx
+++ b/src/components/TileCatalog/TileCatalog.story.jsx
@@ -86,6 +86,11 @@ storiesOf('TileCatalog', module)
     <StatefulTileCatalog
       {...commonTileCatalogProps}
       pagination={{ pageSize: 6, onPage: action('onPage') }}
+      selectedTileId={select(
+        'id',
+        commonTileCatalogProps.tiles.map(tile => tile.id),
+        commonTileCatalogProps.tiles[0].id
+      )}
     />
   ))
   .add('loading', () => <StatefulTileCatalog {...commonTileCatalogProps} isLoading />)

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -25,18 +25,28 @@ export const determineInitialState = ({ pagination, search, selectedTileId, tile
   const pageSize = pagination && pagination.pageSize ? pagination.pageSize : 10;
   const filteredTiles = search ? searchData(tiles, search.value) : tiles;
   const startingIndex = pagination ? (page - 1) * pageSize : 0;
+  const selectedTileIdState =
+    selectedTileId ||
+    (filteredTiles && filteredTiles[startingIndex] ? filteredTiles[startingIndex].id : null);
+  let selectedPage;
+  let selectedStartingIndex;
+  // If a selected tile id is passed, we should page to it
+  if (selectedTileId) {
+    const selectedTileIndex = filteredTiles.findIndex(tile => tile.id === selectedTileId);
+    selectedPage = Math.floor(selectedTileIndex / pageSize) + 1;
+    selectedStartingIndex = pagination ? (selectedPage - 1) * pageSize : 0;
+  }
+
   return {
-    page,
+    page: selectedPage || page,
     pageSize,
     searchState: search && search.value ? search.value : '',
-    selectedTileId:
-      selectedTileId ||
-      (filteredTiles && filteredTiles[startingIndex] ? filteredTiles[startingIndex].id : null),
+    selectedTileId: selectedTileIdState,
     tiles,
     // filtered tiles have any search applied
     filteredTiles,
-    startingIndex,
-    endingIndex: determineEndingIndex(page, pageSize, filteredTiles),
+    startingIndex: selectedStartingIndex || startingIndex,
+    endingIndex: determineEndingIndex(selectedPage || page, pageSize, filteredTiles),
   };
 };
 


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- There was a bug in statefultilecatalog where changing the selectedTileId wouldn't update the page number

**Acceptance Test (how to verify the PR)**

- To test, view the TileCatalog with pages story and change the selectedTileId and once you try and select a selectedTileId that is past the first page, it should automatically page to the second page for you
