### PR TITLE
fix(tabletoolbar): batch actions are missing icon description

### DIFF
--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -149,7 +149,7 @@ const TableToolbar = ({
         shouldShowBatchActions={totalSelected > 0}
         totalSelected={totalSelected}>
         {batchActions.map(i => (
-          <TableBatchAction key={i.id} onClick={() => onApplyBatchAction(i.id)} icon={i.icon}>
+          <TableBatchAction key={i.id} onClick={() => onApplyBatchAction(i.id)} {...i}>
             {i.labelText}
           </TableBatchAction>
         ))}


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- fix(table): batch actions are not sending the icon description through 

**Change List (commits, features, bugs, etc)**

- pass through all batch action props to the BatchAction

**Acceptance Test (how to verify the PR)**

- Verify if we mouseover the batch action icons in the Table Toolbar with batch actions story that the correct alt tag shows on hover
