### PR TITLE
feat(pagehero): add optional left content for blockchain

### DIFF
--- a/src/components/Header/Header.story.jsx
+++ b/src/components/Header/Header.story.jsx
@@ -149,6 +149,24 @@ const HeaderProps = {
   ],
 };
 
-storiesOf('Header', module).add('Header action buttons with dropdowns', () => (
-  <StyledHeader {...HeaderProps} />
-));
+storiesOf('Header', module)
+  .add('Header action buttons with dropdowns', () => <StyledHeader {...HeaderProps} />)
+  .add('Header no submenu', () => (
+    <StyledHeader
+      {...HeaderProps}
+      actionItems={[
+        {
+          label: 'user',
+          onClick: action('click'),
+          btnContent: (
+            <React.Fragment>
+              <User>
+                JohnDoe@ibm.com<span>TenantId: Acme</span>
+              </User>
+              <StyledIcon name="header--avatar" fill="white" description="Icon" />
+            </React.Fragment>
+          ),
+        },
+      ]}
+    />
+  ));

--- a/src/components/Page/PageHero.jsx
+++ b/src/components/Page/PageHero.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import styled from 'styled-components';
 
 import { COLORS, PADDING } from '../../styles/styles';
@@ -46,6 +46,8 @@ const propTypes = {
       }).isRequired
     ),
   }),
+  /** Optional what to render in the left side of the hero */
+  leftContent: PropTypes.node,
   /** Optional What to render in the right side of the hero */
   rightContent: PropTypes.node,
   className: PropTypes.string,
@@ -58,6 +60,7 @@ const defaultProps = {
   className: null,
   big: false,
   crumb: null,
+  leftContent: null,
   rightContent: null,
   switchers: {
     onChange: null,
@@ -73,6 +76,9 @@ const StyledPageHero = styled.div`
   padding-left: ${PADDING.horizontalWrapPadding};
   padding-right: ${PADDING.horizontalWrapPadding};
   padding-bottom: ${PADDING.verticalPadding};
+  display: flex;
+  flex: 1 1;
+  flex-flow: row nowrap;
   min-height: ${props => (props.big ? '193px' : 'unset')};
 `;
 
@@ -94,20 +100,45 @@ const StyledPageBlurb = styled.p`
   flex: 1 1 20%;
 `;
 
+const StyledTitle = styled.div`
+  flex-basis: 75%;
+`;
+
+const StyledRightContent = styled.div`
+  padding-top: ${PADDING.verticalPadding};
+  flex-basis: 25%;
+`;
+
+const StyledLeftContent = styled.div`
+  padding-top: ${PADDING.verticalPadding};
+`;
+
 /**
  * Renders the hero text and styles for the page.  Can either render Section and Title with blurb or support a narrow one with breadcrumbs.
  */
-const PageHero = ({ section, title, blurb, className, crumb, rightContent, switchers }) => (
+const PageHero = ({
+  section,
+  title,
+  blurb,
+  className,
+  crumb,
+  leftContent,
+  rightContent,
+  switchers,
+}) => (
   <StyledPageHero className={className}>
     {crumb || (
-      <div>
-        <PageTitle section={section} title={title} />
-        {switchers && switchers.switcher.length ? <PageSwitcher switchers={switchers} /> : null}
-        <StyledPageHeroWrap>
-          {blurb ? <StyledPageBlurb>{blurb}</StyledPageBlurb> : null}
-          {rightContent}
-        </StyledPageHeroWrap>
-      </div>
+      <Fragment>
+        {leftContent ? <StyledLeftContent>{leftContent}</StyledLeftContent> : null}
+        <StyledTitle>
+          <PageTitle section={section} title={title} />
+          {switchers && switchers.switcher.length ? <PageSwitcher switchers={switchers} /> : null}
+          <StyledPageHeroWrap>
+            {blurb ? <StyledPageBlurb>{blurb}</StyledPageBlurb> : null}
+          </StyledPageHeroWrap>
+        </StyledTitle>
+        {rightContent ? <StyledRightContent>{rightContent}</StyledRightContent> : null}
+      </Fragment>
     )}
   </StyledPageHero>
 );

--- a/src/components/Page/PageHero.story.jsx
+++ b/src/components/Page/PageHero.story.jsx
@@ -9,7 +9,7 @@ const commonPageHeroProps = {
   blurb:
     'Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.',
   big: true,
-  rightContent: <div>Right Content</div>,
+  rightContent: <div style={{ textAlign: 'right' }}>Right Content</div>,
 };
 
 storiesOf('PageHero', module)
@@ -40,4 +40,7 @@ storiesOf('PageHero', module)
   .add('with section', () => <PageHero {...commonPageHeroProps} section="Explore" />)
   .add('has breadcrumb', () => (
     <PageHero {...commonPageHeroProps} crumb={<div>breadcrumb/mybread</div>} />
+  ))
+  .add('has left content', () => (
+    <PageHero {...commonPageHeroProps} leftContent={<div>Left Content</div>} />
   ));


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Added a feature for the blockchain team to position an image to the left of the PageHero

**Change List (commits, features, bugs, etc)**
- feat(pagehero): add new leftContent prop
- fix(pagehero): fix positioning of the rightContent prop

**Acceptance Test (how to verify the PR)**

- Verify the latest pagehero stories 
