### PR TITLE
fix(table): checkboxes don't align in all stories between header and data

### DIFF
--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -86,7 +86,6 @@ const defaultProps = {
 
 const StyledCheckboxTableCell = styled(TableCell)`
   && {
-    padding-left: 1rem;
     padding-bottom: 0.5rem;
     width: 2.5rem;
   }

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -80,7 +80,6 @@ const defaultProps = {
 
 const StyledCheckboxTableHeader = styled(TableHeader)`
   &&& {
-    padding-left: 1rem;
     padding-bottom: 0.5rem;
     width: 2.5rem;
   }


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- fixes alignment for checkboxes by just deferring the padding to the carbon styles

**Change List (commits, features, bugs, etc)**

- remove our extra padding overrides and defer to the carbon styles 

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#195

**Acceptance Test (how to verify the PR)**

- Verify that all of the stories with checkboxes align appropriately, see the bug for the previous issues with alignment.
