### PR TITLE
fix(tilecatalog): asynchronous loaded data flashes the blank tile before showing

### DIFF
--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -78,12 +78,18 @@ const StatefulTileCatalog = ({ onSelection, pagination, search, tiles: tilesProp
     }
   };
 
+  const isFiltered = searchState !== '' || startingIndex !== endingIndex + 1;
+
   return (
     <TileCatalog
       {...props}
       selectedTileId={selectedTileId}
       // slice doesn't include the last index!
-      tiles={filteredTiles.slice(startingIndex, endingIndex + 1)}
+      tiles={
+        isFiltered // if the tiles aren't filtered just show the raw prop so that there's no repaint
+          ? filteredTiles.slice(startingIndex, endingIndex + 1)
+          : tilesProp.slice(startingIndex, endingIndex + 1)
+      }
       search={{ ...search, onSearch: handleSearch, value: searchState }}
       pagination={{ ...pagination, page, onPage: handlePage, totalItems: tiles ? tiles.length : 0 }}
       onSelection={handleSelection}

--- a/src/components/TileCatalog/TileCatalog.story.jsx
+++ b/src/components/TileCatalog/TileCatalog.story.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { select } from '@storybook/addon-knobs';
@@ -91,4 +91,20 @@ storiesOf('TileCatalog', module)
   .add('loading', () => <StatefulTileCatalog {...commonTileCatalogProps} isLoading />)
   .add('error', () => (
     <StatefulTileCatalog {...commonTileCatalogProps} tiles={[]} error="In error state" />
-  ));
+  ))
+  .add('async loaded wait one second', () => {
+    const Container = () => {
+      const [tilesProp, setTiles] = useState([]);
+      const [isLoading, setIsLoading] = useState(true);
+      useEffect(() => {
+        setTimeout(() => {
+          setTiles(commonTileCatalogProps.tiles); // eslint-disable-line
+          setIsLoading(false);
+        }, 1000);
+      }, []);
+      return (
+        <StatefulTileCatalog {...commonTileCatalogProps} isLoading={isLoading} tiles={tilesProp} />
+      );
+    };
+    return <Container />;
+  });

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -1,5 +1,3 @@
-import isNil from 'lodash/isNil';
-
 import { searchData } from '../Table/tableReducer';
 
 export const TILE_ACTIONS = {
@@ -10,13 +8,8 @@ export const TILE_ACTIONS = {
 };
 
 /** figures out the ending index of the array */
-const determineEndingIndex = (page, pageSize, tiles) => {
-  return (
-    Math.min(
-      (page - 1) * pageSize + pageSize,
-      tiles && !isNil(tiles.length) ? tiles.length : Infinity // I'd like to pass undefined here, but Math.min isn't smart enough so I have to use Infinity
-    ) - 1
-  );
+const determineEndingIndex = (page, pageSize) => {
+  return (page - 1) * pageSize + pageSize - 1;
 };
 
 /** This figures out the initial state of the reducer from the props */
@@ -36,7 +29,7 @@ export const determineInitialState = ({ pagination, search, selectedTileId, tile
     // filtered tiles have any search applied
     filteredTiles,
     startingIndex,
-    endingIndex: determineEndingIndex(page, pageSize, filteredTiles),
+    endingIndex: determineEndingIndex(page, pageSize),
   };
 };
 
@@ -59,10 +52,10 @@ export const determineInitialState = ({ pagination, search, selectedTileId, tile
 export const tileCatalogReducer = (state = {}, action) => {
   switch (action.type) {
     case TILE_ACTIONS.PAGE_CHANGE: {
-      const { pageSize, filteredTiles } = state;
+      const { pageSize } = state;
       const page = action.payload;
       const startingIndex = (page - 1) * pageSize;
-      const endingIndex = determineEndingIndex(page, pageSize, filteredTiles);
+      const endingIndex = determineEndingIndex(page, pageSize);
 
       return {
         ...state,

--- a/src/components/TileCatalog/tileCatalogReducer.test.js
+++ b/src/components/TileCatalog/tileCatalogReducer.test.js
@@ -64,7 +64,7 @@ describe('tileCatalogReducer', () => {
     expect(newState.page).toEqual(2);
     // expect(newState.selectedTileId).toEqual(null);
     expect(newState.startingIndex).toEqual(5);
-    expect(newState.endingIndex).toEqual(6);
+    expect(newState.endingIndex).toEqual(9);
   });
   test('search', () => {
     const searchAction = { type: TILE_ACTIONS.SEARCH, payload: 'Tile6' };
@@ -114,7 +114,7 @@ describe('determineInitialState', () => {
     expect(initialState.pageSize).toEqual(10);
     expect(initialState.page).toEqual(1);
     expect(initialState.startingIndex).toEqual(0);
-    expect(initialState.endingIndex).toEqual(tiles.length - 1);
+    expect(initialState.endingIndex).toEqual(9);
     expect(initialState.selectedTileId).toEqual(tiles[0].id);
   });
   test('setting from pagination', () => {
@@ -122,13 +122,13 @@ describe('determineInitialState', () => {
     expect(initialState.pageSize).toEqual(5);
     expect(initialState.page).toEqual(2);
     expect(initialState.startingIndex).toEqual(5);
-    expect(initialState.endingIndex).toEqual(tiles.length - 1);
+    expect(initialState.endingIndex).toEqual(9);
     expect(initialState.selectedTileId).toEqual(tiles[5].id);
   });
   test('setting search', () => {
     const initialState = determineInitialState({ tiles, search: { value: 'Tile6' } });
     expect(initialState.filteredTiles).toHaveLength(1);
-    expect(initialState.endingIndex).toEqual(0);
+    expect(initialState.endingIndex).toEqual(9);
     expect(initialState.selectedTileId).toEqual(tiles[5].id);
   });
 });


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Subtle bug where the TileCatalog was flashing the blank No Data tile before rendering the real contents when the data is loaded asynchronously.

**Acceptance Test (how to verify the PR)**

- View the new async loaded story and make sure the No Data bee doesn't flash for a second before rendering the real data
