### PR TITLE
fix(table): search should be case insensitive

### DIFF
--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -34,7 +34,10 @@ export const filterData = (data, filters) =>
             acc &&
             ((values[columnId] &&
               values[columnId].toString &&
-              values[columnId].toString().includes(value)) ||
+              values[columnId]
+                .toString()
+                .toLowerCase()
+                .includes(value.toString().toLowerCase())) ||
               isNil(values[columnId])), // If passed an invalid column keep going)
           true
         )
@@ -47,7 +50,13 @@ export const searchData = (data, searchString) =>
         { values } // globally check row values for a match
       ) =>
         Object.values(values).find(
-          value => !isNil(value) && value.toString && value.toString().includes(searchString)
+          value =>
+            !isNil(value) &&
+            value.toString &&
+            value
+              .toString() // case insensitive search
+              .toLowerCase()
+              .includes(searchString.toString().toLowerCase())
         )
       )
     : data;

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -240,8 +240,10 @@ describe('table reducer testcases', () => {
 describe('filter, search and sort', () => {
   test('filterData', () => {
     const mockData = [{ values: { number: 10, string: 'string', null: null } }];
-    const stringFilter = { columnId: 'string', value: 'string' };
+    const stringFilter = { columnId: 'string', value: 'String' };
     const numberFilter = { columnId: 'number', value: 10 };
+    expect(filterData(mockData, [stringFilter])).toHaveLength(1);
+    // case insensitive
     expect(filterData(mockData, [stringFilter])).toHaveLength(1);
     expect(filterData(mockData, [numberFilter])).toHaveLength(1);
   });
@@ -250,6 +252,8 @@ describe('filter, search and sort', () => {
     const mockData = [{ values: { number: 10, string: 'string', null: null } }];
     expect(searchData(mockData, 10)).toHaveLength(1);
     expect(searchData(mockData, 'string')).toHaveLength(1);
+    // case insensitive
+    expect(searchData(mockData, 'STRING')).toHaveLength(1);
   });
 
   test('filterSearchAndSort', () => {


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Fix search and filter to be case insensitive

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes an internal bug

**Acceptance Test (how to verify the PR)**

- Test that the filter and search in both table and tilecatalog stories are case insensitive
