### PR TITLE
fix(tilecatalog): fix flash between loading data asynchronously

### DIFF
--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -164,9 +164,9 @@ const TableToolbar = ({
         onCancel={onCancelBatchAction}
         shouldShowBatchActions={totalSelected > 0}
         totalSelected={totalSelected}>
-        {batchActions.map(i => (
-          <TableBatchAction key={i.id} onClick={() => onApplyBatchAction(i.id)} {...i}>
-            {i.labelText}
+        {batchActions.map(({ id, labelText, ...others }) => (
+          <TableBatchAction key={id} onClick={() => onApplyBatchAction(id)} {...others}>
+            {labelText}
           </TableBatchAction>
         ))}
       </TableBatchActions>

--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -97,7 +97,7 @@ const StatefulTileCatalog = ({
     }
   };
 
-  const isFiltered = searchState !== '' || startingIndex !== endingIndex + 1;
+  const isFiltered = searchState !== '';
 
   return (
     <TileCatalog


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Refix of my previous issue to fix the flash between loading data in the tile catalog.  Also cleaning up a console error in the batch actions

**Change List (commits, features, bugs, etc)**

- fix(table): batch actions were throwing a React warning due to passing an extra parameter to the button

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#197


