### PR TITLE
fix(table): expanded rows have lost their background color

### DIFF
--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -179,7 +179,7 @@ const StyledTableExpandRowExpanded = styled(TableExpandRow)`
       }
     }
     `
-        : !props['data-row-nesting']
+        : props['data-row-nesting']
         ? `
     :hover {
       td {

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -159,7 +159,7 @@ const StyledTableExpandRowExpanded = styled(TableExpandRow)`
   &&& {
     cursor: pointer;
     ${props =>
-      props['data-child-count'] === 0 && props['data-row-nesting']
+      (props['data-child-count'] === 0 && props['data-row-nesting']) || !props['data-row-nesting']
         ? `
     td {
       background-color: ${COLORS.blue};
@@ -179,7 +179,7 @@ const StyledTableExpandRowExpanded = styled(TableExpandRow)`
       }
     }
     `
-        : props['data-row-nesting']
+        : !props['data-row-nesting']
         ? `
     :hover {
       td {


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Due to a change for the nested table rows, the normal expanded rows have lost their background color, looks like this: 

![image](https://user-images.githubusercontent.com/6663002/56813936-55e76580-683e-11e9-819a-57ecc701443e.png)

But should have a blue background

**Change List (commits, features, bugs, etc)**

- small fix to correctly render the background for normal expanded rows

**Acceptance Test (how to verify the PR)**

- Verify the expanded
