### PR TITLE
fix(wizard): hide the cancel button

### DIFF
--- a/src/components/WizardInline/StatefulWizard.test.jsx
+++ b/src/components/WizardInline/StatefulWizard.test.jsx
@@ -101,9 +101,9 @@ describe('StatefulWizardInline', () => {
         onBack={mockBack}
       />
     );
-    const cancelBackAndNextButtons = wrapper.find('.bx--btn');
-    expect(cancelBackAndNextButtons).toHaveLength(3);
-    cancelBackAndNextButtons.at(1).simulate('click');
+    const backAndNextButtons = wrapper.find('.bx--btn');
+    expect(backAndNextButtons).toHaveLength(2);
+    backAndNextButtons.at(0).simulate('click');
     expect(mockBack).toHaveBeenCalled();
   });
 });

--- a/src/components/WizardInline/WizardFooter/WizardFooter.jsx
+++ b/src/components/WizardInline/WizardFooter/WizardFooter.jsx
@@ -54,9 +54,11 @@ const WizardFooter = ({
   <Fragment>
     <div>{footerLeftContent}</div>
     <StyledFooterButtons>
-      <Button onClick={onCancel} kind="secondary">
-        {cancelLabel}
-      </Button>
+      {!hasPrev ? (
+        <Button onClick={onCancel} kind="secondary">
+          {cancelLabel}
+        </Button>
+      ) : null}
       {hasPrev ? (
         <Button onClick={onBack} kind="secondary">
           {backLabel}

--- a/src/components/WizardInline/WizardFooter/WizardFooter.test.jsx
+++ b/src/components/WizardInline/WizardFooter/WizardFooter.test.jsx
@@ -24,16 +24,16 @@ describe('WizardFooter', () => {
     const cancelAndNextButtons = mount(<WizardFooter {...commonFooterProps} hasPrev={false} />);
     // should only have Cancel and Next button
     expect(cancelAndNextButtons.find('.bx--btn')).toHaveLength(2);
-    const cancelBackAndNextButtons = mount(<WizardFooter {...commonFooterProps} />);
-    // should have Cancel Back and Next button
-    expect(cancelBackAndNextButtons.find('.bx--btn')).toHaveLength(3);
-    const cancelBackAndAddButtons = mount(<WizardFooter {...commonFooterProps} hasNext={false} />);
-    // should have Cancel Back and Add button
-    expect(cancelBackAndAddButtons.find('.bx--btn')).toHaveLength(3);
+    const backAndNextButtons = mount(<WizardFooter {...commonFooterProps} />);
+    // should have Back and Next button
+    expect(backAndNextButtons.find('.bx--btn')).toHaveLength(2);
+    const backAndAddButtons = mount(<WizardFooter {...commonFooterProps} hasNext={false} />);
+    // should have Back and Add button
+    expect(backAndAddButtons.find('.bx--btn')).toHaveLength(2);
     expect(
-      cancelBackAndAddButtons
+      backAndAddButtons
         .find('.bx--btn')
-        .at(2)
+        .at(1)
         .text()
     ).toContain('Add');
   });

--- a/src/components/WizardModal/WizardModal.test.jsx
+++ b/src/components/WizardModal/WizardModal.test.jsx
@@ -83,8 +83,8 @@ describe('WizardModal', () => {
     // Close
     expect(wrapper.find('.bx--modal-close')).toHaveLength(1);
 
-    // Previous/Cancel
-    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(2);
+    // Previous
+    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(1);
 
     // Submit button
     expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);
@@ -119,8 +119,8 @@ describe('WizardModal', () => {
     // Close
     expect(wrapper.find('.bx--modal-close')).toHaveLength(1);
 
-    // Previous/Cancel
-    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(2);
+    // Previous
+    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(1);
 
     // Submit button
     expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);
@@ -128,8 +128,8 @@ describe('WizardModal', () => {
     // Close
     expect(wrapper.find('.bx--modal-close')).toHaveLength(1);
 
-    // Previous/Cancel
-    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(2);
+    // Previous
+    expect(wrapper.find('.bx--btn--secondary')).toHaveLength(1);
 
     // Submit button
     expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Hide the cancel button unless we're on the first page of the wizards

**Change List (commits, features, bugs, etc)**

- Hide the cancel button if we're not on the first page

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#169

**Acceptance Test (how to verify the PR)**

- Verify that the Wizard only shows the Cancel button if we're on the first page
