### PR TITLE
fix(table): column filter value overlaps the clear and dropdown button when in RTL

### DIFF
--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -27,6 +27,11 @@ const StyledTableHeader = styled(TableHeader)`
         min-width: 12.75rem;
       }
     }
+
+    .bx--list-box input[role='combobox'] {
+      /* need to save enough room for clear and dropdown button */
+      padding-right: 4rem;
+    }
     ${props => {
       const { width } = props;
       return width !== undefined
@@ -51,9 +56,6 @@ const StyledFormItem = styled(FormItem)`
 
     .bx--list-box__selection {
       right: 0;
-    }
-    .bx--list-box input[role='combobox'] {
-      padding-right: 3.5rem;
     }
   }
 `;

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -52,6 +52,9 @@ const StyledFormItem = styled(FormItem)`
     .bx--list-box__selection {
       right: 0;
     }
+    .bx--list-box input[role='combobox'] {
+      padding-right: 3.5rem;
+    }
   }
 `;
 


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- The column filter value contents overlap the filter controls when the table is in RTL mode

**Change List (commits, features, bugs, etc)**

- small change to reserve enough padding on the right to display the Clear and dropdown button

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#167

**Acceptance Test (how to verify the PR)**

- Verify that when you switch to RTL that the Table with filters story doesn't overlap the text
