### PR TITLE
fix(tilecatalog): search and paging is not working

### DIFF
--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -110,7 +110,12 @@ const StatefulTileCatalog = ({
           : tilesProp.slice(startingIndex, endingIndex + 1)
       }
       search={{ ...search, onSearch: handleSearch, value: searchState }}
-      pagination={{ ...pagination, page, onPage: handlePage, totalItems: tiles ? tiles.length : 0 }}
+      pagination={{
+        ...pagination,
+        page,
+        onPage: handlePage,
+        totalItems: isFiltered ? filteredTiles.length : tiles ? tiles.length : 0,
+      }}
       onSelection={handleSelection}
     />
   );

--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -43,7 +43,16 @@ const StatefulTileCatalog = ({
         },
       });
     },
-    [tilesProp.map(tile => omit(tile, 'renderContent')), selectedTileIdProp]
+    [tilesProp.map(tile => omit(tile, 'renderContent'))]
+  );
+
+  useEffect(
+    () => {
+      if (selectedTileIdProp) {
+        dispatch({ type: TILE_ACTIONS.SELECT, payload: selectedTileIdProp });
+      }
+    },
+    [selectedTileIdProp]
   );
 
   const {
@@ -65,29 +74,10 @@ const StatefulTileCatalog = ({
 
   const handleSelection = newSelectedTile => {
     dispatch({ type: TILE_ACTIONS.SELECT, payload: newSelectedTile });
+    if (onSelection) {
+      onSelection(newSelectedTile);
+    }
   };
-
-  /* I couldn't really get the reselect logic to work correctly
-  useDeepCompareEffect(
-    () => {
-      dispatch({
-        type: TILE_ACTIONS.SELECT,
-        payload:
-          selectedTileId ||
-          (filteredTiles && filteredTiles[startingIndex] ? filteredTiles[startingIndex].id : null),
-      });
-    },
-    [filteredTiles.map(tile => omit(tile, 'renderContent')), searchState, startingIndex, page]
-  );
-*/
-  useEffect(
-    () => {
-      if (onSelection) {
-        onSelection(selectedTileId);
-      }
-    },
-    [selectedTileId] // eslint-disable-line
-  );
 
   const handleSearch = (event, ...args) => {
     const newSearch = event.target.value || '';

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -88,11 +88,18 @@ export const tileCatalogReducer = (state = {}, action) => {
         endingIndex: (pageSize || filteredTiles.length) - 1,
       };
     }
-    case TILE_ACTIONS.SELECT:
+    case TILE_ACTIONS.SELECT: {
+      const { filteredTiles, pageSize } = state;
+      const tileIndex = filteredTiles.findIndex(tile => tile.id === action.payload);
+      const page = Math.floor(tileIndex / pageSize) + 1;
       return {
         ...state,
+        page,
+        startingIndex: (page - 1) * pageSize,
+        endingIndex: determineEndingIndex(page, pageSize),
         selectedTileId: action.payload,
       };
+    }
     case TILE_ACTIONS.RESET:
       return determineInitialState(action.payload);
     default:

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -71,8 +71,6 @@ export const tileCatalogReducer = (state = {}, action) => {
         ...state,
         startingIndex,
         endingIndex,
-        // set the selected tile id if the page changes
-        selectedTileId: null,
         page,
       };
     }
@@ -88,8 +86,6 @@ export const tileCatalogReducer = (state = {}, action) => {
         page: 1,
         startingIndex: 0,
         endingIndex: (pageSize || filteredTiles.length) - 1,
-        // Set the selected tile id if the search changes the data
-        selectedTileId: null,
       };
     }
     case TILE_ACTIONS.SELECT:

--- a/src/components/TileCatalog/tileCatalogReducer.test.js
+++ b/src/components/TileCatalog/tileCatalogReducer.test.js
@@ -62,7 +62,6 @@ describe('tileCatalogReducer', () => {
 
     const newState = tileCatalogReducer(existingState, pageChangeAction);
     expect(newState.page).toEqual(2);
-    // expect(newState.selectedTileId).toEqual(null);
     expect(newState.startingIndex).toEqual(5);
     expect(newState.endingIndex).toEqual(9);
   });
@@ -85,7 +84,6 @@ describe('tileCatalogReducer', () => {
     const newState = tileCatalogReducer(existingState, searchAction);
     expect(newState.searchState).toEqual('Tile6');
     expect(newState.page).toEqual(1);
-    // expect(newState.selectedTileId).toEqual(null);
     expect(newState.startingIndex).toEqual(0);
     expect(newState.endingIndex).toEqual(4);
   });

--- a/src/components/TileCatalog/tileCatalogReducer.test.js
+++ b/src/components/TileCatalog/tileCatalogReducer.test.js
@@ -88,7 +88,7 @@ describe('tileCatalogReducer', () => {
     expect(newState.endingIndex).toEqual(4);
   });
   test('select', () => {
-    const selectAction = { type: TILE_ACTIONS.SELECT, payload: 'tile2' };
+    const selectAction = { type: TILE_ACTIONS.SELECT, payload: 'test2' };
     const existingState = {
       page: 1,
       pageSize: 5,
@@ -103,7 +103,13 @@ describe('tileCatalogReducer', () => {
     };
 
     const newState = tileCatalogReducer(existingState, selectAction);
-    expect(newState.selectedTileId).toEqual('tile2');
+    expect(newState.selectedTileId).toEqual('test2');
+    const selectAction2 = { type: TILE_ACTIONS.SELECT, payload: 'test6' };
+    const newState2 = tileCatalogReducer(existingState, selectAction2);
+    expect(newState2.selectedTileId).toEqual('test6');
+    expect(newState2.page).toEqual(2);
+    expect(newState2.startingIndex).toEqual(5);
+    expect(newState2.endingIndex).toEqual(9);
   });
 });
 describe('determineInitialState', () => {


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- two bugs related to tile catalog with searching and paging

**Change List (commits, features, bugs, etc)**

- fix(tilecatalog): searching and paging no longer working because of changes to selectedTileId, the fix is to no longer reset the selectedtileid on search and paging
- fix(tilecatalog): allowed to page past the final page whenever you've searched the results

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes internal bug on the stateful tile catalog not searching any more

**Acceptance Test (how to verify the PR)**

- Verify that the TileCatalog stories with searching and paging work correctly
