### PR TITLE
fix(table): hasRowSelection false proptype instead of empty string

### DIFF
--- a/src/components/Table/AsyncTable/AsyncTable.jsx
+++ b/src/components/Table/AsyncTable/AsyncTable.jsx
@@ -209,7 +209,7 @@ const AsyncTable = ({ fetchData }) => {
         hasFilter: true,
         hasSearch: false,
         hasPagination: true,
-        hasRowSelection: '',
+        hasRowSelection: false,
         hasRowExpansion: false,
         hasRowActions: false,
         hasColumnSelection: true,

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -40,7 +40,7 @@ const propTypes = {
   /** Optional properties to customize how the table should be rendered */
   options: PropTypes.shape({
     hasPagination: PropTypes.bool,
-    hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+    hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
     hasRowExpansion: PropTypes.bool,
     hasRowNesting: PropTypes.bool,
     hasRowActions: PropTypes.bool,
@@ -150,7 +150,7 @@ export const defaultProps = baseProps => ({
   lightweight: false,
   options: {
     hasPagination: false,
-    hasRowSelection: '',
+    hasRowSelection: false,
     hasRowExpansion: false,
     hasRowActions: false,
     hasRowNesting: false,

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -27,7 +27,7 @@ const propTypes = {
   clickToCollapseText: PropTypes.string,
   /** since some columns might not be currently visible */
   totalColumns: PropTypes.number,
-  hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+  hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.bool,
   hasRowActions: PropTypes.bool,
@@ -60,7 +60,7 @@ const defaultProps = {
   expandedRows: [],
   columns: [],
   totalColumns: 0,
-  hasRowSelection: '',
+  hasRowSelection: false,
   hasRowExpansion: false,
   hasRowNesting: false,
   hasRowActions: false,

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -40,7 +40,7 @@ const propTypes = {
   columns: TableColumnsPropTypes.isRequired,
   /** table wide options */
   options: PropTypes.shape({
-    hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+    hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
     hasRowExpansion: PropTypes.bool,
     hasRowNesting: PropTypes.bool,
     shouldExpandOnRowClick: PropTypes.bool,

--- a/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.jsx
@@ -69,7 +69,7 @@ class ColumnHeaderRow extends Component {
       })
     ).isRequired,
     tableOptions: PropTypes.shape({
-      hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+      hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
       hasRowExpansion: PropTypes.bool,
     }).isRequired,
     onChangeOrdering: PropTypes.func.isRequired,

--- a/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
@@ -14,7 +14,7 @@ const commonTableHeadProps = {
   /** Ordering list */
   ordering: [{ columnId: 'col1', isHidden: false }, { columnId: 'col2', isHidden: false }],
   tableOptions: {
-    hasRowSelection: '',
+    hasRowSelection: false,
     hasRowExpansion: false,
   },
   onChangeOrdering: jest.fn(),

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -96,7 +96,7 @@ class FilterHeaderRow extends Component {
     onApplyFilter: PropTypes.func,
     /** properties global to the table */
     tableOptions: PropTypes.shape({
-      hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+      hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
       hasRowExpansion: PropTypes.bool,
       hasRowActions: PropTypes.bool,
     }),

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -16,7 +16,7 @@ const propTypes = {
   /** Important table options that the head needs to know about */
   options: PropTypes.shape({
     hasRowExpansion: PropTypes.bool,
-    hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+    hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
     hasRowActions: PropTypes.bool,
   }),
   /** List of columns */

--- a/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders.jsx
+++ b/src/components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders.jsx
@@ -8,7 +8,7 @@ import { COLORS } from '../../../styles/styles';
 const { TableBody, TableCell, TableRow } = DataTable;
 
 const propTypes = {
-  hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+  hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
   hasRowExpansion: PropTypes.bool,
   hasRowActions: PropTypes.bool,
   rowCount: PropTypes.number,
@@ -16,7 +16,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  hasRowSelection: '',
+  hasRowSelection: false,
   hasRowExpansion: false,
   hasRowActions: false,
   rowCount: 0,

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -101,7 +101,7 @@ const propTypes = {
     /** total number of selected rows */
     totalSelected: PropTypes.number,
     /** row selection option */
-    hasRowSelection: PropTypes.oneOf(['multi', 'single', '']),
+    hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
     /** optional content to render inside the toolbar  */
     customToolbarContent: PropTypes.node,
     /** available batch actions */


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Existing consumers of the table with `hasRowSelection: false` were getting proptypes errors due to an empty string as proptypes, instead of `false`

**Change List (commits, features, bugs, etc)**

- modify proptypes to be `oneOf(["multi", "single", false])`
- modify defaultprops to be `false` instead of `''`

**Related Issues**

**Acceptance Test (how to verify the PR)**

- check out the single selection and multi selection story. Nothing really should change here as this is a really minor fix
