### PR TITLE
feat(table): add small table support with smaller pagination component

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
     "@carbon/icons": "^10.1.0",
-    "@carbon/icons-react": "^0.0.1-alpha.12",
+    "@carbon/icons-react": "^10.1.1",
     "@commitlint/cli": "^7.2.1",
     "@commitlint/config-conventional": "^7.1.2",
     "@semantic-release/commit-analyzer": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -40,14 +40,15 @@
     "react-dnd": "7.0.2",
     "react-dnd-html5-backend": "2.5.1",
     "react-dnd-test-backend": "^7.2.0",
+    "react-sizeme": "^2.6.3",
     "react-transition-group": "^2.6.0",
     "styled-components": "^4.1.3",
     "use-deep-compare-effect": "^1.2.0"
   },
   "peerDependencies": {
+    "@carbon/icons": "^10.1.0",
     "@carbon/icons-react": "^0.0.1-alpha.12",
     "carbon-components": "^9.84.14",
-    "@carbon/icons": "^10.1.0",
     "carbon-components-react": "^6.108.0",
     "carbon-icons": "^7.x",
     "react": "^16.8.3"

--- a/src/components/Header/__snapshots__/HeaderMenu.test.jsx.snap
+++ b/src/components/Header/__snapshots__/HeaderMenu.test.jsx.snap
@@ -26,25 +26,29 @@ exports[`HeaderMenu should render 1`] = `
         <defaultRenderMenuContent>
           <ChevronDownGlyph
             className="bx--header__menu-arrow"
-            focusable={false}
-            height={7}
+            height={6}
             preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 12 7"
-            width={12}
+            viewBox="0 0 10 6"
+            width={10}
             xmlns="http://www.w3.org/2000/svg"
           >
             <svg
               aria-hidden={true}
               className="bx--header__menu-arrow"
-              focusable={false}
-              height={7}
+              focusable="false"
+              height={6}
               preserveAspectRatio="xMidYMid meet"
-              viewBox="0 0 12 7"
-              width={12}
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 10 6"
+              width={10}
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M6.002 5.55L11.27 0l.726.685L6.002 7 0 .685.726 0z"
+                d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
               />
             </svg>
           </ChevronDownGlyph>

--- a/src/components/SideNav/__snapshots__/SideNav.test.jsx.snap
+++ b/src/components/SideNav/__snapshots__/SideNav.test.jsx.snap
@@ -7,14 +7,13 @@ exports[`SideNav testcases should render one level of navigation links 1`] = `
   links={
     Array [
       Object {
-        "icon": <AppSwitcher24
+        "icon": <ForwardRef
           className="bx--header__menu-item bx--header__menu-title"
           description="Icon"
           fill="white"
-          focusable={false}
           height={24}
           preserveAspectRatio="xMidYMid meet"
-          viewBox="0 0 32 32"
+          viewBox="0 0 24 24"
           width={24}
           xmlns="http://www.w3.org/2000/svg"
         />,
@@ -168,14 +167,13 @@ the label you want displayed or read by screen readers.",
                 className="disabled"
                 element="a"
                 icon={
-                  <AppSwitcher24
+                  <ForwardRef
                     className="bx--header__menu-item bx--header__menu-title"
                     description="Icon"
                     fill="white"
-                    focusable={false}
                     height={24}
                     preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
+                    viewBox="0 0 24 24"
                     width={24}
                     xmlns="http://www.w3.org/2000/svg"
                   />
@@ -216,14 +214,13 @@ the label you want displayed or read by screen readers.",
                   }
                   forwardedRef={null}
                   icon={
-                    <AppSwitcher24
+                    <ForwardRef
                       className="bx--header__menu-item bx--header__menu-title"
                       description="Icon"
                       fill="white"
-                      focusable={false}
                       height={24}
                       preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
+                      viewBox="0 0 24 24"
                       width={24}
                       xmlns="http://www.w3.org/2000/svg"
                     />
@@ -237,14 +234,13 @@ the label you want displayed or read by screen readers.",
                     className="disabled SideNav__StyledSideNavLink-yn3bk8-1 hllekx"
                     element="a"
                     icon={
-                      <AppSwitcher24
+                      <ForwardRef
                         className="bx--header__menu-item bx--header__menu-title"
                         description="Icon"
                         fill="white"
-                        focusable={false}
                         height={24}
                         preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
+                        viewBox="0 0 24 24"
                         width={24}
                         xmlns="http://www.w3.org/2000/svg"
                       />
@@ -282,10 +278,9 @@ the label you want displayed or read by screen readers.",
                                   className="bx--header__menu-item bx--header__menu-title"
                                   description="Icon"
                                   fill="white"
-                                  focusable={false}
                                   height={24}
                                   preserveAspectRatio="xMidYMid meet"
-                                  viewBox="0 0 32 32"
+                                  viewBox="0 0 24 24"
                                   width={24}
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
@@ -294,15 +289,20 @@ the label you want displayed or read by screen readers.",
                                     className="bx--header__menu-item bx--header__menu-title"
                                     description="Icon"
                                     fill="white"
-                                    focusable={false}
+                                    focusable="false"
                                     height={24}
                                     preserveAspectRatio="xMidYMid meet"
-                                    viewBox="0 0 32 32"
+                                    style={
+                                      Object {
+                                        "willChange": "transform",
+                                      }
+                                    }
+                                    viewBox="0 0 24 24"
                                     width={24}
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
                                     <path
-                                      d="M14 5h4v4h-4zM5 5h4v4H5zm18 0h4v4h-4zm-9 9h4v4h-4zm-9 0h4v4H5zm18 0h4v4h-4zm-9 9h4v4h-4zm-9 0h4v4H5zm18 0h4v4h-4z"
+                                      d="M18 18h3v3h-3zm-7.5 0h3v3h-3zM3 18h3v3H3zm15-7.5h3v3h-3zm-7.5 0h3v3h-3zm-7.5 0h3v3H3zM18 3h3v3h-3zm-7.5 0h3v3h-3zM3 3h3v3H3z"
                                     />
                                   </svg>
                                 </AppSwitcher24>
@@ -390,14 +390,13 @@ exports[`SideNav testcases should render two levels of navigation links 1`] = `
   links={
     Array [
       Object {
-        "icon": <AppSwitcher24
+        "icon": <ForwardRef
           className="bx--header__menu-item bx--header__menu-title"
           description="Icon"
           fill="white"
-          focusable={false}
           height={24}
           preserveAspectRatio="xMidYMid meet"
-          viewBox="0 0 32 32"
+          viewBox="0 0 24 24"
           width={24}
           xmlns="http://www.w3.org/2000/svg"
         />,
@@ -412,11 +411,10 @@ exports[`SideNav testcases should render two levels of navigation links 1`] = `
       },
       Object {
         "current": true,
-        "icon": <Chip24
+        "icon": <ForwardRef
           className="bx--header__menu-item bx--header__menu-title"
           description="Icon"
           fill="white"
-          focusable={false}
           height={24}
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 32 32"
@@ -443,11 +441,10 @@ exports[`SideNav testcases should render two levels of navigation links 1`] = `
             },
           },
         ],
-        "icon": <Group24
+        "icon": <ForwardRef
           className="bx--header__menu-item bx--header__menu-title"
           description="Icon"
           fill="white"
-          focusable={false}
           height={24}
           preserveAspectRatio="xMidYMid meet"
           viewBox="0 0 32 32"
@@ -602,14 +599,13 @@ the label you want displayed or read by screen readers.",
                 className="disabled"
                 element="a"
                 icon={
-                  <AppSwitcher24
+                  <ForwardRef
                     className="bx--header__menu-item bx--header__menu-title"
                     description="Icon"
                     fill="white"
-                    focusable={false}
                     height={24}
                     preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 32 32"
+                    viewBox="0 0 24 24"
                     width={24}
                     xmlns="http://www.w3.org/2000/svg"
                   />
@@ -650,14 +646,13 @@ the label you want displayed or read by screen readers.",
                   }
                   forwardedRef={null}
                   icon={
-                    <AppSwitcher24
+                    <ForwardRef
                       className="bx--header__menu-item bx--header__menu-title"
                       description="Icon"
                       fill="white"
-                      focusable={false}
                       height={24}
                       preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 32 32"
+                      viewBox="0 0 24 24"
                       width={24}
                       xmlns="http://www.w3.org/2000/svg"
                     />
@@ -671,14 +666,13 @@ the label you want displayed or read by screen readers.",
                     className="disabled SideNav__StyledSideNavLink-yn3bk8-1 hllekx"
                     element="a"
                     icon={
-                      <AppSwitcher24
+                      <ForwardRef
                         className="bx--header__menu-item bx--header__menu-title"
                         description="Icon"
                         fill="white"
-                        focusable={false}
                         height={24}
                         preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 32 32"
+                        viewBox="0 0 24 24"
                         width={24}
                         xmlns="http://www.w3.org/2000/svg"
                       />
@@ -716,10 +710,9 @@ the label you want displayed or read by screen readers.",
                                   className="bx--header__menu-item bx--header__menu-title"
                                   description="Icon"
                                   fill="white"
-                                  focusable={false}
                                   height={24}
                                   preserveAspectRatio="xMidYMid meet"
-                                  viewBox="0 0 32 32"
+                                  viewBox="0 0 24 24"
                                   width={24}
                                   xmlns="http://www.w3.org/2000/svg"
                                 >
@@ -728,15 +721,20 @@ the label you want displayed or read by screen readers.",
                                     className="bx--header__menu-item bx--header__menu-title"
                                     description="Icon"
                                     fill="white"
-                                    focusable={false}
+                                    focusable="false"
                                     height={24}
                                     preserveAspectRatio="xMidYMid meet"
-                                    viewBox="0 0 32 32"
+                                    style={
+                                      Object {
+                                        "willChange": "transform",
+                                      }
+                                    }
+                                    viewBox="0 0 24 24"
                                     width={24}
                                     xmlns="http://www.w3.org/2000/svg"
                                   >
                                     <path
-                                      d="M14 5h4v4h-4zM5 5h4v4H5zm18 0h4v4h-4zm-9 9h4v4h-4zm-9 0h4v4H5zm18 0h4v4h-4zm-9 9h4v4h-4zm-9 0h4v4H5zm18 0h4v4h-4z"
+                                      d="M18 18h3v3h-3zm-7.5 0h3v3h-3zM3 18h3v3H3zm15-7.5h3v3h-3zm-7.5 0h3v3h-3zm-7.5 0h3v3H3zM18 3h3v3h-3zm-7.5 0h3v3h-3zM3 3h3v3H3z"
                                     />
                                   </svg>
                                 </AppSwitcher24>
@@ -762,11 +760,10 @@ the label you want displayed or read by screen readers.",
                 element="a"
                 href="https://google.com"
                 icon={
-                  <Chip24
+                  <ForwardRef
                     className="bx--header__menu-item bx--header__menu-title"
                     description="Icon"
                     fill="white"
-                    focusable={false}
                     height={24}
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 32 32"
@@ -811,11 +808,10 @@ the label you want displayed or read by screen readers.",
                   forwardedRef={null}
                   href="https://google.com"
                   icon={
-                    <Chip24
+                    <ForwardRef
                       className="bx--header__menu-item bx--header__menu-title"
                       description="Icon"
                       fill="white"
-                      focusable={false}
                       height={24}
                       preserveAspectRatio="xMidYMid meet"
                       viewBox="0 0 32 32"
@@ -833,11 +829,10 @@ the label you want displayed or read by screen readers.",
                     element="a"
                     href="https://google.com"
                     icon={
-                      <Chip24
+                      <ForwardRef
                         className="bx--header__menu-item bx--header__menu-title"
                         description="Icon"
                         fill="white"
-                        focusable={false}
                         height={24}
                         preserveAspectRatio="xMidYMid meet"
                         viewBox="0 0 32 32"
@@ -878,7 +873,6 @@ the label you want displayed or read by screen readers.",
                                   className="bx--header__menu-item bx--header__menu-title"
                                   description="Icon"
                                   fill="white"
-                                  focusable={false}
                                   height={24}
                                   preserveAspectRatio="xMidYMid meet"
                                   viewBox="0 0 32 32"
@@ -890,9 +884,14 @@ the label you want displayed or read by screen readers.",
                                     className="bx--header__menu-item bx--header__menu-title"
                                     description="Icon"
                                     fill="white"
-                                    focusable={false}
+                                    focusable="false"
                                     height={24}
                                     preserveAspectRatio="xMidYMid meet"
+                                    style={
+                                      Object {
+                                        "willChange": "transform",
+                                      }
+                                    }
                                     viewBox="0 0 32 32"
                                     width={24}
                                     xmlns="http://www.w3.org/2000/svg"
@@ -901,7 +900,7 @@ the label you want displayed or read by screen readers.",
                                       d="M11 11v10h10V11zm8 8h-6v-6h6z"
                                     />
                                     <path
-                                      d="M29 13v-2h-3V8a2 2 0 0 0-2-2h-3V3h-2v3h-6V3h-2v3H8a2 2 0 0 0-2 2v3H3v2h3v6H3v2h3v3a2 2 0 0 0 2 2h3v3h2v-3h6v3h2v-3h3a2 2 0 0 0 2-2v-3h3v-2h-3v-6zm-5 11H8V8h16z"
+                                      d="M30 13v-2h-4V8a2 2 0 0 0-2-2h-3V2h-2v4h-6V2h-2v4H8a2 2 0 0 0-2 2v3H2v2h4v6H2v2h4v3a2 2 0 0 0 2 2h3v4h2v-4h6v4h2v-4h3a2 2 0 0 0 2-2v-3h4v-2h-4v-6zm-6 11H8V8h16z"
                                     />
                                   </svg>
                                 </Chip24>
@@ -925,11 +924,10 @@ the label you want displayed or read by screen readers.",
                 aria-label="dropdown"
                 className="disabled"
                 icon={
-                  <Group24
+                  <ForwardRef
                     className="bx--header__menu-item bx--header__menu-title"
                     description="Icon"
                     fill="white"
-                    focusable={false}
                     height={24}
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 32 32"
@@ -980,11 +978,10 @@ the label you want displayed or read by screen readers.",
                   }
                   forwardedRef={null}
                   icon={
-                    <Group24
+                    <ForwardRef
                       className="bx--header__menu-item bx--header__menu-title"
                       description="Icon"
                       fill="white"
-                      focusable={false}
                       height={24}
                       preserveAspectRatio="xMidYMid meet"
                       viewBox="0 0 32 32"
@@ -998,11 +995,10 @@ the label you want displayed or read by screen readers.",
                     aria-label="dropdown"
                     className="disabled SideNav__StyledSideNavMenu-yn3bk8-2 cVDWRM"
                     icon={
-                      <Group24
+                      <ForwardRef
                         className="bx--header__menu-item bx--header__menu-title"
                         description="Icon"
                         fill="white"
-                        focusable={false}
                         height={24}
                         preserveAspectRatio="xMidYMid meet"
                         viewBox="0 0 32 32"
@@ -1018,11 +1014,10 @@ the label you want displayed or read by screen readers.",
                       className="disabled SideNav__StyledSideNavMenu-yn3bk8-2 cVDWRM"
                       defaultExpanded={false}
                       icon={
-                        <Group24
+                        <ForwardRef
                           className="bx--header__menu-item bx--header__menu-title"
                           description="Icon"
                           fill="white"
-                          focusable={false}
                           height={24}
                           preserveAspectRatio="xMidYMid meet"
                           viewBox="0 0 32 32"
@@ -1053,7 +1048,6 @@ the label you want displayed or read by screen readers.",
                                 className="bx--header__menu-item bx--header__menu-title"
                                 description="Icon"
                                 fill="white"
-                                focusable={false}
                                 height={24}
                                 preserveAspectRatio="xMidYMid meet"
                                 viewBox="0 0 32 32"
@@ -1065,9 +1059,14 @@ the label you want displayed or read by screen readers.",
                                   className="bx--header__menu-item bx--header__menu-title"
                                   description="Icon"
                                   fill="white"
-                                  focusable={false}
+                                  focusable="false"
                                   height={24}
                                   preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
                                   viewBox="0 0 32 32"
                                   width={24}
                                   xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Table/EmptyTable/EmptyTable.jsx
+++ b/src/components/Table/EmptyTable/EmptyTable.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { DataTable, Button } from 'carbon-components-react';
 import styled from 'styled-components';
-import { Bee32 } from '@carbon/icons-react';
+import Bee32 from '@carbon/icons-react/lib/bee/32';
 
 import { COLORS } from '../../../styles/styles';
 import { EmptyStatePropTypes } from '../TablePropTypes';

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -5,6 +5,8 @@ import pick from 'lodash/pick';
 import { PaginationV2, DataTable } from 'carbon-components-react';
 import get from 'lodash/get';
 import isNil from 'lodash/isNil';
+import styled from 'styled-components';
+import sizeMe from 'react-sizeme';
 
 import { defaultFunction } from '../../utils/componentUtilityFunctions';
 
@@ -23,6 +25,24 @@ import TableSkeletonWithHeaders from './TableSkeletonWithHeaders/TableSkeletonWi
 import TableBody from './TableBody/TableBody';
 
 const { Table: CarbonTable, TableContainer } = DataTable;
+
+const StyledTableDiv = styled.div`
+  &&& {
+    .bx--data-table-v2-container {
+      min-width: unset;
+    }
+  }
+`;
+
+const StyledPagination = sizeMe({ noPlaceholder: true })(styled(PaginationV2)`
+  &&& {
+    .bx--pagination__left,
+    .bx--pagination__text {
+      display: ${props =>
+        props.size && props.size.width && props.size.width < 600 ? 'none' : 'flex'};
+    }
+  }
+`);
 
 const propTypes = {
   /** DOM ID for component */
@@ -243,6 +263,7 @@ const Table = props => {
     options,
     lightweight,
     className,
+    style,
     i18n,
     ...others
   } = merge({}, defaultProps(props), props);
@@ -283,7 +304,7 @@ const Table = props => {
       view.toolbar.search.value !== '');
 
   return (
-    <div id={id} className={className}>
+    <StyledTableDiv id={id} className={className} style={style}>
       <TableToolbar
         clearAllFiltersText={i18n.clearAllFilters}
         columnSelectionText={i18n.columnSelectionButtonAria}
@@ -397,7 +418,7 @@ const Table = props => {
       !view.table.loadingState.isLoading &&
       visibleData &&
       visibleData.length ? ( // don't show pagination row while loading
-        <PaginationV2
+        <StyledPagination
           {...view.pagination}
           onChange={actions.pagination.onChangePage}
           backwardText={i18n.pageBackwardAria}
@@ -410,7 +431,7 @@ const Table = props => {
           pageRangeText={i18n.pageRange}
         />
       ) : null}
-    </div>
+    </StyledTableDiv>
   );
 };
 

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -27,10 +27,8 @@ import TableBody from './TableBody/TableBody';
 const { Table: CarbonTable, TableContainer } = DataTable;
 
 const StyledTableDiv = styled.div`
-  &&& {
-    .bx--data-table-v2-container {
-      min-width: unset;
-    }
+  .bx--data-table-v2-container {
+    min-width: unset;
   }
 `;
 

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -454,6 +454,15 @@ storiesOf('Table', module)
       options={{ hasSearch: true }}
     />
   ))
+  .add('minitable', () => (
+    <StatefulTable
+      style={{ maxWidth: '300px' }}
+      columns={tableColumns.slice(0, 2)}
+      data={tableData}
+      actions={actions}
+      options={{ hasSearch: true, hasPagination: true, hasRowSelection: 'single' }}
+    />
+  ))
   .add('with multi select and batch actions', () => (
     // TODO - batch action bar
     <Table

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -27,6 +27,11 @@ const StyledTableHeader = styled(TableHeader)`
         min-width: 12.75rem;
       }
     }
+
+    .bx--list-box input[role='combobox'] {
+      /* need to save enough room for clear and dropdown button */
+      padding-right: 4rem;
+    }
     ${props => {
       const { width } = props;
       return width !== undefined
@@ -51,9 +56,6 @@ const StyledFormItem = styled(FormItem)`
 
     .bx--list-box__selection {
       right: 0;
-    }
-    .bx--list-box input[role='combobox'] {
-      padding-right: 3.5rem;
     }
   }
 `;

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -52,6 +52,9 @@ const StyledFormItem = styled(FormItem)`
     .bx--list-box__selection {
       right: 0;
     }
+    .bx--list-box input[role='combobox'] {
+      padding-right: 3.5rem;
+    }
   }
 `;
 

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -4,7 +4,7 @@ export const RowActionPropTypes = PropTypes.arrayOf(
   PropTypes.shape({
     /** Unique id of the action */
     id: PropTypes.string.isRequired,
-    /* icon ultimately gets passed through all the way to <Button>, which has this same copied proptype definition for icon */
+    /** icon ultimately gets passed through all the way to <Button>, which has this same copied proptype definition for icon */
     icon: PropTypes.oneOfType([
       PropTypes.shape({
         width: PropTypes.string,

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -44,7 +44,6 @@ const StyledCarbonTableToolbar = styled(CarbonTableToolbar)`
    {
     &&& {
       width: 100%;
-      min-width: 31.25rem;
       padding-top: 0.125rem;
     }
   }

--- a/src/components/TileCatalog/TileCatalog.jsx
+++ b/src/components/TileCatalog/TileCatalog.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { RadioTile, Tile, Search, SkeletonText } from 'carbon-components-react';
-import { Bee32 } from '@carbon/icons-react';
+import Bee32 from '@carbon/icons-react/lib/bee/32';
 
 import SimplePagination from '../SimplePagination/SimplePagination';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3217,6 +3217,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+batch-processor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
+  integrity sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -4931,6 +4936,13 @@ electron-to-chromium@^1.3.96:
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
+element-resize-detector@^1.1.15:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.15.tgz#48eba1a2eaa26969a4c998d972171128c971d8d2"
+  integrity sha512-16/5avDegXlUxytGgaumhjyQoM6hpp5j3+L79sYq5hlXfTNRy5WMMuTVWkZU3egp/CokCmTmvf18P3KeB57Iog==
+  dependencies:
+    batch-processor "^1.0.0"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -8124,6 +8136,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -10453,6 +10470,17 @@ react-modal@^3.6.1:
     prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
+
+react-sizeme@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.3.tgz#82659d64249c0bf8fc1ddc60b4965d3fb58a5680"
+  integrity sha512-39ImpABbJ98pcEa+hjveIT3CIjFgY7UmYDSi76C7PHMXt/MCo2IISPC0U8lDILjYr8/5TCY0p3yqxWm5f9zPmQ==
+  dependencies:
+    element-resize-detector "^1.1.15"
+    invariant "^2.2.4"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    shallowequal "^1.1.0"
 
 react-split-pane@^0.1.84:
   version "0.1.85"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1148,21 +1148,15 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@carbon/icon-helpers@0.0.1-alpha.12":
-  version "0.0.1-alpha.12"
-  resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-0.0.1-alpha.12.tgz#27f1449ff8e503e42e478ca567dfa6a6b453debe"
-
 "@carbon/icon-helpers@0.0.1-beta.5":
   version "0.0.1-beta.5"
   resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-0.0.1-beta.5.tgz#829e8593dbcee76e5d6300839d2b5d734f90c98d"
   integrity sha512-3gFkiIWRlfPrDsYSfgKyveS4kkp0+HIg2fUP4jm5G9JgzOfE+Ebw4f0ASg02z4YMywrs2sw60hbdrFi1GGihGQ==
 
-"@carbon/icons-react@^0.0.1-alpha.12":
-  version "0.0.1-alpha.12"
-  resolved "https://registry.yarnpkg.com/@carbon/icons-react/-/icons-react-0.0.1-alpha.12.tgz#9cdc7846d0862838770c966a7f130953a89887a5"
-  dependencies:
-    "@carbon/icon-helpers" "0.0.1-alpha.12"
-    prop-types "^15.6.2"
+"@carbon/icon-helpers@10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-10.1.1.tgz#08affd6f68936ba48beca7a732b0e70bd5ab8ca0"
+  integrity sha512-FwuAuALKOY2XqPoW5aiIsCYLqzERNeFhuSILMlTtlZptHdZnZC/HdUWiNS7jZIvQO+jC1FVUc/UX9FK8Nh36ow==
 
 "@carbon/icons-react@^0.0.1-beta.2":
   version "0.0.1-beta.5"
@@ -1170,6 +1164,14 @@
   integrity sha512-Cigh18dQHgS5pnqfLpp/wjrUBRRd05KC9A3Iloa3WWMlRCy6/Mgoe6Zg0teMOEIYrfoGFx29bgWeeyvzrufLLw==
   dependencies:
     "@carbon/icon-helpers" "0.0.1-beta.5"
+    prop-types "^15.6.2"
+
+"@carbon/icons-react@^10.1.1":
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/@carbon/icons-react/-/icons-react-10.1.1.tgz#42586dad97256ce5f25699fe9f142f735976026b"
+  integrity sha512-gkh7E8LLoS5SMn6mDbhuEW3XjB7VKmOv1pE43Bt5QJCoG/mMyJGziec1gcsPcTz8XXBIDBm2w7EJYzcrmZixFA==
+  dependencies:
+    "@carbon/icon-helpers" "10.1.1"
     prop-types "^15.6.2"
 
 "@carbon/icons@^10.1.0":


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- summary_here

**Change List (commits, features, bugs, etc)**

- chore(carbon-icons): upgrade to latest carbon-icons and update EmptyState and TileCatalog components to use non-built versions
- feat(Table): detect the size of the table and hide aspects of the pagination component.  Remove min-widths so our table can get narrower if it needs to
- fix(Table): passthrough the style prop to the parent component so the whole thing can be resized

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#221
- Closes IBM/carbon-addons-iot-react#220

**Acceptance Test (how to verify the PR)**

- Verify the new small width table
