### PR TITLE
feat(table): add async row action support

### DIFF
--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -71,6 +71,7 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
     onSelectAll,
     onRowExpanded,
     onApplyRowAction,
+    onClearRowError,
     onEmptyStateAction,
     onChangeOrdering,
   } = table || {};
@@ -142,6 +143,10 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
         } catch (error) {
           dispatch(tableRowActionError(rowId, error));
         }
+      },
+      onClearRowError: rowId => {
+        dispatch(tableRowActionComplete(rowId));
+        callbackParent(onClearRowError, rowId);
       },
       onEmptyStateAction: () =>
         // This action doesn't update our table state, it's up to the user

--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -17,6 +17,9 @@ import {
   tableRowSelectAll,
   tableRowExpand,
   tableColumnOrder,
+  tableRowActionStart,
+  tableRowActionComplete,
+  tableRowActionError,
 } from './tableActionCreators';
 import Table, { defaultProps } from './Table';
 
@@ -131,9 +134,15 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
         dispatch(tableRowExpand(rowId, isExpanded));
         callbackParent(onRowExpanded, rowId, isExpanded);
       },
-      onApplyRowAction: (actionId, rowId) =>
-        // This action doesn't update our table state, it's up to the user
-        callbackParent(onApplyRowAction, actionId, rowId),
+      onApplyRowAction: async (actionId, rowId) => {
+        dispatch(tableRowActionStart(rowId));
+        try {
+          await callbackParent(onApplyRowAction, actionId, rowId);
+          dispatch(tableRowActionComplete(rowId));
+        } catch (error) {
+          dispatch(tableRowActionError(rowId, error));
+        }
+      },
       onEmptyStateAction: () =>
         // This action doesn't update our table state, it's up to the user
         callbackParent(onEmptyStateAction),

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -151,12 +151,14 @@ const propTypes = {
       /** Apply a search criteria to the table */
       onApplySearch: PropTypes.func,
     }),
+    /** table wide actions */
     table: PropTypes.shape({
       onRowSelected: PropTypes.func,
       onRowClicked: PropTypes.func,
       onRowExpanded: PropTypes.func,
       onSelectAll: PropTypes.func,
       onChangeSort: PropTypes.func,
+      /** if you return a promise from apply row action the stateful table will assume you're asynchronous and give a spinner */
       onApplyRowAction: PropTypes.func,
       onEmptyStateAction: PropTypes.func,
       onChangeOrdering: PropTypes.func,

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -17,6 +17,7 @@ import {
   EmptyStatePropTypes,
   TableSearchPropTypes,
   I18NPropTypes,
+  RowActionsStatePropTypes,
 } from './TablePropTypes';
 import TableHead from './TableHead/TableHead';
 import TableToolbar from './TableToolbar/TableToolbar';
@@ -115,7 +116,7 @@ const propTypes = {
         columnId: PropTypes.string,
         direction: PropTypes.oneOf(['NONE', 'ASC', 'DESC']),
       }),
-      /* Specify column ordering and visibility */
+      /** Specify column ordering and visibility */
       ordering: PropTypes.arrayOf(
         PropTypes.shape({
           columnId: PropTypes.string.isRequired,
@@ -123,6 +124,8 @@ const propTypes = {
           isHidden: PropTypes.bool,
         })
       ),
+      /** what is the current state of the row actions */
+      rowActions: RowActionsStatePropTypes,
       expandedIds: PropTypes.arrayOf(PropTypes.string),
       emptyState: EmptyStatePropTypes,
       loadingState: PropTypes.shape({
@@ -192,6 +195,7 @@ export const defaultProps = baseProps => ({
       expandedIds: [],
       isSelectAllSelected: false,
       selectedIds: [],
+      rowActions: [],
       sort: {},
       ordering: baseProps.columns && baseProps.columns.map(i => ({ columnId: i.id })),
       loadingState: {
@@ -363,6 +367,7 @@ const Table = props => {
             <TableBody
               id={id}
               rows={visibleData}
+              rowActionsState={view.table.rowActions}
               expandedRows={expandedData}
               columns={visibleColumns}
               expandedIds={view.table.expandedIds}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -392,6 +392,7 @@ const Table = props => {
                 actions.table,
                 'onRowSelected',
                 'onApplyRowAction',
+                'onClearRowError',
                 'onRowExpanded',
                 'onRowClicked'
               )}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -160,6 +160,7 @@ const propTypes = {
       onChangeSort: PropTypes.func,
       /** if you return a promise from apply row action the stateful table will assume you're asynchronous and give a spinner */
       onApplyRowAction: PropTypes.func,
+      onClearRowError: PropTypes.func,
       onEmptyStateAction: PropTypes.func,
       onChangeOrdering: PropTypes.func,
     }).isRequired,

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -603,6 +603,16 @@ storiesOf('Table', module)
               content: <RowExpansionContent rowId="row-5" />,
             },
           ],
+          rowActions: [
+            {
+              rowId: 'row-1',
+              isRunning: true,
+            },
+            {
+              rowId: 'row-3',
+              error: { title: 'Import failed', message: 'Contact your administrator' },
+            },
+          ],
         },
       }}
     />

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -361,9 +361,26 @@ storiesOf('Table', module)
       <StatefulTable
         {...initialState}
         actions={merge({}, actions, {
-          table: { onApplyRowAction: () => new Promise(resolve => setTimeout(resolve, 3000)) },
+          table: {
+            onApplyRowAction: () => new Promise(resolve => setTimeout(resolve, 3000)),
+            onClearRowError: () => true,
+          },
         })}
         lightweight={boolean('lightweight', false)}
+        view={{
+          table: {
+            rowActions: [
+              {
+                rowId: 'row-1',
+                isRunning: true,
+              },
+              {
+                rowId: 'row-3',
+                error: { title: 'Import failed', message: 'Contact your administrator' },
+              },
+            ],
+          },
+        }}
       />
     ),
     {

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { boolean, text, number } from '@storybook/addon-knobs';
 import styled from 'styled-components';
+import merge from 'lodash/merge';
 
 import { getSortedData } from '../../utils/componentUtilityFunctions';
 
@@ -291,6 +292,7 @@ export const initialState = {
         isHidden: id === 'secretField',
       })),
       expandedIds: [],
+      rowActions: [],
     },
     toolbar: {
       activeBar: 'filter',
@@ -313,6 +315,26 @@ storiesOf('Table', module)
       <StatefulTable
         {...initialState}
         actions={actions}
+        lightweight={boolean('lightweight', false)}
+      />
+    ),
+    {
+      info: {
+        text:
+          'This is an example of the <StatefulTable> component that uses local state to handle all the table actions. This is produced by wrapping the <Table> in a container component and managing the state associated with features such the toolbar, filters, row select, etc. For more robust documentation on the prop model and source, see the other "with function" stories.',
+        propTables: [Table],
+        propTablesExclude: [StatefulTable],
+      },
+    }
+  )
+  .add(
+    'Stateful with async row actions',
+    () => (
+      <StatefulTable
+        {...initialState}
+        actions={merge({}, actions, {
+          table: { onApplyRowAction: () => new Promise(resolve => setTimeout(resolve, 3000)) },
+        })}
         lightweight={boolean('lightweight', false)}
       />
     ),

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -28,7 +28,6 @@ const RowActionsContainer = styled.div`
     color: ${props => (props.isRowExpanded ? COLORS.white : '')};
     svg {
       stroke: ${props => (props.isRowExpanded ? COLORS.white : '')};
-      margin-left: ${props => (props.hideLabel !== 'false' ? '0' : '')};
     }
     /* the spinner was a little too big and causing the row to scroll so need to scale down a bit */
     .bx--loading--small {
@@ -170,54 +169,56 @@ class RowActionsCell extends React.Component {
               {inProgressText}
             </Fragment>
           ) : (
-            actions
-              .filter(action => !action.isOverflow)
-              .map(({ id: actionId, labelText, ...others }) => (
-                <RowActionButton
-                  {...others}
-                  key={`${id}-row-actions-button-${actionId}`}
-                  kind="ghost"
-                  onClick={e => onClick(e, id, actionId, onApplyRowAction)}
-                  small
-                  hideLabel={`${!labelText}`}
-                  isRowExpanded={isRowExpanded}>
-                  {labelText}
-                </RowActionButton>
-              ))
-          )}
-          {hasOverflow ? (
-            <StyledOverflowMenu
-              floatingMenu
-              flipped
-              ariaLabel={overflowMenuText}
-              onClick={event => event.stopPropagation()}
-              isRowExpanded={isRowExpanded}
-              iconDescription={overflowMenuText}
-              isOpen={isOpen}
-              onOpen={this.handleOpen}
-              onClose={this.handleClose}>
+            <Fragment>
               {actions
-                .filter(action => action.isOverflow)
-                .map(action => (
-                  <OverflowMenuItem
-                    key={`${id}-row-actions-button-${action.id}`}
-                    onClick={e => onClick(e, id, action.id, onApplyRowAction)}
-                    requireTitle
-                    itemText={
-                      action.icon ? (
-                        <OverflowMenuContent>
-                          <StyledIcon name={action.icon} iconTitle={action.labelText} />
-                          {action.labelText}
-                        </OverflowMenuContent>
-                      ) : (
-                        action.labelText
-                      )
-                    }
-                    floatingMenu
-                  />
+                .filter(action => !action.isOverflow)
+                .map(({ id: actionId, labelText, ...others }) => (
+                  <RowActionButton
+                    {...others}
+                    key={`${id}-row-actions-button-${actionId}`}
+                    kind="ghost"
+                    onClick={e => onClick(e, id, actionId, onApplyRowAction)}
+                    small
+                    hideLabel={`${!labelText}`}
+                    isRowExpanded={isRowExpanded}>
+                    {labelText}
+                  </RowActionButton>
                 ))}
-            </StyledOverflowMenu>
-          ) : null}
+              {hasOverflow ? (
+                <StyledOverflowMenu
+                  floatingMenu
+                  flipped
+                  ariaLabel={overflowMenuText}
+                  onClick={event => event.stopPropagation()}
+                  isRowExpanded={isRowExpanded}
+                  iconDescription={overflowMenuText}
+                  isOpen={isOpen}
+                  onOpen={this.handleOpen}
+                  onClose={this.handleClose}>
+                  {actions
+                    .filter(action => action.isOverflow)
+                    .map(action => (
+                      <OverflowMenuItem
+                        key={`${id}-row-actions-button-${action.id}`}
+                        onClick={e => onClick(e, id, action.id, onApplyRowAction)}
+                        requireTitle
+                        itemText={
+                          action.icon ? (
+                            <OverflowMenuContent>
+                              <StyledIcon name={action.icon} iconTitle={action.labelText} />
+                              {action.labelText}
+                            </OverflowMenuContent>
+                          ) : (
+                            action.labelText
+                          )
+                        }
+                        floatingMenu
+                      />
+                    ))}
+                </StyledOverflowMenu>
+              ) : null}
+            </Fragment>
+          )}
         </RowActionsContainer>
       </TableCell>
     ) : null;

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -110,6 +110,7 @@ const propTypes = {
   isRowActionRunning: PropTypes.bool,
   /** row action error out */
   rowActionsError: RowActionErrorPropTypes,
+  onClearError: PropTypes.func,
   /** I18N label for in progress */
   inProgressText: PropTypes.string,
   /** I18N label for action failed */
@@ -127,6 +128,7 @@ const defaultProps = {
   rowActionsError: null,
   overflowMenuText: 'More actions',
   inProgressText: 'In progress',
+  onClearError: null,
 };
 
 const onClick = (e, id, action, onApplyRowAction) => {
@@ -163,6 +165,7 @@ class RowActionsCell extends React.Component {
       overflowMenuText,
       isRowActionRunning,
       rowActionsError,
+      onClearError,
       inProgressText,
     } = this.props;
     const { isOpen } = this.state;
@@ -173,7 +176,7 @@ class RowActionsCell extends React.Component {
           visible={isRowExpanded || isRowActionRunning || rowActionsError}
           isRowExpanded={isRowExpanded}>
           {rowActionsError ? (
-            <RowActionsError rowActionsError={rowActionsError} />
+            <RowActionsError rowActionsError={rowActionsError} onClearError={onClearError} />
           ) : isRowActionRunning ? (
             <Fragment>
               <Loading small withOverlay={false} />

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsError.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsError.jsx
@@ -75,7 +75,9 @@ const RowActionsError = ({
               <a href={learnMoreURL} target="_blank" rel="noopener noreferrer">
                 {learnMoreText}
               </a>
-            ) : null}
+            ) : (
+              <div />
+            )}
             {onClearError ? (
               <Button
                 onClick={evt => {

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsError.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsError.jsx
@@ -1,0 +1,47 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import Warn from '@carbon/icons-react/lib/warning--alt/16';
+import styled from 'styled-components';
+
+import { RowActionErrorPropTypes } from '../../TablePropTypes';
+
+const StyledSpan = styled.span`
+  margin-left: 0.5rem;
+`;
+
+const propTypes = {
+  /** I18N label for action failed */
+  actionFailedText: PropTypes.string,
+  /** I18N label for learn more */
+  learnMoreText: PropTypes.string, // eslint-disable-line
+  /** I18N label for dismiss */
+  dismissText: PropTypes.string, // eslint-disable-line
+  /** did an error occur */
+  rowActionsError: RowActionErrorPropTypes,
+};
+
+const defaultProps = {
+  actionFailedText: 'Action failed',
+  learnMoreText: 'Learn more',
+  dismissText: 'Dismiss',
+  rowActionsError: null,
+};
+
+const RowActionsError = ({
+  rowActionsError,
+  actionFailedText,
+  // learnMoreText,
+  // dismissText
+}) => {
+  return rowActionsError ? (
+    <Fragment>
+      <Warn />
+      <StyledSpan>{actionFailedText}</StyledSpan>
+    </Fragment>
+  ) : null;
+};
+
+RowActionsError.propTypes = propTypes;
+RowActionsError.defaultProps = defaultProps;
+
+export default RowActionsError;

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsError.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsError.jsx
@@ -2,11 +2,28 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Warn from '@carbon/icons-react/lib/warning--alt/16';
 import styled from 'styled-components';
+import { Tooltip, Button } from 'carbon-components-react';
 
 import { RowActionErrorPropTypes } from '../../TablePropTypes';
 
 const StyledSpan = styled.span`
   margin-left: 0.5rem;
+`;
+
+const StyledTitle = styled.p`
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+`;
+
+const StyledTooltipFooter = styled.div`
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const StyledTooltipContents = styled.div`
+  font-size: 0.875rem;
 `;
 
 const propTypes = {
@@ -18,6 +35,7 @@ const propTypes = {
   dismissText: PropTypes.string, // eslint-disable-line
   /** did an error occur */
   rowActionsError: RowActionErrorPropTypes,
+  onClearError: PropTypes.func,
 };
 
 const defaultProps = {
@@ -25,17 +43,51 @@ const defaultProps = {
   learnMoreText: 'Learn more',
   dismissText: 'Dismiss',
   rowActionsError: null,
+  onClearError: null,
 };
 
 const RowActionsError = ({
   rowActionsError,
   actionFailedText,
-  // learnMoreText,
-  // dismissText
+  learnMoreText,
+  dismissText,
+  onClearError,
 }) => {
+  if (!rowActionsError) {
+    return null;
+  }
+  const { title, message, learnMoreURL } = rowActionsError;
   return rowActionsError ? (
     <Fragment>
-      <Warn />
+      <Tooltip
+        clickToOpen
+        tabIndex={0}
+        triggerText=""
+        triggerId="tooltip-error"
+        renderIcon={React.forwardRef((props, ref) => (
+          <Warn ref={ref} />
+        ))}>
+        <StyledTooltipContents>
+          <StyledTitle>{title}</StyledTitle>
+          {message}
+          <StyledTooltipFooter>
+            {learnMoreURL ? (
+              <a href={learnMoreURL} target="_blank" rel="noopener noreferrer">
+                {learnMoreText}
+              </a>
+            ) : null}
+            {onClearError ? (
+              <Button
+                onClick={evt => {
+                  onClearError(evt);
+                  evt.stopPropagation();
+                }}>
+                {dismissText}
+              </Button>
+            ) : null}
+          </StyledTooltipFooter>
+        </StyledTooltipContents>
+      </Tooltip>
       <StyledSpan>{actionFailedText}</StyledSpan>
     </Fragment>
   ) : null;

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import { DataTable } from 'carbon-components-react';
 import pick from 'lodash/pick';
 
-import { ExpandedRowsPropTypes, TableRowPropTypes, TableColumnsPropTypes } from '../TablePropTypes';
+import {
+  ExpandedRowsPropTypes,
+  TableRowPropTypes,
+  TableColumnsPropTypes,
+  RowActionsStatePropTypes,
+} from '../TablePropTypes';
 
 import TableBodyRow from './TableBodyRow/TableBodyRow';
 
@@ -31,6 +36,8 @@ const propTypes = {
   hasRowExpansion: PropTypes.bool,
   hasRowNesting: PropTypes.bool,
   hasRowActions: PropTypes.bool,
+  /** the current state of the row actions */
+  rowActionsState: RowActionsStatePropTypes,
   shouldExpandOnRowClick: PropTypes.bool,
 
   actions: PropTypes.shape({
@@ -58,6 +65,7 @@ const defaultProps = {
   clickToCollapseText: 'Click to collapse.',
   rows: [],
   expandedRows: [],
+  rowActionsState: [],
   columns: [],
   totalColumns: 0,
   hasRowSelection: '',
@@ -80,6 +88,7 @@ const TableBody = ({
   clickToCollapseText,
   totalColumns,
   actions,
+  rowActionsState,
   hasRowActions,
   hasRowSelection,
   hasRowExpansion,
@@ -101,6 +110,7 @@ const TableBody = ({
     const isRowExpanded = expandedIds.includes(row.id);
     const shouldShowChildren =
       hasRowNesting && isRowExpanded && row.children && row.children.length > 0;
+    const myRowActionState = rowActionsState.find(rowAction => rowAction.rowId === row.id);
     const rowElement = (
       <TableBodyRow
         key={row.id}
@@ -111,6 +121,8 @@ const TableBody = ({
             ? expandedRows.find(j => j.rowId === row.id).content
             : null
         }
+        rowActionsError={myRowActionState ? myRowActionState.error : null}
+        isRowActionRunning={myRowActionState ? myRowActionState.isRunning : null}
         ordering={orderingMap}
         selectRowText={selectRowText}
         overflowMenuText={overflowMenuText}

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -136,9 +136,9 @@ const TableBody = ({
           'onRowExpanded',
           'onRowClicked'
         )}
-        rowActions={row.rowActions}>
-        {row.values}
-      </TableBodyRow>
+        rowActions={row.rowActions}
+        values={row.values}
+      />
     );
     return shouldShowChildren
       ? [rowElement].concat(row.children.map(childRow => renderRow(childRow, nestingLevel + 1)))

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -146,7 +146,8 @@ const TableBody = ({
           'onRowSelected',
           'onApplyRowAction',
           'onRowExpanded',
-          'onRowClicked'
+          'onRowClicked',
+          'onClearRowError'
         )}
         rowActions={row.rowActions}
         values={row.values}

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -6,7 +6,11 @@ import styled from 'styled-components';
 import { COLORS } from '../../../../styles/styles';
 import RowActionsCell from '../RowActionsCell/RowActionsCell';
 import TableCellRenderer from '../../TableCellRenderer/TableCellRenderer';
-import { RowActionPropTypes, TableColumnsPropTypes } from '../../TablePropTypes';
+import {
+  RowActionPropTypes,
+  RowActionErrorPropTypes,
+  TableColumnsPropTypes,
+} from '../../TablePropTypes';
 import { stopPropagationAndCallback } from '../../../../utils/componentUtilityFunctions';
 
 const { TableRow, TableExpandRow, TableCell } = DataTable;
@@ -53,7 +57,7 @@ const propTypes = {
   /** table Id */
   tableId: PropTypes.string.isRequired,
   /** contents of the row each object value is a renderable node keyed by column id */
-  children: PropTypes.objectOf(PropTypes.node).isRequired,
+  values: PropTypes.objectOf(PropTypes.node).isRequired,
 
   /** is the row currently selected */
   isSelected: PropTypes.bool,
@@ -75,6 +79,18 @@ const propTypes = {
   }).isRequired,
   /** optional per-row actions */
   rowActions: RowActionPropTypes,
+  /** Is a row action actively running */
+  isRowActionRunning: PropTypes.bool,
+  /** has a row action errored out */
+  rowActionsError: RowActionErrorPropTypes,
+  /** I18N label for in progress */
+  inProgressText: PropTypes.string,
+  /** I18N label for action failed */
+  actionFailedText: PropTypes.string,
+  /** I18N label for learn more */
+  learnMoreText: PropTypes.string,
+  /** I18N label for dismiss */
+  dismissText: PropTypes.string,
 };
 
 const defaultProps = {
@@ -102,6 +118,7 @@ const StyledTableRow = styled(TableRow)`
   &&& {
     :hover {
       td {
+        /* show the row actions if the table row is hovered over */
         div > * {
           opacity: 1;
         }
@@ -281,10 +298,12 @@ const TableBodyRow = ({
   overflowMenuText,
   clickToExpandText,
   clickToCollapseText,
-  children,
+  values,
   nestingLevel,
   nestingChildCount,
   rowActions,
+  isRowActionRunning,
+  rowActionsError,
   rowDetails,
 }) => {
   const nestingOffset = nestingLevel * 16;
@@ -330,13 +349,13 @@ const TableBodyRow = ({
               {col.renderDataFunction ? (
                 col.renderDataFunction({
                   // Call the column renderer if it's provided
-                  value: children[col.columnId],
+                  value: values[col.columnId],
                   columnId: col.columnId,
                   rowId: id,
-                  row: children,
+                  row: values,
                 })
               ) : (
-                <TableCellRenderer>{children[col.columnId]}</TableCellRenderer>
+                <TableCellRenderer>{values[col.columnId]}</TableCellRenderer>
               )}
             </StyledNestedSpan>
           </StyledTableCellRow>
@@ -346,9 +365,11 @@ const TableBodyRow = ({
         <RowActionsCell
           id={id}
           actions={rowActions}
+          isRowActionRunning={isRowActionRunning}
           isRowExpanded={isExpanded && !hasRowNesting}
           overflowMenuText={overflowMenuText}
           onApplyRowAction={onApplyRowAction}
+          rowActionsError={rowActionsError}
         />
       ) : nestingLevel > 0 && hasRowActions ? (
         <TableCell key={`${id}-row-actions-cell`} />

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -291,7 +291,7 @@ const TableBodyRow = ({
     hasRowNesting,
     shouldExpandOnRowClick,
   },
-  tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction },
+  tableActions: { onRowSelected, onRowExpanded, onRowClicked, onApplyRowAction, onClearRowError },
   isExpanded,
   isSelected,
   selectRowText,
@@ -370,6 +370,7 @@ const TableBodyRow = ({
           overflowMenuText={overflowMenuText}
           onApplyRowAction={onApplyRowAction}
           rowActionsError={rowActionsError}
+          onClearError={onClearRowError ? () => onClearRowError(id) : null}
         />
       ) : nestingLevel > 0 && hasRowActions ? (
         <TableCell key={`${id}-row-actions-cell`} />

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -15,7 +15,13 @@ const tableBodyRowProps = {
   totalColumns: 1,
   tableId: 'tableId',
   values: { string: 'My String' },
-  tableActions: actions('onRowSelected', 'onRowClicked', 'onApplyRowAction', 'onRowExpanded'),
+  tableActions: actions(
+    'onRowSelected',
+    'onRowClicked',
+    'onApplyRowAction',
+    'onRowExpanded',
+    'onClearRowError'
+  ),
 };
 
 const TableDecorator = storyFn => (
@@ -51,7 +57,11 @@ storiesOf('TableBodyRow', module)
       {...tableBodyRowProps}
       rowActions={[{ id: 'add', icon: 'icon--add' }]}
       options={{ hasRowActions: true, hasRowExpansion: true }}
-      rowActionsError={{ title: 'Import failed:', message: 'Model type not currently supported.' }}
+      rowActionsError={{
+        title: 'Import failed:',
+        message: 'Model type not currently supported.',
+        learnMoreURL: 'http://www.cnn.com',
+      }}
       isExpanded={boolean('isExpanded', false)}
     />
   ));

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { actions } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+import { DataTable } from 'carbon-components-react';
+
+import TableBodyRow from './TableBodyRow';
+
+const { Table, TableContainer, TableBody } = DataTable;
+
+const tableBodyRowProps = {
+  ordering: [{ columnId: 'string' }],
+  columns: [{ id: 'string', name: 'String' }],
+  id: 'rowId',
+  totalColumns: 1,
+  tableId: 'tableId',
+  values: { string: 'My String' },
+  tableActions: actions('onRowSelected', 'onRowClicked', 'onApplyRowAction', 'onRowExpanded'),
+};
+
+const TableDecorator = storyFn => (
+  <TableContainer>
+    <Table>
+      <TableBody>{storyFn()}</TableBody>
+    </Table>
+  </TableContainer>
+);
+storiesOf('TableBodyRow', module)
+  // Table rows need to be rendered in a tbody or else they'll throw an error
+  .addDecorator(TableDecorator)
+  .add('normal', () => <TableBodyRow {...tableBodyRowProps} />)
+  .add('rowActions', () => (
+    <TableBodyRow
+      {...tableBodyRowProps}
+      isExpanded={boolean('isExpanded', false)}
+      rowActions={[{ id: 'add', icon: 'icon--add' }]}
+      options={{ hasRowActions: true, hasRowExpansion: true }}
+    />
+  ))
+  .add('rowActions running', () => (
+    <TableBodyRow
+      {...tableBodyRowProps}
+      rowActions={[{ id: 'add', icon: 'icon--add' }]}
+      options={{ hasRowActions: true, hasRowExpansion: true }}
+      isRowActionRunning
+      isExpanded={boolean('isExpanded', false)}
+    />
+  ))
+  .add('rowActions error', () => (
+    <TableBodyRow
+      {...tableBodyRowProps}
+      rowActions={[{ id: 'add', icon: 'icon--add' }]}
+      options={{ hasRowActions: true, hasRowExpansion: true }}
+      rowActionsError={{ title: 'Import failed:', message: 'Model type not currently supported.' }}
+      isExpanded={boolean('isExpanded', false)}
+    />
+  ));

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -15,7 +15,7 @@ const tableRowProps = {
   totalColumns: 1,
   id: 'tableRow',
   ordering: [{ columnId: 'col1', isHidden: false }],
-  children: { col1: 'value1' },
+  values: { col1: 'value1' },
 };
 
 describe('TableBodyRow', () => {
@@ -66,7 +66,7 @@ describe('TableBodyRow', () => {
       id: 'tableRow',
       columns: [{ id: 'col1' }, { id: 'col2' }],
       ordering: [{ columnId: 'col1' }, { columnId: 'col2' }],
-      children: { col1: 'value1', col2: undefined },
+      values: { col1: 'value1', col2: undefined },
     };
     const wrapper = mount(
       <TableBodyRow tableActions={mockActions} {...tableRowPropsWithUndefined} />
@@ -87,7 +87,7 @@ describe('TableBodyRow', () => {
         { columnId: 'col1', renderDataFunction: customRenderDataFunction },
         { columnId: 'col2' },
       ],
-      children: { col1: 'value1', col2: 'value2' },
+      values: { col1: 'value1', col2: 'value2' },
     };
     const wrapper = mount(
       <TableBodyRow
@@ -115,7 +115,7 @@ describe('TableBodyRow', () => {
       tableActions: { onRowSelected: mockRowSelection, onRowClicked: mockRowClicked },
       columns: [{ id: 'col1' }, { id: 'col2' }],
       ordering: [{ columnId: 'col1' }, { columnId: 'col2' }],
-      children: { col1: 'value1', col2: undefined },
+      values: { col1: 'value1', col2: undefined },
     };
     const wrapper = mount(
       <TableBodyRow tableActions={mockActions} {...tableRowPropsWithSelection} />

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -28,6 +28,14 @@ export const RowActionErrorPropTypes = PropTypes.shape({
   learnMoreURL: PropTypes.string,
 });
 
+export const RowActionsStatePropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    rowId: PropTypes.string,
+    isRunning: PropTypes.bool,
+    error: RowActionErrorPropTypes,
+  })
+);
+
 export const EmptyStatePropTypes = PropTypes.oneOfType([
   PropTypes.shape({
     message: PropTypes.string.isRequired,

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -22,6 +22,12 @@ export const RowActionPropTypes = PropTypes.arrayOf(
   })
 );
 
+export const RowActionErrorPropTypes = PropTypes.shape({
+  title: PropTypes.node,
+  message: PropTypes.node,
+  learnMoreURL: PropTypes.string,
+});
+
 export const EmptyStatePropTypes = PropTypes.oneOfType([
   PropTypes.shape({
     message: PropTypes.string.isRequired,

--- a/src/components/Table/baseTableReducer.js
+++ b/src/components/Table/baseTableReducer.js
@@ -10,6 +10,9 @@ import {
   TABLE_COLUMN_SORT,
   TABLE_ROW_SELECT,
   TABLE_ROW_SELECT_ALL,
+  TABLE_ROW_ACTION_START,
+  TABLE_ROW_ACTION_COMPLETE,
+  TABLE_ROW_ACTION_ERROR,
   TABLE_ROW_EXPAND,
   TABLE_COLUMN_ORDER,
   TABLE_SEARCH_APPLY,
@@ -132,6 +135,43 @@ export const baseTableReducer = (state = {}, action) => {
         },
       });
     }
+    // Row Actions
+    case TABLE_ROW_ACTION_START:
+      return update(state, {
+        view: {
+          table: {
+            // add the in progress row
+            rowActions: { $push: [{ rowId: action.payload, isRunning: true }] },
+          },
+        },
+      });
+    case TABLE_ROW_ACTION_COMPLETE: {
+      const index = state.view.table.rowActions.findIndex(
+        rowAction => rowAction.rowId === action.payload
+      );
+      return update(state, {
+        view: {
+          table: {
+            // remove the finished row
+            rowActions: { $splice: [[index, 1]] },
+          },
+        },
+      });
+    }
+    case TABLE_ROW_ACTION_ERROR: {
+      const index = state.view.table.rowActions.findIndex(
+        rowAction => rowAction.rowId === action.payload
+      );
+      return update(state, {
+        view: {
+          table: {
+            // replace the row with the error
+            rowActions: { $splice: [[index, 1, { rowId: action.payload, error: action.error }]] },
+          },
+        },
+      });
+    }
+
     // Column operations
     case TABLE_COLUMN_SORT: {
       // TODO should check that columnId actually is valid

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -7,13 +7,13 @@ export const TABLE_ACTION_CANCEL = 'TABLE_ACTION_CANCEL';
 export const TABLE_ACTION_APPLY = 'TABLE_ACTION_APPLY';
 export const TABLE_ROW_ACTION_START = 'TABLE_ROW_ACTION_START';
 export const TABLE_ROW_ACTION_COMPLETE = 'TABLE_ROW_ACTION_COMPLETE';
+export const TABLE_ROW_ACTION_ERROR = 'TABLE_ROW_ACTION_ERROR';
 export const TABLE_COLUMN_SORT = 'TABLE_COLUMN_SORT';
 export const TABLE_COLUMN_ORDER = 'TABLE_COLUMN_ORDER';
 export const TABLE_ROW_SELECT = 'TABLE_ROW_SELECT';
 export const TABLE_ROW_SELECT_ALL = 'TABLE_ROW_SELECT_ALL';
 export const TABLE_ROW_CLICK = 'TABLE_ROW_CLICK';
 export const TABLE_ROW_EXPAND = 'TABLE_ROW_EXPAND';
-export const TABLE_ROW_ACTION_APPLY = 'TABLE_ROW_ACTION_APPLY';
 export const TABLE_SEARCH_APPLY = 'TABLE_SEARCH_APPLY';
 export const TABLE_EMPTY_STATE_ACTION = 'TABLE_EMPTY_STATE_ACTION';
 export const TABLE_LOADING_SET = 'TABLE_LOADING_SET';
@@ -40,7 +40,15 @@ export const tableColumnOrder = ordering => ({ type: TABLE_COLUMN_ORDER, payload
 export const tableEmptyStateAction = () => ({ type: TABLE_EMPTY_STATE_ACTION });
 /** Table row actions */
 export const tableRowActionStart = rowId => ({ type: TABLE_ROW_ACTION_START, payload: rowId });
-export const tableRowActionComplete = rowId => ({ type: TABLE_ACTION_APPLY, payload: rowId });
+export const tableRowActionComplete = rowId => ({
+  type: TABLE_ROW_ACTION_COMPLETE,
+  payload: rowId,
+});
+export const tableRowActionError = (rowId, error) => ({
+  type: TABLE_ROW_ACTION_ERROR,
+  payload: rowId,
+  error,
+});
 
 /** Select a row of the table */
 export const tableRowSelect = (rowId, isSelected, hasRowSelection) => ({
@@ -59,10 +67,6 @@ export const tableRowClick = rowId => ({
 export const tableRowExpand = (rowId, isExpanded) => ({
   type: TABLE_ROW_EXPAND,
   payload: { rowId, isExpanded },
-});
-export const tableRowActionApply = (rowId, actionId) => ({
-  type: TABLE_ROW_ACTION_APPLY,
-  payload: { rowId, actionId },
 });
 
 /**

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -5,6 +5,8 @@ export const TABLE_FILTER_CLEAR = 'TABLE_FILTER_CLEAR';
 export const TABLE_TOOLBAR_TOGGLE = 'TABLE_TOOLBAR_TOGGLE';
 export const TABLE_ACTION_CANCEL = 'TABLE_ACTION_CANCEL';
 export const TABLE_ACTION_APPLY = 'TABLE_ACTION_APPLY';
+export const TABLE_ROW_ACTION_START = 'TABLE_ROW_ACTION_START';
+export const TABLE_ROW_ACTION_COMPLETE = 'TABLE_ROW_ACTION_COMPLETE';
 export const TABLE_COLUMN_SORT = 'TABLE_COLUMN_SORT';
 export const TABLE_COLUMN_ORDER = 'TABLE_COLUMN_ORDER';
 export const TABLE_ROW_SELECT = 'TABLE_ROW_SELECT';
@@ -36,6 +38,9 @@ export const tableColumnSort = column => ({ type: TABLE_COLUMN_SORT, payload: co
 export const tableColumnOrder = ordering => ({ type: TABLE_COLUMN_ORDER, payload: ordering });
 /** Table empty state action */
 export const tableEmptyStateAction = () => ({ type: TABLE_EMPTY_STATE_ACTION });
+/** Table row actions */
+export const tableRowActionStart = rowId => ({ type: TABLE_ROW_ACTION_START, payload: rowId });
+export const tableRowActionComplete = rowId => ({ type: TABLE_ACTION_APPLY, payload: rowId });
 
 /** Select a row of the table */
 export const tableRowSelect = (rowId, isSelected, hasRowSelection) => ({

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -16,6 +16,8 @@ import {
   TABLE_ROW_SELECT,
   TABLE_ROW_SELECT_ALL,
   TABLE_ROW_EXPAND,
+  TABLE_ROW_ACTION_START,
+  TABLE_ROW_ACTION_COMPLETE,
   TABLE_COLUMN_ORDER,
   TABLE_REGISTER,
   TABLE_SEARCH_APPLY,
@@ -146,6 +148,10 @@ export const tableReducer = (state = {}, action) => {
         action
       );
     }
+    // Row actions
+    case TABLE_ROW_ACTION_START:
+    case TABLE_ROW_ACTION_COMPLETE:
+      return state;
     // Toolbar Actions
     case TABLE_TOOLBAR_TOGGLE:
       return baseTableReducer(state, action);

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -18,6 +18,7 @@ import {
   TABLE_ROW_EXPAND,
   TABLE_ROW_ACTION_START,
   TABLE_ROW_ACTION_COMPLETE,
+  TABLE_ROW_ACTION_ERROR,
   TABLE_COLUMN_ORDER,
   TABLE_REGISTER,
   TABLE_SEARCH_APPLY,
@@ -73,11 +74,9 @@ export const filterSearchAndSort = (data, sort = {}, search = {}, filters = []) 
   return !isEmpty(sort) ? getSortedData(searchedData, columnId, direction) : searchedData;
 };
 
+/** This reducer handles sort, filter and search that needs data otherwise it proxies for the baseTableReducer */
 export const tableReducer = (state = {}, action) => {
   switch (action.type) {
-    // Page Actions
-    case TABLE_PAGE_CHANGE:
-      return baseTableReducer(state, action);
     // Filter Actions
     case TABLE_FILTER_APPLY: {
       const newFilters = Object.entries(action.payload)
@@ -148,13 +147,7 @@ export const tableReducer = (state = {}, action) => {
         action
       );
     }
-    // Row actions
-    case TABLE_ROW_ACTION_START:
-    case TABLE_ROW_ACTION_COMPLETE:
-      return state;
-    // Toolbar Actions
-    case TABLE_TOOLBAR_TOGGLE:
-      return baseTableReducer(state, action);
+
     // Batch Actions
     case TABLE_ACTION_CANCEL:
       return baseTableReducer(state, action);
@@ -210,8 +203,7 @@ export const tableReducer = (state = {}, action) => {
         action
       );
     }
-    case TABLE_COLUMN_ORDER:
-      return baseTableReducer(state, action);
+
     case TABLE_ROW_SELECT: {
       const data = state.view.table.filteredData || state.data;
       return baseTableReducer({ ...state, data }, action);
@@ -220,8 +212,6 @@ export const tableReducer = (state = {}, action) => {
       const data = state.view.table.filteredData || state.data;
       return baseTableReducer({ ...state, data }, action);
     }
-    case TABLE_ROW_EXPAND:
-      return baseTableReducer(state, action);
     // By default we need to setup our sorted and filteredData and turn off the loading state
     case TABLE_REGISTER: {
       const updatedData = action.payload.data || state.data;
@@ -249,6 +239,15 @@ export const tableReducer = (state = {}, action) => {
         },
       });
     }
+    // Actions that are handled by the base reducer
+    case TABLE_PAGE_CHANGE:
+    case TABLE_ROW_ACTION_START:
+    case TABLE_ROW_ACTION_COMPLETE:
+    case TABLE_ROW_ACTION_ERROR:
+    case TABLE_TOOLBAR_TOGGLE:
+    case TABLE_COLUMN_ORDER:
+    case TABLE_ROW_EXPAND:
+      return baseTableReducer(state, action);
     default:
       return state;
   }

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -16,12 +16,37 @@ import {
   tableRowSelectAll,
   tableRowExpand,
   tableSearchApply,
+  tableRowActionStart,
+  tableRowActionComplete,
+  tableRowActionError,
 } from './tableActionCreators';
 import { initialState, tableColumns } from './Table.story';
 
 describe('table reducer testcases', () => {
   test('nothing', () => {
     expect(tableReducer(undefined, { type: 'BOGUS' })).toEqual({});
+  });
+  describe('row action tests', () => {
+    const updatedRowActionState = tableReducer(initialState, tableRowActionStart('row-1'));
+    const newRowActions = updatedRowActionState.view.table.rowActions;
+    expect(newRowActions).toHaveLength(1);
+    expect(newRowActions[0].rowId).toEqual('row-1');
+    expect(newRowActions[0].isRunning).toEqual(true);
+
+    // Set the error for the running one
+    const updatedRowActionState2 = tableReducer(
+      updatedRowActionState,
+      tableRowActionError('row-1', 'error')
+    );
+    const newRowActions2 = updatedRowActionState2.view.table.rowActions;
+    expect(newRowActions2).toHaveLength(1);
+    expect(newRowActions2[0].rowId).toEqual('row-1');
+    expect(newRowActions2[0].error).toEqual('error');
+
+    // Clear the action
+    const updatedRowActionState3 = tableReducer(initialState, tableRowActionComplete('row-1'));
+    const newRowActions3 = updatedRowActionState3.view.table.rowActions;
+    expect(newRowActions3).toHaveLength(0);
   });
   describe('filter tests', () => {
     test('TABLE_FILTER_CLEAR', () => {


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Adds actions, reducers and props and StatefulTable support to allow for async row actions

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#128 
- Closes IBM/carbon-addons-iot-react#129 

**Acceptance Test (how to verify the PR)**

- Verify the new async row actions story runs the spinner for 3 seconds before completing
