### PR TITLE
feat(table): add option to only pass data in visible page

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -63,6 +63,8 @@ const propTypes = {
     hasRowNesting: PropTypes.bool,
     hasRowActions: PropTypes.bool,
     hasFilter: PropTypes.bool,
+    /** if true, the data prop will be assumed to only represent the currently visible page */
+    hasOnlyPageData: PropTypes.bool,
     /** has simple search capability */
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
@@ -178,6 +180,7 @@ export const defaultProps = baseProps => ({
     hasRowActions: false,
     hasRowNesting: false,
     hasFilter: false,
+    hasOnlyPageData: false,
     hasSearch: false,
     hasColumnSelection: false,
   },
@@ -282,11 +285,11 @@ const Table = props => {
   };
 
   const minItemInView =
-    options.hasPagination && view.pagination
+    options.hasPagination && !options.hasOnlyPageData && view.pagination
       ? (view.pagination.page - 1) * view.pagination.pageSize
       : 0;
   const maxItemInView =
-    options.hasPagination && view.pagination
+    options.hasPagination && !options.hasOnlyPageData && view.pagination
       ? view.pagination.page * view.pagination.pageSize
       : data.length;
   const visibleData = data.slice(minItemInView, maxItemInView);

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -1067,6 +1067,34 @@ storiesOf('Table', module)
       lightweight={boolean('lightweight', true)}
     />
   ))
+  .add(
+    'with hasOnlyPageData',
+    () => {
+      return (
+        <Table
+          columns={tableColumns}
+          options={{ hasOnlyPageData: true, hasPagination: true }}
+          data={tableData.slice(25, 35)} // this isn't the "8267th page", but we just want to indicate that it is not the first page of data
+          actions={actions}
+          view={{
+            pagination: {
+              pageSize: 10,
+              pageSizes: [10, 20, 30],
+              page: 8267,
+              totalItems: 97532,
+            },
+          }}
+        />
+      );
+    },
+    {
+      info: {
+        text:
+          'By default, tables with pagination will expect the entire table data to be passed in on the `data` prop; the visible data for a page is calculated dynamically by the table based on the page size and page number.  In the case where the table is rendering a large data set, the `options.hasOnlyPageData` prop can be used change this behavior.  With `options.hasOnlyPageData = true`, the `data` prop will be expected to contain only the rows for the visible page.',
+        source: true,
+      },
+    }
+  )
   .add('horizontal scroll - custom width', () => {
     const tableColumnsConcat = [
       { id: 'test2', name: 'Test 2' },


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

Added a prop `hasOnlyPageData` that allows a user to pass just the `data` that is currently in the page view, rather than passing the entire set and letting the Table do pagination.  Useful for cases where the table has massive datasets and everything should be lazily-loaded.

![image](https://user-images.githubusercontent.com/2175647/57485309-0018b180-7271-11e9-97d5-785d074fa971.png)

**Related Issues**

- Closes IBM/carbon-addons-iot-react#186

**Acceptance Test (how to verify the PR)**

- Verify paging works in the stateful examples, and the new example ("with hasOnlyPageData") looks good