### PR TITLE
fix(table): clear selection when data changes

### DIFF
--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -235,6 +235,16 @@ export const tableReducer = (state = {}, action) => {
                 rowCount: updatedData ? updatedData.length : 0,
               },
             },
+            // Clear selection if the data changes
+            selectedIds: {
+              $set: [],
+            },
+            isSelectAllIndeterminate: {
+              $set: false,
+            },
+            isSelectAllSelected: {
+              $set: false,
+            },
           },
         },
       });

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -272,11 +272,15 @@ describe('table reducer testcases', () => {
       // Data should be filtered once table registers
       expect(initialState.view.table.filteredData).toBeUndefined();
       const tableWithFilteredData = tableReducer(
-        initialState,
+        merge({}, initialState, {
+          view: { table: { isSelectAllSelected: true, isSelectAllIndeterminate: true } },
+        }),
         tableRegister({ data: initialState.data, isLoading: false })
       );
       expect(tableWithFilteredData.data).toEqual(initialState.data);
       expect(tableWithFilteredData.view.table.filteredData.length).toBeGreaterThan(0);
+      expect(tableWithFilteredData.view.table.isSelectAllSelected).toEqual(false);
+      expect(tableWithFilteredData.view.table.isSelectAllIndeterminate).toEqual(false);
       expect(tableWithFilteredData.view.table.filteredData.length).not.toEqual(
         initialState.data.length
       );


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Clear multiple selection row when data changes

Closes #236

**Acceptance Test (how to verify the PR)**

- Verify that if you select rows then delete other rows, that the selection is cleared
