### PR TITLE
Fix tilecatalog selection

### DIFF
--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -235,6 +235,16 @@ export const tableReducer = (state = {}, action) => {
                 rowCount: updatedData ? updatedData.length : 0,
               },
             },
+            // Clear selection if the data changes
+            selectedIds: {
+              $set: [],
+            },
+            isSelectAllIndeterminate: {
+              $set: false,
+            },
+            isSelectAllSelected: {
+              $set: false,
+            },
           },
         },
       });

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -272,11 +272,15 @@ describe('table reducer testcases', () => {
       // Data should be filtered once table registers
       expect(initialState.view.table.filteredData).toBeUndefined();
       const tableWithFilteredData = tableReducer(
-        initialState,
+        merge({}, initialState, {
+          view: { table: { isSelectAllSelected: true, isSelectAllIndeterminate: true } },
+        }),
         tableRegister({ data: initialState.data, isLoading: false })
       );
       expect(tableWithFilteredData.data).toEqual(initialState.data);
       expect(tableWithFilteredData.view.table.filteredData.length).toBeGreaterThan(0);
+      expect(tableWithFilteredData.view.table.isSelectAllSelected).toEqual(false);
+      expect(tableWithFilteredData.view.table.isSelectAllIndeterminate).toEqual(false);
       expect(tableWithFilteredData.view.table.filteredData.length).not.toEqual(
         initialState.data.length
       );

--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -42,6 +42,10 @@ const StatefulTileCatalog = ({
           pagination,
         },
       });
+      // If we totally change the tiles data, we should generate a selection event for the initial default selection
+      if (onSelection && tilesProp.length > 0 && !selectedTileIdProp) {
+        onSelection(tilesProp[0].id);
+      }
     },
     [tilesProp.map(tile => omit(tile, 'renderContent'))]
   );

--- a/src/components/TileCatalog/StatefulTileCatalog.test.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.test.jsx
@@ -35,10 +35,10 @@ describe('StatefulTileCatalog', () => {
     expect(mockSearch).toHaveBeenCalledWith(value);
   });
   test('handles Clicking on option', () => {
-    mockOnSelection.mockClear();
     const wrapper = mount(<StatefulTileCatalog {...commonTileProps} />);
     // Need to use at to get a new ReactWrapper
     const tileInput = wrapper.find('input[type="radio"]').at(0);
+    mockOnSelection.mockClear();
     tileInput.simulate('change');
     expect(mockOnSelection).toHaveBeenCalledTimes(1);
     expect(mockOnSelection).toHaveBeenCalledWith('test1');
@@ -102,6 +102,7 @@ describe('StatefulTileCatalog', () => {
 
     const newTiles = commonTileProps.tiles.slice(1, 5);
     // Back to Page 1
+    mockOnSelection.mockClear();
     wrapper.setProps({ tiles: newTiles });
     wrapper.update();
     expect(
@@ -110,6 +111,9 @@ describe('StatefulTileCatalog', () => {
         .at(1)
         .text()
     ).toContain('Page 1');
+
+    // Needs to have called the selection callback for the newly default selected row
+    expect(mockOnSelection).toHaveBeenCalledTimes(1);
 
     // The new first tile should be selected
     expect(


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- bug where the initial tile selection callback isn't being made when the data changes

**Change List (commits, features, bugs, etc)**

- need to fire the onSelection callback event if the default selection is made

**Acceptance Test (how to verify the PR)**

- Validate on any story where we're not passing a selectedTileID, that the initial render generates a selection callback in the actions panel.  For example in the TileCatalog async loaded one:

![image](https://user-images.githubusercontent.com/6663002/57526243-26038c00-732d-11e9-8718-cc2aee4087ef.png)

