### PR TITLE
feat(table): add optional filtering actions by instance id

### DIFF
--- a/src/components/Table/StatefulTableMockReducers.test.jsx
+++ b/src/components/Table/StatefulTableMockReducers.test.jsx
@@ -38,12 +38,14 @@ describe('StatefulTable tests with Mock reducer', () => {
     // First we're called by empty array
     expect(mockDispatch).toHaveBeenCalledWith({
       payload: { data: [], isLoading: undefined },
+      instanceId: null,
       type: 'TABLE_REGISTER',
     });
     statefulTable.setProps({ data: initialState.data });
     // Then table dispatches another item with the real data
     expect(mockDispatch).toHaveBeenCalledWith({
       payload: { data: initialState.data, isLoading: undefined },
+      instanceId: null,
       type: 'TABLE_REGISTER',
     });
   });

--- a/src/components/Table/baseTableReducer.js
+++ b/src/components/Table/baseTableReducer.js
@@ -20,6 +20,13 @@ import {
 } from './tableActionCreators';
 
 export const baseTableReducer = (state = {}, action) => {
+  // To support instance matching (i.e. multiple table states in one store), just ensure
+  // that a instanceId is provided on state passed to baseTableReducer.  If no instanceId
+  // is provided, all matching actions will be processed by this table reducer.
+  if (typeof action.instanceId === 'string' && action.instanceId !== state.instanceId) {
+    return state;
+  }
+
   switch (action.type) {
     // Page Actions
     case TABLE_PAGE_CHANGE: {

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -18,7 +18,6 @@ export const TABLE_SEARCH_APPLY = 'TABLE_SEARCH_APPLY';
 export const TABLE_EMPTY_STATE_ACTION = 'TABLE_EMPTY_STATE_ACTION';
 export const TABLE_LOADING_SET = 'TABLE_LOADING_SET';
 
-/** Set initial data and provide instanceId if supporting multiple tables */
 export const tableRegister = (data, totalItems, instanceId = null) => ({
   type: TABLE_REGISTER,
   payload: data,

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -18,61 +18,121 @@ export const TABLE_SEARCH_APPLY = 'TABLE_SEARCH_APPLY';
 export const TABLE_EMPTY_STATE_ACTION = 'TABLE_EMPTY_STATE_ACTION';
 export const TABLE_LOADING_SET = 'TABLE_LOADING_SET';
 
-export const tableRegister = (data, totalItems) => ({
+/** Set initial data and provide instanceId if supporting multiple tables */
+export const tableRegister = (data, totalItems, instanceId = null) => ({
   type: TABLE_REGISTER,
   payload: data,
   totalItems,
+  instanceId,
 });
-export const tablePageChange = page => ({ type: TABLE_PAGE_CHANGE, payload: page });
-export const tableToolbarToggle = toolbar => ({ type: TABLE_TOOLBAR_TOGGLE, payload: toolbar });
-/** Apply filters */
-export const tableFilterApply = filter => ({ type: TABLE_FILTER_APPLY, payload: filter });
-export const tableFilterClear = () => ({ type: TABLE_FILTER_CLEAR });
 
-export const tableSearchApply = search => ({ type: TABLE_SEARCH_APPLY, payload: search });
+export const tablePageChange = (page, instanceId = null) => ({
+  type: TABLE_PAGE_CHANGE,
+  payload: page,
+  instanceId,
+});
+
+export const tableToolbarToggle = (toolbar, instanceId = null) => ({
+  type: TABLE_TOOLBAR_TOGGLE,
+  payload: toolbar,
+  instanceId,
+});
+
+/** Apply filters */
+export const tableFilterApply = (filter, instanceId = null) => ({
+  type: TABLE_FILTER_APPLY,
+  payload: filter,
+  instanceId,
+});
+export const tableFilterClear = (instanceId = null) => ({
+  type: TABLE_FILTER_CLEAR,
+  instanceId,
+});
+
+export const tableSearchApply = (search, instanceId = null) => ({
+  type: TABLE_SEARCH_APPLY,
+  payload: search,
+  instanceId,
+});
+
 /** Table Batch Actions */
-export const tableActionCancel = () => ({ type: TABLE_ACTION_CANCEL });
-export const tableActionApply = id => ({ type: TABLE_ACTION_APPLY, payload: id });
+export const tableActionCancel = (instanceId = null) => ({
+  type: TABLE_ACTION_CANCEL,
+  instanceId,
+});
+export const tableActionApply = (id, instanceId = null) => ({
+  type: TABLE_ACTION_APPLY,
+  payload: id,
+  instanceId,
+});
+
 /** Table column actions */
-export const tableColumnSort = column => ({ type: TABLE_COLUMN_SORT, payload: column });
-export const tableColumnOrder = ordering => ({ type: TABLE_COLUMN_ORDER, payload: ordering });
+export const tableColumnSort = (column, instanceId = null) => ({
+  type: TABLE_COLUMN_SORT,
+  payload: column,
+  instanceId,
+});
+export const tableColumnOrder = (ordering, instanceId = null) => ({
+  type: TABLE_COLUMN_ORDER,
+  payload: ordering,
+  instanceId,
+});
+
 /** Table empty state action */
-export const tableEmptyStateAction = () => ({ type: TABLE_EMPTY_STATE_ACTION });
+export const tableEmptyStateAction = (instanceId = null) => ({
+  type: TABLE_EMPTY_STATE_ACTION,
+  instanceId,
+});
+
 /** Table row actions */
-export const tableRowActionStart = rowId => ({ type: TABLE_ROW_ACTION_START, payload: rowId });
-export const tableRowActionComplete = rowId => ({
+export const tableRowActionStart = (rowId, instanceId = null) => ({
+  type: TABLE_ROW_ACTION_START,
+  payload: rowId,
+  instanceId,
+});
+export const tableRowActionComplete = (rowId, instanceId = null) => ({
   type: TABLE_ROW_ACTION_COMPLETE,
   payload: rowId,
+  instanceId,
 });
-export const tableRowActionError = (rowId, error) => ({
+export const tableRowActionError = (rowId, error, instanceId = null) => ({
   type: TABLE_ROW_ACTION_ERROR,
   payload: rowId,
   error,
+  instanceId,
 });
 
 /** Select a row of the table */
-export const tableRowSelect = (rowId, isSelected, hasRowSelection) => ({
+export const tableRowSelect = (rowId, isSelected, hasRowSelection, instanceId = null) => ({
   type: TABLE_ROW_SELECT,
   payload: { rowId, isSelected, hasRowSelection },
+  instanceId,
 });
+
 /** Select all the currently filtered rows of the table */
-export const tableRowSelectAll = isSelected => ({
+export const tableRowSelectAll = (isSelected, instanceId = null) => ({
   type: TABLE_ROW_SELECT_ALL,
   payload: { isSelected },
+  instanceId,
 });
-export const tableRowClick = rowId => ({
+
+export const tableRowClick = (rowId, instanceId = null) => ({
   type: TABLE_ROW_CLICK,
   payload: { rowId },
+  instanceId,
 });
-export const tableRowExpand = (rowId, isExpanded) => ({
+
+export const tableRowExpand = (rowId, isExpanded, instanceId = null) => ({
   type: TABLE_ROW_EXPAND,
   payload: { rowId, isExpanded },
+  instanceId,
 });
 
 /**
  * rowCount: The number of rows currently being loaded
  */
-export const tableLoadingSet = (isLoading, rowCount) => ({
+export const tableLoadingSet = (isLoading, rowCount, instanceId = null) => ({
   type: TABLE_LOADING_SET,
   payload: { isLoading, rowCount },
+  instanceId,
 });


### PR DESCRIPTION
**Summary**

In cases where applications consume the Table's baseTableReducer (in redux, for example) to customize sorting and filtering logic, there are often cases where multiple table instance states reside in the same store.  This PR adds an `instanceId` property to each action creator function, and (if `instanceId` is passed in to the baseTableReducer state) will process actions only if the `instanceId` matches.

**Acceptance Test (how to verify the PR)**

- Verify that the StatefulTable behaves as expected.  No `instanceId` was provided in the reducer used by this component.
