### PR TITLE
Fix table column is filterable

### DIFF
--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -185,64 +185,76 @@ class FilterHeaderRow extends Component {
           .map(c => {
             const column = columns.find(i => c.columnId === i.id);
             const columnStateValue = this.state[column.id]; // eslint-disable-line
+
+            let child;
+            // undefined check has the effect of making isFilterable default to true
+            // if unspecified
+            if (column.isFilterable !== undefined && !column.isFilterable) {
+              child = <div />;
+            } else if (column.options) {
+              child = (
+                <ComboBox
+                  aria-label={filterText}
+                  translateWithId={this.handleTranslation}
+                  items={column.options}
+                  itemToString={item => (item ? item.text : '')}
+                  initialSelectedItem={{
+                    id: columnStateValue,
+                    text: (column.options.find(i => i.id === columnStateValue) || { text: '' })
+                      .text, // eslint-disable-line react/destructuring-assignment
+                  }}
+                  placeholder={column.placeholderText || 'Choose an option'}
+                  onChange={evt => {
+                    this.setState(
+                      state => ({
+                        ...state,
+                        [column.id]: evt.selectedItem === null ? '' : evt.selectedItem.id,
+                      }),
+                      this.handleApplyFilter
+                    );
+                  }}
+                  light={!lightweight}
+                />
+              );
+            } else {
+              child = (
+                <StyledFormItem>
+                  <TextInput
+                    id={column.id}
+                    labelText={column.id}
+                    hideLabel
+                    light={!lightweight}
+                    placeholder={column.placeholderText || 'Type and hit enter to apply'}
+                    onKeyDown={event => handleEnterKeyDown(event, this.handleApplyFilter)}
+                    onBlur={this.handleApplyFilter}
+                    onChange={event => this.setState({ [column.id]: event.target.value })}
+                    value={this.state[column.id]} // eslint-disable-line react/destructuring-assignment
+                  />
+                  {this.state[column.id] ? ( // eslint-disable-line react/destructuring-assignment
+                    <div
+                      role="button"
+                      className="bx--list-box__selection"
+                      tabIndex="0"
+                      onClick={event => {
+                        this.handleClearFilter(event, column);
+                      }}
+                      onKeyDown={event => {
+                        this.handleClearFilter(event, column);
+                      }}
+                      title={clearFilterText}>
+                      <Icon icon={iconClose} description={clearFilterText} focusable="false" />
+                    </div>
+                  ) : null}
+                </StyledFormItem>
+              );
+            }
+
             return (
               <StyledTableHeader
                 data-column={column.id}
                 key={`FilterHeader${column.id}`}
                 width={column.width}>
-                {column.options ? (
-                  <ComboBox
-                    aria-label={filterText}
-                    translateWithId={this.handleTranslation}
-                    items={column.options}
-                    itemToString={item => (item ? item.text : '')}
-                    initialSelectedItem={{
-                      id: columnStateValue,
-                      text: (column.options.find(i => i.id === columnStateValue) || { text: '' })
-                        .text, // eslint-disable-line react/destructuring-assignment
-                    }}
-                    placeholder={column.placeholderText || 'Choose an option'}
-                    onChange={evt => {
-                      this.setState(
-                        state => ({
-                          ...state,
-                          [column.id]: evt.selectedItem === null ? '' : evt.selectedItem.id,
-                        }),
-                        this.handleApplyFilter
-                      );
-                    }}
-                    light={!lightweight}
-                  />
-                ) : (
-                  <StyledFormItem>
-                    <TextInput
-                      id={column.id}
-                      labelText={column.id}
-                      hideLabel
-                      light={!lightweight}
-                      placeholder={column.placeholderText || 'Type and hit enter to apply'}
-                      onKeyDown={event => handleEnterKeyDown(event, this.handleApplyFilter)}
-                      onBlur={this.handleApplyFilter}
-                      onChange={event => this.setState({ [column.id]: event.target.value })}
-                      value={this.state[column.id]} // eslint-disable-line react/destructuring-assignment
-                    />
-                    {this.state[column.id] ? ( // eslint-disable-line react/destructuring-assignment
-                      <div
-                        role="button"
-                        className="bx--list-box__selection"
-                        tabIndex="0"
-                        onClick={event => {
-                          this.handleClearFilter(event, column);
-                        }}
-                        onKeyDown={event => {
-                          this.handleClearFilter(event, column);
-                        }}
-                        title={clearFilterText}>
-                        <Icon icon={iconClose} description={clearFilterText} focusable="false" />
-                      </div>
-                    ) : null}
-                  </StyledFormItem>
-                )}
+                {child}
               </StyledTableHeader>
             );
           })}

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -186,13 +186,12 @@ class FilterHeaderRow extends Component {
             const column = columns.find(i => c.columnId === i.id);
             const columnStateValue = this.state[column.id]; // eslint-disable-line
 
-            let child;
             // undefined check has the effect of making isFilterable default to true
             // if unspecified
-            if (column.isFilterable !== undefined && !column.isFilterable) {
-              child = <div />;
-            } else if (column.options) {
-              child = (
+            const headerContent =
+              column.isFilterable !== undefined && !column.isFilterable ? (
+                <div />
+              ) : column.options ? (
                 <ComboBox
                   aria-label={filterText}
                   translateWithId={this.handleTranslation}
@@ -215,9 +214,7 @@ class FilterHeaderRow extends Component {
                   }}
                   light={!lightweight}
                 />
-              );
-            } else {
-              child = (
+              ) : (
                 <StyledFormItem>
                   <TextInput
                     id={column.id}
@@ -247,14 +244,13 @@ class FilterHeaderRow extends Component {
                   ) : null}
                 </StyledFormItem>
               );
-            }
 
             return (
               <StyledTableHeader
                 data-column={column.id}
                 key={`FilterHeader${column.id}`}
                 width={column.width}>
-                {child}
+                {headerContent}
               </StyledTableHeader>
             );
           })}

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
@@ -14,7 +14,7 @@ describe('FilterHeaderRow', () => {
       <FilterHeaderRow
         {...commonFilterProps}
         ordering={[{ columnId: 'col1' }]}
-        columns={[{ id: 'col1' }]}
+        columns={[{ id: 'col1', isFilterable: true }]}
       />
     );
     wrapper.find('input').simulate('change', { target: { value: 'mytext' } });
@@ -60,5 +60,16 @@ describe('FilterHeaderRow', () => {
     wrapper.find('input').simulate('change', { target: { value: 'mytext' } });
     wrapper.find('[title="Clear filter"]').simulate('click');
     expect(wrapper.state()).toEqual({ col1: '' });
+  });
+
+  test('filter input is hidden when isFilterable is false', () => {
+    const wrapper = mount(
+      <FilterHeaderRow
+        {...commonFilterProps}
+        ordering={[{ columnId: 'col1' }]}
+        columns={[{ id: 'col1', isFilterable: false }]}
+      />
+    );
+    expect(wrapper.find('input').exists()).toEqual(false);
   });
 });

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -90,6 +90,10 @@ export const TableColumnsPropTypes = PropTypes.arrayOf(
      *    row: PropTypes.object like this {col: value, col2: value}
      * }, you should return the node that should render within that cell */
     renderDataFunction: PropTypes.func,
+
+    /**
+     * If omitted, no filter input will be shown for this column
+     */
     filter: PropTypes.shape({
       /** I18N text for the filter */
       placeholderText: PropTypes.string,


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

Prior work has added an `isFilterable` boolean property type for each `column` object passed in as properties to the `TableHeaderRow` component. This value is dynamically set to true or false by the `Table` component, determined by whether or not the `column.filters` property is present.

However, the value of this property was not actually being honoured in any way; meaning that it is not possible to enable filtering for a subset of columns (it was either ALL or NONE). This PR resolves this issue.

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#253

**Acceptance Test (how to verify the PR)**

- New component test added to verify filter input is omitted when `TableHeaderRow` column.isFitlerable is set to false.
- Snapshots of Table story verified and updated accordingly.

- To manually verify: check that filter inputs are absent for columns lacking the `filter` property.