### PR TITLE
fix(table): remove skeleton when lazy rendering data tables

### DIFF
--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, SkeletonText } from 'carbon-components-react';
+import { DataTable } from 'carbon-components-react';
 import VisibilitySensor from 'react-visibility-sensor';
 import pick from 'lodash/pick';
 
@@ -187,17 +187,7 @@ const TableBody = ({
             scrollCheck
             partialVisibility
             resizeCheck>
-            {({ isVisible }) =>
-              isVisible ? (
-                renderRow(row)
-              ) : (
-                <tr>
-                  <td colSpan="100%">
-                    <SkeletonText />
-                  </td>
-                </tr>
-              )
-            }
+            {({ isVisible }) => (isVisible ? renderRow(row) : <tr />)}
           </VisibilitySensor>
         ) : (
           renderRow(row)


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Remove skeleton when lazy rendering Table component.

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#257
