### PR TITLE
Add 16 column grid to dashboard

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -27,6 +27,8 @@ const propTypes = {
   title: PropTypes.string.isRequired,
   cards: PropTypes.arrayOf(PropTypes.shape(ValueCardPropTypes)).isRequired,
   layouts: PropTypes.shape({
+    max: PropTypes.array,
+    xl: PropTypes.array,
     lg: PropTypes.array,
     md: PropTypes.array,
     sm: PropTypes.array,
@@ -73,7 +75,7 @@ const Dashboard = ({
   // console.log(breakpoint);
   // console.log(dashboardBreakpoints, cardDimensions, rowHeight);
 
-  const generatedLayouts = Object.keys(DASHBOARD_BREAKPOINTS).reduce((acc, layoutName) => {
+  const generatedLayouts = Object.keys(dashboardBreakpoints).reduce((acc, layoutName) => {
     return {
       ...acc, // only generate the layout if we're not passed from the parent
       [layoutName]:
@@ -101,7 +103,7 @@ const Dashboard = ({
       <GridLayout
         layouts={generatedLayouts}
         compactType="vertical"
-        cols={DASHBOARD_COLUMNS}
+        cols={dashboardColumns}
         breakpoints={dashboardBreakpoints}
         margin={[GUTTER, GUTTER]}
         rowHeight={rowHeight[breakpoint]}
@@ -125,6 +127,7 @@ const Dashboard = ({
                 key={card.id}
                 breakpoint={breakpoint}
                 dashboardBreakpoints={dashboardBreakpoints}
+                dashboardColumns={dashboardColumns}
                 cardDimensions={cardDimensions}
                 rowHeight={rowHeight}
               />

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -6,6 +6,7 @@ import { Button } from 'carbon-components-react';
 
 import {
   DASHBOARD_BREAKPOINTS,
+  DASHBOARD_COLUMNS,
   CARD_DIMENSIONS,
   ROW_HEIGHT,
   CARD_SIZES,
@@ -105,6 +106,92 @@ const originalCards = [
   },
 ];
 
+export const DASHBOARD_SIZES_16_COL = {
+  MAX: 'max',
+  XLARGE: 'xl',
+  LARGE: 'lg',
+  MEDIUM: 'md',
+  SMALL: 'sm',
+  XSMALL: 'xs',
+};
+
+export const DASHBOARD_COLUMNS_16_COL = {
+  max: 16,
+  xl: 16,
+  lg: 16,
+  md: 8,
+  sm: 4,
+  xs: 4,
+};
+
+export const DASHBOARD_BREAKPOINTS_16_COL = {
+  max: 1800,
+  xl: 1312,
+  lg: 1056,
+  md: 672,
+  sm: 480,
+  xs: 320,
+};
+
+const CARD_DIMENSIONS_16_COL = {
+  XSMALL: {
+    max: { w: 2, h: 1 },
+    xl: { w: 2, h: 1 },
+    lg: { w: 4, h: 1 },
+    md: { w: 2, h: 1 },
+    sm: { w: 2, h: 1 },
+    xs: { w: 4, h: 1 },
+  },
+  SMALL: {
+    max: { w: 2, h: 2 },
+    xl: { w: 4, h: 2 },
+    lg: { w: 4, h: 2 },
+    md: { w: 4, h: 2 },
+    sm: { w: 2, h: 2 },
+    xs: { w: 4, h: 2 },
+  },
+  TALL: {
+    max: { w: 2, h: 4 },
+    xl: { w: 4, h: 4 },
+    lg: { w: 4, h: 4 },
+    md: { w: 4, h: 2 },
+    sm: { w: 2, h: 4 },
+    xs: { w: 4, h: 4 },
+  },
+  MEDIUM: {
+    max: { w: 6, h: 2 },
+    xl: { w: 8, h: 2 },
+    lg: { w: 8, h: 2 },
+    md: { w: 8, h: 2 },
+    sm: { w: 4, h: 2 },
+    xs: { w: 4, h: 2 },
+  },
+  WIDE: {
+    max: { w: 8, h: 2 },
+    xl: { w: 8, h: 2 },
+    lg: { w: 12, h: 2 },
+    md: { w: 8, h: 2 },
+    sm: { w: 4, h: 2 },
+    xs: { w: 4, h: 2 },
+  },
+  LARGE: {
+    max: { w: 6, h: 4 },
+    xl: { w: 8, h: 4 },
+    lg: { w: 8, h: 4 },
+    md: { w: 8, h: 4 },
+    sm: { w: 4, h: 4 },
+    xs: { w: 4, h: 4 },
+  },
+  XLARGE: {
+    max: { w: 8, h: 4 },
+    xl: { w: 12, h: 4 },
+    lg: { w: 16, h: 4 },
+    md: { w: 8, h: 4 },
+    sm: { w: 4, h: 4 },
+    xs: { w: 4, h: 4 },
+  },
+};
+
 const StatefulDashboard = ({ ...props }) => {
   const [cards, setCards] = useState(originalCards);
 
@@ -148,14 +235,28 @@ const StatefulDashboard = ({ ...props }) => {
   );
 };
 
-storiesOf('Dashboard (Experimental)', module).add('basic', () => {
-  return (
-    <StatefulDashboard
-      title={text('title', 'Munich Building')}
-      isEditable={boolean('isEditable', true)}
-      dashboardBreakpoints={object('breakpoints', DASHBOARD_BREAKPOINTS)}
-      cardDimensions={object('card dimensions', CARD_DIMENSIONS)}
-      rowHeight={object('row height', ROW_HEIGHT)}
-    />
-  );
-});
+storiesOf('Dashboard (Experimental)', module)
+  .add('basic - 12 col', () => {
+    return (
+      <StatefulDashboard
+        title={text('title', 'Munich Building')}
+        isEditable={boolean('isEditable', true)}
+        dashboardBreakpoints={object('breakpoints', DASHBOARD_BREAKPOINTS)}
+        dashboardColumns={object('columns', DASHBOARD_COLUMNS)}
+        cardDimensions={object('card dimensions', CARD_DIMENSIONS)}
+        rowHeight={object('row height', ROW_HEIGHT)}
+      />
+    );
+  })
+  .add('basic - 16 col', () => {
+    return (
+      <StatefulDashboard
+        title={text('title', 'Munich Building')}
+        isEditable={boolean('isEditable', true)}
+        dashboardBreakpoints={object('breakpoints', DASHBOARD_BREAKPOINTS_16_COL)}
+        dashboardColumns={object('columns', DASHBOARD_COLUMNS_16_COL)}
+        cardDimensions={object('card dimensions', CARD_DIMENSIONS_16_COL)}
+        rowHeight={object('row height', ROW_HEIGHT)}
+      />
+    );
+  });

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -39,6 +39,7 @@ export const DASHBOARD_BREAKPOINTS = {
 };
 
 export const ROW_HEIGHT = {
+  max: 128,
   xl: 128,
   lg: 128,
   md: 128,


### PR DESCRIPTION
**Summary**

- This PR adds a 16-column grid layout in the Dashboard story and fixes a bug where the `dashboardColumns` prop wasn't be propagated down to the card for layout calculation

**Acceptance Test (how to verify the PR)**

- View the new dashboard 16-col story