### PR TITLE
fix(linechart): build process need to exclude d3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "carbon-components-react": "^6.108.0",
     "carbon-icons": "^7.x",
     "react": "^16.8.3",
-    "d3": "3.5.17"
+    "d3": "^3.5.17"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "carbon-components": "^9.84.14",
     "carbon-components-react": "^6.108.0",
     "carbon-icons": "^7.x",
-    "react": "^16.8.3"
+    "react": "^16.8.3",
+    "d3": "3.5.17"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ export default {
       'carbon-components': 'CarbonComponents',
       'carbon-components-react': 'CarbonComponentsReact',
       'styled-components': 'styled',
+      d3: 'd3',
     },
   },
   external: [
@@ -36,6 +37,7 @@ export default {
     '@carbon/icons',
     '@carbon/icons-react',
     'carbon-components',
+    'd3',
   ],
   plugins: [
     resolve({ browser: true, extensions: ['.mjs', '.js', '.jsx', '.json'] }),


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- fix so that carbon-addons-iot-react can be used by downstream components again

**Change List (commits, features, bugs, etc)**

- fix(package.json): set d3 as peer dep
- fix(rollup): exclude d3 from build process as it was breaking it

https://stackoverflow.com/questions/35560305/d3-js-uncaught-typeerror-cannot-read-property-document-of-undefined