### PR TITLE
fix(stateful): loses selection in single select

### DIFF
--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -1,4 +1,5 @@
-import React, { useReducer, useEffect } from 'react';
+import React, { useReducer } from 'react';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import merge from 'lodash/merge';
 import get from 'lodash/get';
 
@@ -39,7 +40,7 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
   const [state, dispatch] = useReducer(tableReducer, { data: initialData, view: initialState });
   const isLoading = get(initialState, 'table.loadingState.isLoading');
   // Need to initially sort and filter the tables data
-  useEffect(
+  useDeepCompareEffect(
     () => {
       dispatch(tableRegister({ data: initialData, isLoading }));
     },


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- If the stateful table was consumed externally, it would lose the single selection indicator.  This is because the registerTable action was being dispatched everytime the parent rendered (due to not really comparing the data rows)

**Change List (commits, features, bugs, etc)**

- items_here


**Acceptance Test (how to verify the PR)**

- Tough to verify, it showed up in our EntityDetailsTable in Analytics Service, so if you pull this latest version you should see the table render and maintain it's selections
