### PR TITLE
Add isEmpty and isLoading states to Card

### DIFF
--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -39,15 +39,17 @@ const BarChartCard = ({ title, content: { data }, size, ...others }) => {
   };
   return (
     <Card title={title} size={size} {...others}>
-      <ContentWrapper>
-        <C3Chart
-          {...chart}
-          style={{
-            height: '100%',
-            width: '100%',
-          }}
-        />
-      </ContentWrapper>
+      {!others.isLoading ? (
+        <ContentWrapper>
+          <C3Chart
+            {...chart}
+            style={{
+              height: '100%',
+              width: '100%',
+            }}
+          />
+        </ContentWrapper>
+      ) : null}
     </Card>
   );
 };

--- a/src/components/BarChartCard/BarChartCard.story.jsx
+++ b/src/components/BarChartCard/BarChartCard.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, select, object } from '@storybook/addon-knobs';
+import { text, select, object, boolean } from '@storybook/addon-knobs';
 
 import { COLORS, CARD_SIZES } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
@@ -17,6 +17,7 @@ storiesOf('BarChartCard (Experimental)', module).add('basic', () => {
       <BarChartCard
         title={text('title', 'Temperature')}
         id="facility-temperature"
+        isLoading={boolean('isLoading', false)}
         content={object('content', {
           data: [
             {

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -8,6 +8,7 @@ import {
   Button,
   Select,
   SelectItem,
+  SkeletonText,
 } from 'carbon-components-react';
 import Close16 from '@carbon/icons-react/lib/close/16';
 import Popup20 from '@carbon/icons-react/lib/popup/20';
@@ -78,6 +79,21 @@ const StyledToolbar = styled(Toolbar)`
   }
 `;
 
+const SkeletonWrapper = styled.div`
+  padding: ${CARD_CONTENT_PADDING}px;
+  width: 80%;
+`;
+
+const EmptyMessageWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 ${CARD_CONTENT_PADDING}px ${CARD_CONTENT_PADDING}px;
+  text-align: center;
+  line-height: 1.3;
+`;
+
 const TinyButton = styled(Button)`
   &.bx--btn > svg {
     margin: 0;
@@ -88,6 +104,8 @@ const defaultProps = {
   size: CARD_SIZES.SMALL,
   layout: CARD_SIZES.HORIZONTAL,
   toolbar: undefined,
+  isLoading: false,
+  isEmpty: false,
   isEditable: false,
   isExpanded: false,
   availableActions: {
@@ -108,6 +126,8 @@ const Card = ({
   children,
   title,
   layout,
+  isLoading,
+  isEmpty,
   isEditable,
   isExpanded,
   id,
@@ -212,7 +232,15 @@ const Card = ({
         {toolbar}
       </CardHeader>
       <CardContent layout={layout} height={dimensions.y}>
-        {children}
+        {isLoading ? (
+          <SkeletonWrapper>
+            <SkeletonText paragraph lineCount={3} width="100%" />
+          </SkeletonWrapper>
+        ) : isEmpty ? (
+          <EmptyMessageWrapper>No data is available for this time range.</EmptyMessageWrapper>
+        ) : (
+          children
+        )}
       </CardContent>
     </CardWrapper>
   );

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -234,7 +234,7 @@ const Card = ({
       <CardContent layout={layout} height={dimensions.y}>
         {isLoading ? (
           <SkeletonWrapper>
-            <SkeletonText paragraph lineCount={3} width="100%" />
+            <SkeletonText paragraph lineCount={size === CARD_SIZES.XSMALL ? 2 : 3} width="100%" />
           </SkeletonWrapper>
         ) : isEmpty ? (
           <EmptyMessageWrapper>No data is available for this time range.</EmptyMessageWrapper>

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -7,19 +7,78 @@ import { getCardMinSize } from '../../utils/componentUtilityFunctions';
 
 import Card from './Card';
 
-storiesOf('Card (Experimental)', module).add('card props', () => {
-  const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
-  return (
-    <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
-      <Card
-        title={text('title', 'Card Title')}
-        id="facilitycard"
-        size={size}
-        isEditable={boolean('isEditable', false)}
-        isExpanded={boolean('isExpanded', false)}
-        breakpoint="lg"
-        onCardAction={(id, type, payload) => console.log('onCardAction', id, type, payload)}
-      />
-    </div>
-  );
-});
+storiesOf('Card (Experimental)', module)
+  .add('basic', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <Card
+          title={text('title', 'Card Title')}
+          id="facilitycard"
+          size={size}
+          isLoading={boolean('isLoading', false)}
+          isEmpty={boolean('isEmpty', false)}
+          isEditable={boolean('isEditable', false)}
+          isExpanded={boolean('isExpanded', false)}
+          breakpoint="lg"
+          onCardAction={(id, type, payload) => console.log('onCardAction', id, type, payload)}
+        />
+      </div>
+    );
+  })
+  .add('with loading', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <Card
+          title={text('title', 'Card Title')}
+          id="facilitycard"
+          size={size}
+          isLoading={boolean('isLoading', true)}
+          isEmpty={boolean('isEmpty', false)}
+          isEditable={boolean('isEditable', false)}
+          isExpanded={boolean('isExpanded', false)}
+          breakpoint="lg"
+          onCardAction={(id, type, payload) => console.log('onCardAction', id, type, payload)}
+        />
+      </div>
+    );
+  })
+  .add('with empty state', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <Card
+          title={text('title', 'Card Title')}
+          id="facilitycard"
+          size={size}
+          isLoading={boolean('isLoading', false)}
+          isEmpty={boolean('isEmpty', true)}
+          isEditable={boolean('isEditable', false)}
+          isExpanded={boolean('isExpanded', false)}
+          breakpoint="lg"
+          onCardAction={(id, type, payload) => console.log('onCardAction', id, type, payload)}
+        />
+      </div>
+    );
+  })
+  .add('size gallery', () => {
+    return Object.keys(CARD_SIZES).map(i => (
+      <React.Fragment>
+        <h3>{i}</h3>
+        <div style={{ width: `${getCardMinSize('lg', CARD_SIZES[i]).x}px`, margin: 20 }}>
+          <Card
+            title={text('title', 'Card Title')}
+            id="facilitycard"
+            size={CARD_SIZES[i]}
+            isLoading={boolean('isLoading', false)}
+            isEmpty={boolean('isEmpty', true)}
+            isEditable={boolean('isEditable', false)}
+            isExpanded={boolean('isExpanded', false)}
+            breakpoint="lg"
+            onCardAction={(id, type, payload) => console.log('onCardAction', id, type, payload)}
+          />
+        </div>
+      </React.Fragment>
+    ));
+  });

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -5,7 +5,6 @@ import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import styled from 'styled-components';
 import find from 'lodash/find';
-import { Loading } from 'carbon-components-react';
 
 import { getLayout } from '../../utils/componentUtilityFunctions';
 import {
@@ -121,6 +120,7 @@ const Dashboard = ({
       {card.type === CARD_TYPES.VALUE ? (
         <ValueCard
           {...card}
+          isLoading={isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -134,6 +134,7 @@ const Dashboard = ({
       {card.type === CARD_TYPES.TIMESERIES ? (
         <TimeSeriesCard
           {...card}
+          isLoading={isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -147,6 +148,7 @@ const Dashboard = ({
       {card.type === CARD_TYPES.DONUT ? (
         <DonutCard
           {...card}
+          isLoading={isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -160,6 +162,7 @@ const Dashboard = ({
       {card.type === CARD_TYPES.PIE ? (
         <PieCard
           {...card}
+          isLoading={isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -173,6 +176,7 @@ const Dashboard = ({
       {card.type === CARD_TYPES.BAR ? (
         <BarChartCard
           {...card}
+          isLoading={isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -224,33 +228,29 @@ const Dashboard = ({
         lastUpdatedLabel={lastUpdatedLabel}
         filter={filter}
       />
-      {isLoading ? (
-        <Loading withOverlay={false} />
-      ) : (
-        <StyledGridLayout
-          layouts={generatedLayouts}
-          compactType="vertical"
-          cols={dashboardColumns}
-          breakpoints={dashboardBreakpoints}
-          margin={[GUTTER, GUTTER]}
-          rowHeight={rowHeight[breakpoint]}
-          preventCollision={false}
-          // Stop the initial animation
-          shouldAnimate={isEditable}
-          // TODO: need to consider preserving their loose packing decisions on layout change
-          // TODO: also, should we reorder our cards based on the layout change, and regenerate all
-          //       other layouts?  for example, moving card 5 to before card 2 in lg should mean
-          //       that the order changes for xl, md, sm, xs, etc. layouts
-          /* onLayoutChange={
-         layout =>  console.log('new layout, time to regenerate', JSON.stringify(layout)
-        } */
-          onBreakpointChange={newBreakpoint => setBreakpoint(newBreakpoint)}
-          isResizable={false}
-          isDraggable={isEditable}
-        >
-          {gridContents}
-        </StyledGridLayout>
-      )}
+      <StyledGridLayout
+        layouts={generatedLayouts}
+        compactType="vertical"
+        cols={dashboardColumns}
+        breakpoints={dashboardBreakpoints}
+        margin={[GUTTER, GUTTER]}
+        rowHeight={rowHeight[breakpoint]}
+        preventCollision={false}
+        // Stop the initial animation
+        shouldAnimate={isEditable}
+        // TODO: need to consider preserving their loose packing decisions on layout change
+        // TODO: also, should we reorder our cards based on the layout change, and regenerate all
+        //       other layouts?  for example, moving card 5 to before card 2 in lg should mean
+        //       that the order changes for xl, md, sm, xs, etc. layouts
+        /* onLayoutChange={
+        layout =>  console.log('new layout, time to regenerate', JSON.stringify(layout)
+      } */
+        onBreakpointChange={newBreakpoint => setBreakpoint(newBreakpoint)}
+        isResizable={false}
+        isDraggable={isEditable}
+      >
+        {gridContents}
+      </StyledGridLayout>
     </div>
   );
 };

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -393,6 +393,7 @@ storiesOf('Dashboard (Experimental)', module)
       <StatefulDashboard
         title={text('title', 'Munich Building')}
         isEditable={boolean('isEditable', false)}
+        isLoading={boolean('isLoading', false)}
         dashboardBreakpoints={object('breakpoints', DASHBOARD_BREAKPOINTS)}
         dashboardColumns={object('columns', DASHBOARD_COLUMNS)}
         cardDimensions={object('card dimensions', CARD_DIMENSIONS)}
@@ -405,6 +406,7 @@ storiesOf('Dashboard (Experimental)', module)
       <StatefulDashboard
         title={text('title', 'Munich Building')}
         isEditable={boolean('isEditable', false)}
+        isLoading={boolean('isLoading', false)}
         dashboardBreakpoints={object('breakpoints', DASHBOARD_BREAKPOINTS_16_COL)}
         dashboardColumns={object('columns', DASHBOARD_COLUMNS_16_COL)}
         cardDimensions={object('card dimensions', CARD_DIMENSIONS_16_COL)}

--- a/src/components/DonutCard/DonutCard.jsx
+++ b/src/components/DonutCard/DonutCard.jsx
@@ -45,15 +45,17 @@ const DonutCard = ({ title, content, content: { data }, size, ...others }) => {
   };
   return (
     <Card title={title} size={size} {...others}>
-      <ContentWrapper>
-        <C3Chart
-          {...chart}
-          style={{
-            height: '100%',
-            width: '100%',
-          }}
-        />
-      </ContentWrapper>
+      {!others.isLoading ? (
+        <ContentWrapper>
+          <C3Chart
+            {...chart}
+            style={{
+              height: '100%',
+              width: '100%',
+            }}
+          />
+        </ContentWrapper>
+      ) : null}
     </Card>
   );
 };

--- a/src/components/PieCard/PieCard.jsx
+++ b/src/components/PieCard/PieCard.jsx
@@ -45,15 +45,17 @@ const PieCard = ({ title, content, content: { data }, size, ...others }) => {
   };
   return (
     <Card title={title} size={size} {...others}>
-      <ContentWrapper>
-        <C3Chart
-          {...chart}
-          style={{
-            height: '100%',
-            width: '100%',
-          }}
-        />
-      </ContentWrapper>
+      {!others.isLoading ? (
+        <ContentWrapper>
+          <C3Chart
+            {...chart}
+            style={{
+              height: '100%',
+              width: '100%',
+            }}
+          />
+        </ContentWrapper>
+      ) : null}
     </Card>
   );
 };

--- a/src/components/PieCard/PieCard.story.jsx
+++ b/src/components/PieCard/PieCard.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, select, object } from '@storybook/addon-knobs';
+import { text, select, object, boolean } from '@storybook/addon-knobs';
 
 import { COLORS, CARD_SIZES } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
@@ -14,6 +14,7 @@ storiesOf('PieCard (Experimental)', module).add('basic', () => {
       <PieCard
         title={text('title', 'Alerts (last month)')}
         id="facility-temperature"
+        isLoading={boolean('isLoading', false)}
         content={object('content', {
           title: 'Alerts',
           data: [

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -97,15 +97,17 @@ const TimeSeriesCard = ({ title, content: { range, data }, size, ...others }) =>
   };
   return (
     <Card title={title} size={size} {...others}>
-      <ContentWrapper>
-        <C3Chart
-          {...chart}
-          style={{
-            height: '100%',
-            width: '100%',
-          }}
-        />
-      </ContentWrapper>
+      {others.isLoading ? (
+        <ContentWrapper>
+          <C3Chart
+            {...chart}
+            style={{
+              height: '100%',
+              width: '100%',
+            }}
+          />
+        </ContentWrapper>
+      ) : null}
     </Card>
   );
 };

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, select, object } from '@storybook/addon-knobs';
+import { text, select, object, boolean } from '@storybook/addon-knobs';
 
 import { COLORS, CARD_SIZES } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
@@ -18,6 +18,7 @@ storiesOf('TimeSeriesCard (Experimental)', module)
         <TimeSeriesCard
           title={text('title', 'Temperature')}
           id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
           content={object('content', {
             data: [
               {
@@ -46,6 +47,7 @@ storiesOf('TimeSeriesCard (Experimental)', module)
         <TimeSeriesCard
           title={text('title', 'Facility Metrics')}
           id="facility-multi"
+          isLoading={boolean('isLoading', false)}
           content={object('content', {
             data: [
               {
@@ -85,6 +87,7 @@ storiesOf('TimeSeriesCard (Experimental)', module)
         <TimeSeriesCard
           title={text('title', 'Temperature')}
           id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
           content={object('content', {
             range: 'day',
             data: {
@@ -111,6 +114,7 @@ storiesOf('TimeSeriesCard (Experimental)', module)
         <TimeSeriesCard
           title={text('title', 'Pressure')}
           id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
           content={object('content', {
             range: 'week',
             data: {

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -133,6 +133,8 @@ export const CardSizesToDimensionsPropTypes = PropTypes.shape({
 export const CardPropTypes = {
   title: PropTypes.string.isRequired,
   id: PropTypes.string,
+  isLoading: PropTypes.bool,
+  isEmpty: PropTypes.bool,
   isEditable: PropTypes.bool,
   isExpanded: PropTypes.bool,
   size: PropTypes.oneOf(Object.values(CARD_SIZES)),


### PR DESCRIPTION
**Summary**

- Added basic loading/empty state to Card.  We can improve on the visuals in the future.
- Included new stories for Card for each state, and a "size gallery" to render all sizes of a card hooked up to the same prop knobs, to see how loading/empty scale up and down as size changes

![image](https://user-images.githubusercontent.com/2175647/58960266-758e7980-876c-11e9-891e-5f73ee0776d7.png)

![image](https://user-images.githubusercontent.com/2175647/58960274-7a532d80-876c-11e9-9d8b-31bd37c5f96b.png)

![image](https://user-images.githubusercontent.com/2175647/58960255-71625c00-876c-11e9-86ba-0f9844abac80.png)


