### PR TITLE
refactor(valuecard): change prop types to pass values as flat object

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import styled from 'styled-components';
 import C3Chart from 'react-c3js';
-import 'c3/c3.css';
+import isEmpty from 'lodash/isEmpty';
 
+import 'c3/c3.css';
 import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
@@ -14,7 +15,15 @@ const ContentWrapper = styled.div`
   width: 100%;
 `;
 
-const TimeSeriesCard = ({ title, content: { range, data }, size, ...others }) => {
+const TimeSeriesCard = ({
+  title,
+  content: { series, timeDataSourceId },
+  size,
+  range,
+  values,
+  ...others
+}) => {
+  // TODO: need to i18n the format of the x-axis and y-axis labels
   const format =
     range === 'month'
       ? '%m/%d'
@@ -40,41 +49,39 @@ const TimeSeriesCard = ({ title, content: { range, data }, size, ...others }) =>
           .toISOString()
       : range.min;
   const max = range === undefined ? undefined : range.max ? range.max : moment().toISOString();
-  const chartData =
-    data.label === undefined
+  const chartData = !isEmpty(values)
+    ? series.label === undefined
       ? {
-          // an array of datasets with multiple x axes
-          xs: data
-            .map(i => i.label)
-            .reduce((acc, curr, idx) => ({ ...acc, [curr]: `t${idx + 1}` }), {}),
           xFormat: '%Y-%m-%dT%H:%M:%S.%LZ',
-          colors: data.reduce(
-            (acc, curr) => Object.assign({}, acc, curr.color ? { [curr.label]: curr.color } : {}),
+          colors: series.reduce(
+            (acc, curr) =>
+              Object.assign({}, acc, curr.color ? { [curr.dataSourceId]: curr.color } : {}),
             {}
           ),
-          json: data.reduce(
-            (acc, curr, idx) => ({
-              ...acc,
-              [curr.label]: curr.values.map(i => i.v),
-              [`t${idx + 1}`]: curr.values.map(i => i.t),
-            }),
+          names: series.reduce(
+            (acc, curr) =>
+              Object.assign({}, acc, curr.label ? { [curr.dataSourceId]: curr.label } : {}),
             {}
           ),
+          json: values,
+          keys: { value: series.map(line => line.dataSourceId), x: timeDataSourceId },
           type: 'line',
         }
       : {
           // a single dataset
-          x: 't',
+          x: timeDataSourceId,
           xFormat: '%Y-%m-%dT%H:%M:%S.%LZ',
           colors: {
-            [data.label]: data.color,
+            [series.dataSourceId]: series.color,
           },
-          json: {
-            [data.label]: data.values.map(i => i.v),
-            t: data.values.map(i => i.t),
+          names: {
+            [series.dataSourceId]: series.label,
           },
+          keys: { value: [series.dataSourceId], x: timeDataSourceId },
+          json: values,
           type: 'line',
-        };
+        }
+    : [];
   const chart = {
     data: chartData,
     axis: {
@@ -97,7 +104,7 @@ const TimeSeriesCard = ({ title, content: { range, data }, size, ...others }) =>
   };
 
   return (
-    <Card title={title} size={size} {...others}>
+    <Card title={title} size={size} {...others} isEmpty={isEmpty(values)}>
       {!others.isLoading ? (
         <ContentWrapper>
           <C3Chart

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -8,11 +8,11 @@ import { chartData } from '../../utils/sample';
 
 import TimeSeriesCard from './TimeSeriesCard';
 
+// need a timeOffset to make the data always show up
+const timeOffset = new Date().getTime() - Object.values(chartData.dataItemToMostRecentTimestamp)[0];
 storiesOf('TimeSeriesCard (Experimental)', module)
   .add('single line - no range', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
-    const field = 'temperature';
-    const timeOffset = new Date().getTime() - chartData.dataItemToMostRecentTimestamp[field];
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <TimeSeriesCard
@@ -20,19 +20,16 @@ storiesOf('TimeSeriesCard (Experimental)', module)
           id="facility-temperature"
           isLoading={boolean('isLoading', false)}
           content={object('content', {
-            data: [
-              {
-                label: 'Temperature',
-                values: chartData.events
-                  .filter((i, idx) => idx < 20)
-                  .map(i => ({
-                    t: new Date(i.timestamp + timeOffset).toISOString(),
-                    v: i[field],
-                  })),
-                color: COLORS.RED,
-              },
-            ],
+            series: {
+              label: 'Temperature',
+              dataSourceId: 'temperature',
+              color: text('color', COLORS.RED),
+            },
+            xLabel: text('xLabel', 'X Axis'),
+            yLabel: text('yLabel', 'Y Axis'),
+            timeDataSourceId: 'timestamp',
           })}
+          values={chartData.events}
           breakpoint="lg"
           size={size}
         />
@@ -41,7 +38,6 @@ storiesOf('TimeSeriesCard (Experimental)', module)
   })
   .add('multi line - no range', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
-    const timeOffset = new Date().getTime() - chartData.dataItemToMostRecentTimestamp.temperature;
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <TimeSeriesCard
@@ -49,30 +45,22 @@ storiesOf('TimeSeriesCard (Experimental)', module)
           id="facility-multi"
           isLoading={boolean('isLoading', false)}
           content={object('content', {
-            data: [
+            series: [
               {
                 label: 'Temperature',
-                values: chartData.events
-                  .filter((i, idx) => idx < 20)
-                  .map(i => ({
-                    t: new Date(i.timestamp + timeOffset).toISOString(),
-                    v: i.temperature,
-                  })),
+                dataSourceId: 'temperature',
                 color: COLORS.RED,
               },
               {
                 label: 'Pressure',
-                values: chartData.events
-                  .filter((i, idx) => idx < 20)
-                  .map(i => ({
-                    t: new Date(i.timestamp + timeOffset).toISOString(),
-                    v: i.pressure,
-                  })),
+                dataSourceId: 'pressure',
                 color: COLORS.BLUE,
               },
             ],
+            timeDataSourceId: 'timestamp',
           })}
           breakpoint="lg"
+          values={chartData.events}
           size={size}
         />
       </div>
@@ -80,8 +68,6 @@ storiesOf('TimeSeriesCard (Experimental)', module)
   })
   .add('single line - day', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
-    const field = 'temperature';
-    const timeOffset = new Date().getTime() - chartData.dataItemToMostRecentTimestamp[field];
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <TimeSeriesCard
@@ -89,17 +75,20 @@ storiesOf('TimeSeriesCard (Experimental)', module)
           id="facility-temperature"
           isLoading={boolean('isLoading', false)}
           content={object('content', {
-            range: 'day',
-            data: {
+            series: {
               label: 'Temperature',
-              values: chartData.events.map(i => ({
-                t: new Date(i.timestamp + timeOffset).toISOString(),
-                v: i[field],
-              })),
+              dataSourceId: 'temperature',
               color: COLORS.RED,
             },
+            timeDataSourceId: 'timestamp',
           })}
+          range="day"
           breakpoint="lg"
+          // Need to update the values to have recent dates
+          values={chartData.events.map(data => ({
+            ...data,
+            timestamp: data.timestamp + timeOffset,
+          }))}
           size={size}
         />
       </div>
@@ -107,26 +96,75 @@ storiesOf('TimeSeriesCard (Experimental)', module)
   })
   .add('single line - week', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
-    const field = 'pressure';
-    const timeOffset = new Date().getTime() - chartData.dataItemToMostRecentTimestamp[field];
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <TimeSeriesCard
           title={text('title', 'Pressure')}
           id="facility-temperature"
           isLoading={boolean('isLoading', false)}
+          range="week"
           content={object('content', {
-            range: 'week',
-            data: {
+            series: {
               label: 'Pressure',
-              values: chartData.events.map(i => ({
-                t: new Date(i.timestamp + timeOffset).toISOString(),
-                v: i[field],
-              })),
+              dataSourceId: 'pressure',
               color: COLORS.BLUE,
             },
+            timeDataSourceId: 'timestamp',
           })}
           breakpoint="lg"
+          // Need to update the values to have recent dates
+          values={chartData.events.map(data => ({
+            ...data,
+            timestamp: data.timestamp + timeOffset,
+          }))}
+          size={size}
+        />
+      </div>
+    );
+  })
+  .add('empty', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TimeSeriesCard
+          title={text('title', 'Temperature')}
+          id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
+          content={object('content', {
+            series: {
+              label: 'Temperature',
+              dataSourceId: 'temperature',
+              color: COLORS.RED,
+            },
+            timeDataSourceId: 'timestamp',
+          })}
+          range="day"
+          breakpoint="lg"
+          values={[]}
+          size={size}
+        />
+      </div>
+    );
+  })
+  .add('empty for a range', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TimeSeriesCard
+          title={text('title', 'Temperature')}
+          id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
+          content={object('content', {
+            series: {
+              label: 'Temperature',
+              dataSourceId: 'temperature',
+              color: COLORS.RED,
+            },
+            timeDataSourceId: 'timestamp',
+          })}
+          range="day"
+          breakpoint="lg"
+          values={chartData.events}
           size={size}
         />
       </div>

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -50,8 +50,12 @@ const propTypes = {
   value: PropTypes.any, // eslint-disable-line
   unit: PropTypes.any, // eslint-disable-line
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
-  /** Additional information about the Attribute, like it's range or aggregator */
-  secondaryValue: PropTypes.any, // eslint-disable-line
+  /** Optional trend information */
+  secondaryValue: PropTypes.shape({
+    color: PropTypes.string,
+    trend: PropTypes.oneOf(['up', 'down']),
+    value: PropTypes.any,
+  }),
   /** need to render smaller attribute */
   isSmall: PropTypes.bool,
   isVertical: PropTypes.bool, // are the attributes and labels in a column?
@@ -72,6 +76,7 @@ const defaultProps = {
   thresholds: [],
   isVertical: false,
   isSmall: false,
+  secondaryValue: null,
 };
 
 const Attribute = ({
@@ -134,7 +139,7 @@ const Attribute = ({
       )}
       <UnitRenderer value={value} unit={unit} layout={layout} />
       {thresholdIcon}
-      {secondaryValue !== undefined ? (
+      {!isNil(secondaryValue) ? (
         <AttributeSecondaryValue color={secondaryValue.color} trend={secondaryValue.trend}>
           {secondaryValue.trend && secondaryValue.trend === 'up' ? (
             <TrendIcon icon={iconCaretUp} />

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -17,12 +17,13 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={object('content', [
             {
-              value: 88,
+              dataSourceId: 'occupancy',
               unit: '%',
             },
           ])}
           breakpoint="lg"
           size={size}
+          values={{ occupancy: number('occupancy', 88) }}
         />
       </div>
     );
@@ -36,12 +37,13 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={object('content', [
             {
-              title: 'Average',
-              value: 13572,
+              label: 'Average',
+              dataSourceId: 'footTraffic',
             },
           ])}
           breakpoint="lg"
           size={size}
+          values={{ footTraffic: number('footTraffic', 13572) }}
         />
       </div>
     );
@@ -55,12 +57,13 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={object('content', [
             {
-              value: 13572,
-              secondaryValue: { value: '22%', trend: 'down', color: 'red' },
+              dataSourceId: 'footTraffic',
+              secondaryValue: { dataSourceId: 'trend', trend: 'down', color: 'red' },
             },
           ])}
           breakpoint="lg"
           size={size}
+          values={{ footTraffic: number('footTraffic', 13572), trend: text('trend', '22%') }}
         />
       </div>
     );
@@ -74,12 +77,13 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={object('content', [
             {
-              value: 35,
-              secondaryValue: { value: '12', trend: 'up', color: 'green' },
+              dataSourceId: 'alerts',
+              secondaryValue: { dataSourceId: 'trend', trend: 'up', color: 'green' },
             },
           ])}
           breakpoint="lg"
           size={size}
+          values={{ alerts: number('alerts', 35), trend: number('trend', 12) }}
         />
       </div>
     );
@@ -93,7 +97,7 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={[
             {
-              value: number('value', 35),
+              dataSourceId: 'alertCount',
               thresholds: [
                 {
                   comparison: '>=',
@@ -115,6 +119,7 @@ storiesOf('ValueCard (Experimental)', module)
           ]}
           breakpoint="lg"
           size={size}
+          values={{ alertCount: number('alertCount', 35) }}
         />
       </div>
     );
@@ -128,7 +133,7 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={[
             {
-              value: number('value', 4),
+              dataSourceId: 'alertCount',
               thresholds: [
                 {
                   comparison: '<',
@@ -141,6 +146,7 @@ storiesOf('ValueCard (Experimental)', module)
           ]}
           breakpoint="lg"
           size={size}
+          values={{ alertCount: number('alertCount', 4) }}
         />
       </div>
     );
@@ -154,7 +160,7 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={object('content', [
             {
-              value: text('value', 'Bad'),
+              dataSourceId: 'status',
               thresholds: [
                 {
                   comparison: '=',
@@ -173,6 +179,7 @@ storiesOf('ValueCard (Experimental)', module)
           ])}
           breakpoint="lg"
           size={size}
+          values={{ status: text('status', 'Bad') }}
         />
       </div>
     );
@@ -184,9 +191,12 @@ storiesOf('ValueCard (Experimental)', module)
         <ValueCard
           title={text('title', 'Facility Conditions')}
           id="facilitycard"
-          content={object('content', [{ title: 'Comfort Level', value: 89, unit: '%' }])}
+          content={object('content', [
+            { label: 'Comfort Level', dataSourceId: 'comfortLevel', unit: '%' },
+          ])}
           breakpoint="lg"
           size={size}
+          values={{ comfortLevel: number('comfortLevel', 89) }}
         />
       </div>
     );
@@ -199,12 +209,17 @@ storiesOf('ValueCard (Experimental)', module)
           title={text('title', 'Facility Conditions')}
           id="facilitycard"
           content={object('content', [
-            { title: 'Comfort Level', value: 89, unit: '%' },
-            { title: 'Average Temperature', value: 76.7, unit: '˚F', precision: 1 },
-            { title: 'Utilization', value: 76, unit: '%' },
+            { label: 'Comfort Level', dataSourceId: 'comfortLevel', unit: '%' },
+            { label: 'Average Temperature', dataSourceId: 'averageTemp', unit: '˚F', precision: 1 },
+            { label: 'Utilization', dataSourceId: 'utilization', unit: '%' },
           ])}
           breakpoint="lg"
           size={size}
+          values={{
+            comfortLevel: number('comfortLevel', 89),
+            averageTemp: number('averageTemp', 76.7),
+            utilization: number('utilization', 76),
+          }}
         />
       </div>
     );
@@ -216,9 +231,10 @@ storiesOf('ValueCard (Experimental)', module)
         <ValueCard
           title={text('title', 'Uncomfortable?')}
           id="facilitycard"
-          content={[{ title: 'Monthly summary', value: boolean('value', false) }]}
+          content={[{ label: 'Monthly summary', dataSourceId: 'monthlySummary' }]}
           breakpoint="lg"
           size={size}
+          values={{ monthlySummary: boolean('monthlySummary', false) }}
         />
       </div>
     );
@@ -246,13 +262,14 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={[
             {
-              title: 'Monthly summary',
-              value: number('value', 20000000000000000),
+              label: 'Monthly summary',
+              dataSourceId: 'monthlySummary',
               unit: text('unit', ''),
             },
           ]}
           breakpoint="lg"
           size={size}
+          values={{ monthlySummary: number('monthlySummary', 20000000000000000) }}
         />
       </div>
     );
@@ -266,18 +283,22 @@ storiesOf('ValueCard (Experimental)', module)
           id="facilitycard"
           content={[
             {
-              title: 'Monthly summary',
-              value: number('value', 100000000),
+              label: 'Monthly summary',
+              dataSourceId: 'monthlySummary',
               unit: text('unit', 'Wh'),
             },
             {
-              title: 'Yearly summary',
-              value: number('value', 40000000000000),
+              label: 'Yearly summary',
+              dataSourceId: 'yearlySummary',
               unit: text('unit', 'Wh'),
             },
           ]}
           breakpoint="lg"
           size={size}
+          values={{
+            monthlySummary: number('monthlySummary', 100000000),
+            yearlySummary: number('yearlySummary', 40000000000000),
+          }}
         />
       </div>
     );

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -52,31 +52,27 @@ export const ValueCardPropTypes = {
 
 export const TimeSeriesDatasetPropTypes = PropTypes.shape({
   label: PropTypes.string.isRequired,
-  values: PropTypes.arrayOf(
-    PropTypes.shape({
-      /** time attribute */
-      t: PropTypes.number.isRequired,
-      /** value attribute */
-      v: PropTypes.number.isRequired,
-    })
-  ),
+  /** the attribute in values to map to */
+  dataSourceId: PropTypes.string.isRequired,
+  /** optional units to put in the legend */
+  unit: PropTypes.string,
+  /** optional param to set the colors */
   color: PropTypes.string,
 });
 
 export const TimeSeriesCardPropTypes = {
   content: PropTypes.shape({
-    range: PropTypes.oneOfType([
-      PropTypes.oneOf(['day', 'week', 'month']),
-      PropTypes.shape({
-        start: PropTypes.instanceOf(Date),
-        end: PropTypes.instanceOf(Date),
-      }),
-    ]),
-    data: PropTypes.oneOfType([
+    series: PropTypes.oneOfType([
       TimeSeriesDatasetPropTypes,
       PropTypes.arrayOf(TimeSeriesDatasetPropTypes),
     ]).isRequired,
+    xLabel: PropTypes.string,
+    yLabel: PropTypes.string,
+    /** Which attribute is the time attribute */
+    timeDataSourceId: PropTypes.string.isRequired,
   }).isRequired,
+  /** array of data from the backend for instance [{timestamp: 134234234234, temperature: 35, humidity: 10}, ...] */
+  values: PropTypes.arrayOf(PropTypes.object),
 };
 
 export const TableCardPropTypes = {
@@ -177,6 +173,14 @@ export const CardPropTypes = {
   size: PropTypes.oneOf(Object.values(CARD_SIZES)),
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
   breakpoint: PropTypes.oneOf(Object.values(DASHBOARD_SIZES)),
+  /** Optional range to pass at the card level */
+  range: PropTypes.oneOfType([
+    PropTypes.oneOf(['day', 'week', 'month']),
+    PropTypes.shape({
+      start: PropTypes.instanceOf(Date),
+      end: PropTypes.instanceOf(Date),
+    }),
+  ]),
   availableActions: PropTypes.shape({
     edit: PropTypes.bool,
     clone: PropTypes.bool,

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import { CARD_SIZES, CARD_LAYOUTS, DASHBOARD_SIZES } from './LayoutConstants';
 
 export const AttributePropTypes = PropTypes.shape({
-  title: PropTypes.string, // optional for little cards
-  value: PropTypes.any,
+  label: PropTypes.string, // optional for little cards
+  /** the key to load the value from the values object */
+  dataSourceId: PropTypes.string.isRequired,
   secondaryValue: PropTypes.shape({
-    value: PropTypes.string,
+    /** the key to load the value from the values object */
+    dataSourceId: PropTypes.string.isRequired,
     color: PropTypes.string,
     trend: PropTypes.oneOf(['up', 'down']),
   }),
@@ -44,6 +46,8 @@ export const DashboardColumnsPropTypes = PropTypes.shape({
 
 export const ValueCardPropTypes = {
   content: PropTypes.arrayOf(AttributePropTypes).isRequired,
+  /** Value card expects its values passed as an object with key value pairs */
+  values: PropTypes.object,
 };
 
 export const TimeSeriesDatasetPropTypes = PropTypes.shape({


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Refactoring to pass both the line chart and value card values as a flat object.  This allows each card to easily determine if it's empty or not for the current data range

**Acceptance Test (how to verify the PR)**

- Verify the Line Chart and Value Card stories
