### PR TITLE
refactor(deploy): remove travis deploy settings in favor of netlify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,3 @@ script:
 after_success:
   - npx semantic-release@beta
   - yarn run jest --coverage --coverageReporters=text-lcov | yarn run coveralls # report coveralls status
-
-before_deploy:
-  - yarn build:storybook
-
-deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GH_TOKEN
-  keep-history: true
-  local-dir: ./storybook-static
-  on:
-    branch: master


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Travis deploy is no longer needed for gh-pages deployment

**Change List (commits, features, bugs, etc)**

- remove deploy settings from .travis.yml

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- #305 

