### PR TITLE
feat(card): add per card error state and loading

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -148,6 +148,7 @@ const Card = ({
   isEmpty,
   isEditable,
   isExpanded,
+  error,
   id,
   tooltip,
   onCardAction,
@@ -262,7 +263,9 @@ const Card = ({
         {toolbar}
       </CardHeader>
       <CardContent layout={layout} height={dimensions.y}>
-        {isLoading ? (
+        {error ? (
+          <EmptyMessageWrapper>{error}</EmptyMessageWrapper>
+        ) : isLoading ? (
           <SkeletonWrapper>
             <SkeletonText paragraph lineCount={size === CARD_SIZES.XSMALL ? 2 : 3} width="100%" />
           </SkeletonWrapper>

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -81,4 +81,19 @@ storiesOf('Card (Experimental)', module)
         </div>
       </React.Fragment>
     ));
+  })
+  .add('error', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <Card
+          title={text('title', 'Card Title')}
+          id="facilitycard"
+          size={size}
+          error={text('error', 'Error loading card')}
+          breakpoint="lg"
+          onCardAction={(id, type, payload) => console.log('onCardAction', id, type, payload)}
+        />
+      </div>
+    );
   });

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -40,6 +40,10 @@ const propTypes = {
     PropTypes.shape({
       content: PropTypes.object,
       values: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+      /** is the card actively loading, it will override the dashboard loading state if true */
+      isLoading: PropTypes.bool,
+      /** was there an error loading */
+      error: PropTypes.node,
     })
   ).isRequired,
   layouts: PropTypes.shape({
@@ -141,7 +145,7 @@ const Dashboard = ({
         <ValueCard
           {...card}
           i18n={i18n}
-          isLoading={isLoading}
+          isLoading={card.isLoading || isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -156,7 +160,7 @@ const Dashboard = ({
         <TimeSeriesCard
           {...card}
           i18n={i18n}
-          isLoading={isLoading}
+          isLoading={card.isLoading || isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -171,7 +175,7 @@ const Dashboard = ({
         <TableCard
           {...card}
           i18n={i18n}
-          isLoading={isLoading}
+          isLoading={card.isLoading || isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -186,7 +190,7 @@ const Dashboard = ({
         <DonutCard
           {...card}
           i18n={i18n}
-          isLoading={isLoading}
+          isLoading={card.isLoading || isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -201,7 +205,7 @@ const Dashboard = ({
         <PieCard
           {...card}
           i18n={i18n}
-          isLoading={isLoading}
+          isLoading={card.isLoading || isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}
@@ -216,7 +220,7 @@ const Dashboard = ({
         <BarChartCard
           {...card}
           i18n={i18n}
-          isLoading={isLoading}
+          isLoading={card.isLoading || isLoading}
           isEditable={isEditable}
           onCardAction={onCardAction}
           key={card.id}


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Add isLoading per card that can be used instead of the global dashboard state, and add a per card error state

**Acceptance Test (how to verify the PR)**

- check stories for card errors
