### PR TITLE
feat(table): single selection support for nested table rows

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -568,6 +568,44 @@ storiesOf('Table', module)
       view={{ table: { selectedIds: ['row-3'] } }}
     />
   ))
+  .add('with single select and nested table rows ', () => (
+    <Table
+      columns={tableColumns}
+      data={tableData.map((i, idx) => ({
+        ...i,
+        children:
+          idx === 3
+            ? [getNewRow(idx, 'A'), getNewRow(idx, 'B')]
+            : idx === 7
+            ? [
+                getNewRow(idx, 'A'),
+                {
+                  ...getNewRow(idx, 'B'),
+                  children: [getNewRow(idx, 'B-1'), getNewRow(idx, 'B-2')],
+                },
+                getNewRow(idx, 'C'),
+                {
+                  ...getNewRow(idx, 'D'),
+                  children: [getNewRow(idx, 'D-1'), getNewRow(idx, 'D-2'), getNewRow(idx, 'D-3')],
+                },
+              ]
+            : undefined,
+      }))}
+      options={{
+        hasPagination: true,
+        hasRowSelection: 'single',
+        hasRowExpansion: true,
+        hasRowNesting: true,
+      }}
+      actions={actions}
+      view={{
+        table: {
+          expandedIds: ['row-3', 'row-7', 'row-7_B'],
+          selectedIds: ['row-3_A'],
+        },
+      }}
+    />
+  ))
   .add('with row expansion', () => (
     <Table
       columns={tableColumns}

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -130,12 +130,21 @@ const StyledTableRow = styled(TableRow)`
 const StyledSingleSelectedTableRow = styled(TableRow)`
   &&& {
     background: ${COLORS.lightBlue};
-    border-left: 5px solid ${COLORS.blue};
 
-    td {
-      margin-left: -5px;
+    td:first-of-type {
+      position: relative;
     }
-  }
+
+    td:first-of-type:after {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 3px;
+      background-color: ${COLORS.blue};
+      border-right: solid 1px rgb(223,227,230);
+    }
 `;
 
 const StyledTableExpandRow = styled(TableExpandRow)`
@@ -180,6 +189,28 @@ const StyledTableExpandRow = styled(TableExpandRow)`
         }
       }
     }
+
+    ${props =>
+      props.hasRowSelection === 'single' && props.isSelected
+        ? `
+        background: ${COLORS.lightBlue};
+
+        td:first-of-type {
+          position: relative;
+        }
+    
+        td:first-of-type:after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          height: 100%;
+          width: 3px;
+          background-color: ${COLORS.blue};
+          border-right: solid 1px rgb(223,227,230);
+        }
+        `
+        : ``}
   }
 `;
 
@@ -231,6 +262,28 @@ const StyledTableExpandRowExpanded = styled(TableExpandRow)`
     }
     `
         : ``}
+
+    ${props =>
+      props.hasRowSelection === 'single' && props.isSelected
+        ? `
+        background: ${COLORS.lightBlue};
+
+        td:first-of-type {
+          position: relative;
+        }
+    
+        td:first-of-type:after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          height: 100%;
+          width: 3px;
+          background-color: ${COLORS.blue};
+          border-right: solid 1px rgb(223,227,230);
+        }
+        `
+        : ``}
   }
 `;
 
@@ -252,6 +305,28 @@ const StyledExpansionTableRow = styled(TableRow)`
         border-width: 0 0 0 4px;
       }
     }
+
+    ${props =>
+      props.hasRowSelection === 'single' && props.isSelected
+        ? `
+        background: ${COLORS.lightBlue};
+
+        td:first-of-type {
+          position: relative;
+        }
+    
+        td:first-of-type:after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          height: 100%;
+          width: 3px;
+          background-color: ${COLORS.blue};
+          border-right: solid 1px rgb(223,227,230);
+        }
+        `
+        : ``}
   }
 `;
 
@@ -310,7 +385,11 @@ const TableBodyRow = ({
   rowActionsError,
   rowDetails,
 }) => {
-  const nestingOffset = nestingLevel * 16;
+  const singleSelectionIndicatorWidth = hasRowSelection === 'single' ? 0 : 5;
+  const nestingOffset =
+    hasRowSelection === 'single'
+      ? nestingLevel * 16 - singleSelectionIndicatorWidth
+      : nestingLevel * 16;
   const rowSelectionCell =
     hasRowSelection === 'multi' ? (
       <StyledCheckboxTableCell
@@ -397,6 +476,8 @@ const TableBodyRow = ({
           ariaLabel={clickToCollapseAria}
           expandIconDescription={clickToCollapseAria}
           isExpanded
+          isSelected={isSelected}
+          hasRowSelection={hasRowSelection}
           data-row-nesting={hasRowNesting}
           data-nesting-offset={nestingOffset}
           onExpand={evt => stopPropagationAndCallback(evt, onRowExpanded, id, false)}
@@ -428,6 +509,8 @@ const TableBodyRow = ({
         ariaLabel={clickToExpandAria}
         expandIconDescription={clickToExpandAria}
         isExpanded={false}
+        isSelected={isSelected}
+        hasRowSelection={hasRowSelection}
         onExpand={evt => stopPropagationAndCallback(evt, onRowExpanded, id, true)}
         onClick={() => {
           if (shouldExpandOnRowClick) {
@@ -455,6 +538,8 @@ const TableBodyRow = ({
   ) : (
     <StyledTableRow
       key={id}
+      isSelected={isSelected}
+      hasRowSelection={hasRowSelection}
       onClick={() => {
         if (hasRowSelection === 'single') {
           onRowSelected(id, true);


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Nested rows didn't include the styling for single select. It silently fails currently - table row is selected but no visual change.

**Change List (commits, features, bugs, etc)**

- add single select styling conditions to expanded/nested table rows
- slightly refactor single select for non-nested rows to have same styling approach as nested table rows


**Acceptance Test (how to verify the PR)**

- Check out the deploy preview storybook for new `with single select and nested table rows`
