### PR TITLE
fix(valuecard): explicitly set line height for labels

### DIFF
--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -118,6 +118,7 @@ const shouldLabelWrap = ({ title, isVertical }) => {
  * Render a given attribute label
  */
 const AttributeLabel = styled.div`
+  ${props => `line-height: ${determineLabelFontSize(props)}rem;`}
   ${props => `font-size: ${determineLabelFontSize(props)}rem;`};
   text-align: ${props => getLabelAlignment(props)};
   ${props =>


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- If our Value card gets pulled into projects with css-resets, we need to override their global line-height for our labels

**Acceptance Test (how to verify the PR)**

- Verify the value card stories
