### PR TITLE
fix(timeseriescard): layout adjustments to render chart at 100% height

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -52,6 +52,7 @@ export const CardHeader = styled.div`
 
 export const CardContent = styled.div`
   flex: 1;
+  position: relative;
 `;
 
 const CardTitle = styled.span`
@@ -270,7 +271,7 @@ const Card = ({
         </CardTitle>
         {toolbar}
       </CardHeader>
-      <CardContent height={dimensions.y}>
+      <CardContent>
         {error ? (
           <EmptyMessageWrapper>
             {size === CARD_SIZES.XSMALL || size === CARD_SIZES.XSMALLWIDE

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -10,7 +10,7 @@ import { Button } from 'carbon-components-react';
 import moment from 'moment';
 */
 
-import { chartData, tableColumns, tableData } from '../../utils/sample';
+import { getIntervalChartData, chartData, tableColumns, tableData } from '../../utils/sample';
 import { COLORS, CARD_SIZES, CARD_TYPES } from '../../constants/LayoutConstants';
 
 import Dashboard from './Dashboard';
@@ -178,6 +178,25 @@ const originalCards = [
     values: { health: 'Healthy' },
   },
   {
+    title: 'Temperature',
+    id: 'facility-temperature-timeseries',
+    size: CARD_SIZES.MEDIUM,
+    type: CARD_TYPES.TIMESERIES,
+    content: {
+      series: [
+        {
+          label: 'Temperature',
+          dataSourceId: 'temperature',
+        },
+      ],
+      xLabel: 'Time',
+      yLabel: 'Temperature (˚F)',
+      timeDataSourceId: 'timestamp',
+    },
+    values: getIntervalChartData('day', 10, { min: 10, max: 100 }, 100),
+    interval: 'hour',
+  },
+  {
     title: 'Alerts',
     id: 'alert-table1',
     size: CARD_SIZES.LARGE,
@@ -250,6 +269,31 @@ const originalCards = [
         { label: 'Sev 1', value: 18, color: COLORS.BLUE },
       ],
     },
+  },
+  {
+    title: 'Environment',
+    id: 'facility-multi-timeseries',
+    size: CARD_SIZES.LARGE,
+    type: CARD_TYPES.TIMESERIES,
+    content: {
+      series: [
+        {
+          label: 'Temperature',
+          dataSourceId: 'temperature',
+          // color: text('color', COLORS.PURPLE),
+        },
+        {
+          label: 'Pressure',
+          dataSourceId: 'pressure',
+          // color: text('color', COLORS.PURPLE),
+        },
+      ],
+      xLabel: 'Time',
+      yLabel: 'Temperature (˚F)',
+      timeDataSourceId: 'timestamp',
+    },
+    values: getIntervalChartData('day', 10, { min: 10, max: 100 }, 100),
+    interval: 'hour',
   },
 ];
 


### PR DESCRIPTION
**Summary**

- Removed size calculation of line chart wrapper, instead it will render at 100% width/height inside the CardContent (added relative position)

![image](https://user-images.githubusercontent.com/2175647/59928639-cb1d8400-9404-11e9-8742-e3c09a43e740.png)
