### PR TITLE
fix(dashboard): onLayoutChange needs allLayouts param

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -298,7 +298,9 @@ const Dashboard = ({
         preventCollision={false}
         // Stop the initial animation
         shouldAnimate={isEditable}
-        onLayoutChange={layout => onLayoutChange && onLayoutChange(layout)}
+        onLayoutChange={(layout, allLayouts) =>
+          onLayoutChange && onLayoutChange(layout, allLayouts)
+        }
         onBreakpointChange={newBreakpoint => {
           setBreakpoint(newBreakpoint);
           if (onBreakpointChange) {


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- small fix to the onLayoutChange callback to pass back all the updated layouts

**Change List (commits, features, bugs, etc)**

- Just pass the additional parameter

**Acceptance Test (how to verify the PR)**

- You can verify that as you resize the main Dashboard story, if it's in the Editable state it calls out to onLayoutChange
