### PR TITLE
docs(storybook): update theme, page titles, readme beta install

### DIFF
--- a/.storybook/TitleAddon.js
+++ b/.storybook/TitleAddon.js
@@ -1,0 +1,11 @@
+// https://github.com/storybookjs/storybook/issues/6339#issuecomment-500647083
+import addons from '@storybook/addons';
+import { STORY_RENDERED } from '@storybook/core-events';
+import packageJson from '../package.json';
+
+addons.register('TitleAddon', api => {
+  api.on(STORY_RENDERED, story => {
+    const storyData = api.getCurrentStoryData();
+    document.title = `${storyData.kind}: ${storyData.name} - ${packageJson.name}`;
+  });
+});

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -3,3 +3,4 @@ import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
 import '@storybook/addon-a11y/register';
 import 'storybook-addon-rtl/register';
+import './TitleAddon';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,13 +1,20 @@
 import React from 'react';
-import { configure, addDecorator } from '@storybook/react';
+import { configure, addDecorator, addParameters } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { checkA11y } from '@storybook/addon-a11y';
 import { withKnobs } from '@storybook/addon-knobs';
 import { initializeRTL } from 'storybook-addon-rtl';
+import theme from './theme';
 
 initializeRTL();
 
 import Container from './Container';
+
+addParameters({
+  options: {
+    theme: theme,
+  },
+});
 
 addDecorator(
   withInfo({

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,0 +1,42 @@
+import { create } from '@storybook/theming';
+import { g10 } from '@carbon/themes';
+import { name, homepage } from '../package.json';
+
+const { field01, interactive01, text01, text04, ui01, ui03, ui04, uiBackground } = g10;
+
+export default create({
+  base: 'light',
+
+  colorPrimary: interactive01,
+  colorSecondary: ui04,
+
+  // UI
+  appBg: ui01,
+  appContentBg: uiBackground,
+  appBorderColor: ui04,
+  appBorderRadius: 0,
+
+  // Typography
+  fontBase: '"IBM Plex Sans", sans-serif',
+  fontCode: '"IBM Plex Mono", monospace',
+
+  // Text colors
+  textColor: text01,
+  textInverseColor: text04,
+
+  // Toolbar default and active colors
+  barTextColor: text01,
+  barSelectedColor: interactive01,
+  barBg: uiBackground,
+
+  // Form colors
+  inputBg: field01,
+  inputBorder: ui03,
+  inputTextColor: text01,
+  inputBorderRadius: 0,
+
+  brandTitle: name,
+  brandUrl: homepage,
+  //   brandImage:
+  //     'https://user-images.githubusercontent.com/3360588/59875762-3add3180-9367-11e9-8a65-a6cf7efa5061.png',
+});

--- a/README.MD
+++ b/README.MD
@@ -14,13 +14,13 @@
     <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg" alt="Our Storybook" />
   </a>
   <a href="https://travis-ci.org/IBM/carbon-addons-iot-react">
-    <img src="https://travis-ci.org/IBM/carbon-addons-iot-react.svg?branch=master" alt="Build Status" />
+    <img src="https://travis-ci.org/IBM/carbon-addons-iot-react.svg?branch=beta" alt="Build Status" />
   </a>
   <a href="https://www.npmjs.com/package/carbon-addons-iot-react">
     <img src="https://img.shields.io/npm/v/carbon-addons-iot-react/beta.svg" alt="@beta release" />
   </a>
-  <a href="https://coveralls.io/github/IBM/carbon-addons-iot-react?branch=master">
-    <img src="https://coveralls.io/repos/github/IBM/carbon-addons-iot-react/badge.svg?branch=master" alt="Coverage Report" />
+  <a href="https://coveralls.io/github/IBM/carbon-addons-iot-react?branch=beta">
+    <img src="https://coveralls.io/repos/github/IBM/carbon-addons-iot-react/badge.svg?branch=beta" alt="Coverage Report" />
   </a>
   <a href="https://github.com/IBM/carbon-addons-iot-react/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Carbon add-ons for Watson IoT is released under the Apache-2.0 license" />
@@ -32,16 +32,18 @@
 
 ## Getting Started
 
+Add the `@beta` suffix to the package name to install the latest release from the `beta` branch:
+
 Run the following command using [npm](https://www.npmjs.com/):
 
 ```bash
-npm install -S carbon-components carbon-components-react carbon-icons carbon-addons-iot-react
+npm install -S carbon-components carbon-components-react carbon-icons carbon-addons-iot-react@beta
 ```
 
 If you prefer [Yarn](https://yarnpkg.com/en/), use the following command instead:
 
 ```bash
-yarn add carbon-components carbon-components-react carbon-icons carbon-addons-iot-react
+yarn add carbon-components carbon-components-react carbon-icons carbon-addons-iot-react@beta
 ```
 
 You can then import any component that you need by doing the following in your project:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bugs": {
     "url": "https://github.com/IBM/carbon-addons-iot-react/issues"
   },
+  "homepage": "https://github.com/IBM/carbon-addons-iot-react",
   "scripts": {
     "build": "rollup -c",
     "build:storybook": "build-storybook",
@@ -32,6 +33,7 @@
     }
   },
   "dependencies": {
+    "@carbon/themes": "^10.3.0",
     "c3": "^0.7.1",
     "classnames": "^2.2.5",
     "immutability-helper": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@carbon/colors@10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-10.2.0.tgz#a9b0f2372fdf231a34b070ec8cff3f9d7a044fbd"
+  integrity sha512-WH6IQNt/HfqExMhTcgIBJN6Cqunrr+udtEKZAE3k8eMlBceKpiidfzgVNbAVKAujGjgwDR60XF+gQGRbteCWUg==
+
 "@carbon/icon-helpers@10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@carbon/icon-helpers/-/icon-helpers-10.1.1.tgz#08affd6f68936ba48beca7a732b0e70bd5ab8ca0"
@@ -1351,6 +1356,13 @@
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@carbon/icons/-/icons-10.1.0.tgz#12daa64ef63c47128c2b2cc570456df5fdc34f1d"
   integrity sha512-LEgjcD2W87t6vmmv9cfEMIji92gAgadMMOmb6LqXFepPn3dQechHmejS4td8K2thOf4hIuqcOQUlJSHJwCFMuA==
+
+"@carbon/themes@^10.3.0":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@carbon/themes/-/themes-10.3.0.tgz#c31f687f5ca2f58ec89ff8505f24b431a561cc36"
+  integrity sha512-Ig9Dmn4f2PWD7SWvRmXcc8AbNBnZkIZSlYPge/rlStQbGX4jDjQ51ksHPEA46fWtEwo1et1Qc6ZQfJwW/0Fs+w==
+  dependencies:
+    "@carbon/colors" "10.2.0"
 
 "@commitlint/cli@^7.2.1":
   version "7.2.1"


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- A few items towards the storybook theming. Doesn't completely resolve - will update the linked issue with remaining items.

**Change List (commits, features, bugs, etc)**

- add carbon themes dep
- add storybook theme override
- add title addon for dynamic page titles
- update readme w/ beta install instructions

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- IBM/carbon-addons-iot-react#309

**Acceptance Test (how to verify the PR)**

- View the deploy preview, theme should look like it does in my dev env, also the document.title should be updated per story.

![image](https://user-images.githubusercontent.com/3360588/59947756-b1dffc00-9433-11e9-9a4f-5380c22615fa.png)

