### PR TITLE
fix(filedrop): support multiple tries with same file

### DIFF
--- a/src/components/FileDrop/FileDrop.jsx
+++ b/src/components/FileDrop/FileDrop.jsx
@@ -235,6 +235,11 @@ class FileDrop extends React.Component {
         <span
           onClick={() => {
             if (this.fileInput) {
+              if (!multiple) {
+                this.setState({ files: [] });
+              }
+              this.fileInput.files = null;
+              this.fileInput.value = null;
               this.fileInput.click();
             }
           }}

--- a/src/components/FileDrop/FileDrop.story.jsx
+++ b/src/components/FileDrop/FileDrop.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import FileDrop from './FileDrop';
 
@@ -9,8 +10,8 @@ const FileDropProps = {
   description: 'Any file can be uploaded.  Feel free to upload more than one!',
   buttonLabel: 'Try it out!',
   kind: 'browse',
-  onData: data => console.log('FileDrop.onData', data),
-  onError: err => console.log('FileDrop.onError', err),
+  onData: action('onData'),
+  onError: action('onError'),
 };
 
 storiesOf('FileDrop', module)

--- a/src/components/Page/EditPage.jsx
+++ b/src/components/Page/EditPage.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled from 'styled-components';
+import { SkeletonText } from 'carbon-components-react';
 
 import ButtonEnhanced from '../ButtonEnhanced/ButtonEnhanced';
 
@@ -38,6 +39,7 @@ const propTypes = {
   children: PropTypes.node.isRequired,
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
   /** Labels needed to support i18n */
   i18n: PropTypes.shape({
     saveLabel: PropTypes.string,
@@ -48,6 +50,7 @@ const propTypes = {
 
 const defaultProps = {
   className: null,
+  isLoading: false,
   i18n: {
     saveLabel: 'Save',
     cancelLabel: 'Cancel',
@@ -66,6 +69,7 @@ const EditPage = ({
   children,
   i18n: { saveLabel, cancelLabel },
   i18n,
+  isLoading,
   ...others
 }) => {
   const [isSaving, setSaving] = useState();
@@ -80,16 +84,27 @@ const EditPage = ({
   };
   return (
     <StyledEditPage className={classNames('bx--modal-container', className)}>
-      <PageHeader {...others} onClose={onClose} i18n={i18n} />
-      <StyledPageContent>{children}</StyledPageContent>
-      <StyledPageFooter className="bx--modal-footer">
-        <ButtonEnhanced kind="secondary" onClick={onClose}>
-          {cancelLabel}
-        </ButtonEnhanced>
-        <ButtonEnhanced onClick={handleSave} loading={isSaving}>
-          {saveLabel}
-        </ButtonEnhanced>
-      </StyledPageFooter>
+      {isLoading ? (
+        <Fragment>
+          <PageHeader {...others} onClose={onClose} i18n={i18n} isLoading />
+          <StyledPageContent>
+            <SkeletonText width="30%" />
+          </StyledPageContent>
+        </Fragment>
+      ) : (
+        <Fragment>
+          <PageHeader {...others} onClose={onClose} i18n={i18n} />
+          <StyledPageContent>{children}</StyledPageContent>
+          <StyledPageFooter className="bx--modal-footer">
+            <ButtonEnhanced kind="secondary" onClick={onClose}>
+              {cancelLabel}
+            </ButtonEnhanced>
+            <ButtonEnhanced onClick={handleSave} loading={isSaving}>
+              {saveLabel}
+            </ButtonEnhanced>
+          </StyledPageFooter>
+        </Fragment>
+      )}
     </StyledEditPage>
   );
 };

--- a/src/components/Page/EditPage.story.jsx
+++ b/src/components/Page/EditPage.story.jsx
@@ -14,6 +14,7 @@ const commonEditPageProps = {
 
 storiesOf('EditPage', module)
   .add('normal', () => <EditPage {...commonEditPageProps} />)
+  .add('isLoading', () => <EditPage {...commonEditPageProps} isLoading />)
   .add('with blurb', () => (
     <EditPage {...commonEditPageProps} blurb={text('blurb', 'My blurrrrbbbb!!')} />
   ));

--- a/src/components/Page/PageHeader.jsx
+++ b/src/components/Page/PageHeader.jsx
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
+import { SkeletonText } from 'carbon-components-react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -28,6 +29,7 @@ class PageHeader extends Component {
   static propTypes = {
     /** Title in the header  */
     title: PropTypes.string.isRequired,
+    isLoading: PropTypes.bool,
     blurb: PropTypes.string,
     children: PropTypes.node,
     onClose: PropTypes.func.isRequired,
@@ -37,6 +39,7 @@ class PageHeader extends Component {
   static defaultProps = {
     blurb: null,
     children: null,
+    isLoading: false,
     i18n: {
       closeLabel: 'Close',
     },
@@ -51,39 +54,48 @@ class PageHeader extends Component {
       onClose,
       children,
       className,
+      isLoading,
       i18n: { closeLabel },
     } = this.props;
 
     return (
       <StyledPageHeader className={className}>
-        <div className="bx--modal-header">
-          <StyledDivHeading>
-            <p className="bx--modal-header__heading bx--type-beta">{title}</p>
+        {isLoading ? (
+          <StyledDivHeading className="bx--modal-header">
+            <SkeletonText className="bx--modal-header__heading bx--type-beta" width="10%" />
           </StyledDivHeading>
-          {children || null}
-          <button
-            className="bx--modal-close"
-            type="button"
-            data-modal-close
-            aria-label={closeLabel}
-            onClick={onClose}
-          >
-            <svg
-              className="bx--modal-close__icon"
-              width="10"
-              height="10"
-              viewBox="0 0 10 10"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <title>{closeLabel}</title>
-              <path
-                d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
-                fillRule="nonzero"
-              />
-            </svg>
-          </button>
-        </div>
-        {blurb ? <div>{blurb}</div> : null}
+        ) : (
+          <Fragment>
+            <div className="bx--modal-header">
+              <StyledDivHeading>
+                <p className="bx--modal-header__heading bx--type-beta">{title}</p>
+              </StyledDivHeading>
+              {children || null}
+              <button
+                className="bx--modal-close"
+                type="button"
+                data-modal-close
+                aria-label={closeLabel}
+                onClick={onClose}
+              >
+                <svg
+                  className="bx--modal-close__icon"
+                  width="10"
+                  height="10"
+                  viewBox="0 0 10 10"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <title>{closeLabel}</title>
+                  <path
+                    d="M6.32 5L10 8.68 8.68 10 5 6.32 1.32 10 0 8.68 3.68 5 0 1.32 1.32 0 5 3.68 8.68 0 10 1.32 6.32 5z"
+                    fillRule="nonzero"
+                  />
+                </svg>
+              </button>
+            </div>
+            {blurb ? <div>{blurb}</div> : null}
+          </Fragment>
+        )}
       </StyledPageHeader>
     );
   };

--- a/src/components/Page/PageHeader.story.jsx
+++ b/src/components/Page/PageHeader.story.jsx
@@ -12,6 +12,7 @@ const commonPageHeaderProps = {
 
 storiesOf('PageHeader', module)
   .add('normal', () => <PageHeader {...commonPageHeaderProps} />)
+  .add('is loading', () => <PageHeader {...commonPageHeaderProps} isLoading />)
   .add('with blurb', () => (
     <PageHeader {...commonPageHeaderProps} blurb={text('blurb', 'My blurrrrbbbb!!')} />
   ))


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- fix, FileDrop drag and drop wouldn't trigger the upload on the second drop of the same file if we used the upload button
- feat(EditPage): add isLoading styles to the EditPage

**Acceptance Test (how to verify the PR)**

- Verify in the FileDrop story that you can upload files and it always triggers the onData action even without clearing the files
- Verify the new isLoading Edit page stories
