### PR TITLE
chore(locale): locale x-axis date format, use useDeepCompareEffect

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import moment from 'moment';
 import { LineChart } from '@carbon/charts-react';
 import '@carbon/charts/style.css';
@@ -6,6 +6,7 @@ import isEmpty from 'lodash/isEmpty';
 import 'c3/c3.css';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
@@ -68,6 +69,7 @@ const TimeSeriesCard = ({
   interval,
   isEditable,
   values: valuesProp,
+  locale,
   ...others
 }) => {
   let chartRef = useRef();
@@ -89,6 +91,7 @@ const TimeSeriesCard = ({
     );
 
   const formatInterval = (timestamp, index, ticksInterval) => {
+    moment.locale(locale);
     const m = moment.unix(timestamp / 1000);
 
     return interval === 'hour' && index === 0
@@ -135,12 +138,15 @@ const TimeSeriesCard = ({
       : ' '.repeat(idx)
   );
 
-  useEffect(() => {
-    if (chartRef) {
-      const chartData = formatChartData(labels, series, values);
-      chartRef.chart.setData(chartData);
-    }
-  });
+  useDeepCompareEffect(
+    () => {
+      if (chartRef) {
+        const chartData = formatChartData(labels, series, values);
+        chartRef.chart.setData(chartData);
+      }
+    },
+    [values]
+  );
 
   return (
     <Card title={title} size={size} {...others} isEditable={isEditable} isEmpty={isEmpty(values)}>

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -665,6 +665,36 @@ storiesOf('TimeSeriesCard (Experimental)', module)
       </div>
     );
   })
+  .add('large / LOCALE DATE', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TimeSeriesCard
+          title={text('title', 'Temperature')}
+          id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
+          content={object('content', {
+            series: [
+              {
+                label: 'Temperature',
+                dataSourceId: 'temperature',
+                color: text('color', COLORS.MAGENTA),
+              },
+            ],
+            unit: '˚F',
+            xLabel: text('xLabel', 'Time'),
+            yLabel: text('yLabel', 'Temperature'),
+            timeDataSourceId: 'timestamp',
+          })}
+          locale="sq"
+          values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100)}
+          interval="day"
+          breakpoint="lg"
+          size={size}
+        />
+      </div>
+    );
+  })
   .add('empty', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
     return (


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Use locale for x-axis date
- Use useDeepCompareEffect instead of useEffect

![image](https://user-images.githubusercontent.com/22034430/60134279-8d5a8b80-9775-11e9-8f1b-d97182b34b95.png)


**Change List (commits, features, bugs, etc)**

- items_here

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#NUMBER

**Acceptance Test (how to verify the PR)**

- tests here
