### PR TITLE
fix(timeseries): reduce ticks for smaller cards

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -16,6 +16,7 @@ import { generateSampleValues } from './timeSeriesUtils';
 
 const LineChartWrapper = styled.div`
   padding-left: 16px;
+  padding-right: 1rem;
   padding-top: ${props => (props.isLegendHidden ? '16px' : '0px')};
   padding-bottom: 16px;
   position: absolute;

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -122,8 +122,11 @@ const TimeSeriesCard = ({
 
   const maxTicksPerSize = () => {
     switch (size) {
+      case CARD_SIZES.SMALL:
+        return 2;
       case CARD_SIZES.MEDIUM:
-        return 6;
+        return 4;
+      case CARD_SIZES.WIDE:
       case CARD_SIZES.LARGE:
         return 6;
       case CARD_SIZES.XLARGE:
@@ -147,7 +150,7 @@ const TimeSeriesCard = ({
         chartRef.chart.setData(chartData);
       }
     },
-    [values]
+    [values, labels, series]
   );
 
   return (


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- reduce the number of ticks for smaller cards, they're not fitting on real dashboards

**Acceptance Test (how to verify the PR)**

- Verify the smaller card stories (in a real dashboard layout ideally)
