### PR TITLE
fix(table): bug on late loading tables not paging

### DIFF
--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -42,7 +42,14 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
   // Need to initially sort and filter the tables data, but preserve the selectedId
   useDeepCompareEffect(
     () => {
-      dispatch(tableRegister({ data: initialData, isLoading, view: initialState }));
+      dispatch(
+        tableRegister({
+          data: initialData,
+          isLoading,
+          view: initialState,
+          totalItems: initialData.length,
+        })
+      );
     },
     [initialData, isLoading, initialState]
   );

--- a/src/components/Table/StatefulTableMockReducers.test.jsx
+++ b/src/components/Table/StatefulTableMockReducers.test.jsx
@@ -40,6 +40,7 @@ describe('StatefulTable tests with Mock reducer', () => {
       payload: { data: [], isLoading: undefined, view: expect.any(Object) },
       instanceId: null,
       type: 'TABLE_REGISTER',
+      totalItems: 0,
     });
     statefulTable.setProps({ data: initialState.data });
     // Then table dispatches another item with the real data
@@ -47,6 +48,7 @@ describe('StatefulTable tests with Mock reducer', () => {
       payload: { data: initialState.data, isLoading: undefined, view: expect.any(Object) },
       instanceId: null,
       type: 'TABLE_REGISTER',
+      totalItems: initialState.data.length,
     });
   });
   test('check callbacks are propagated up!', () => {

--- a/src/components/Table/StatefulTableMockReducers.test.jsx
+++ b/src/components/Table/StatefulTableMockReducers.test.jsx
@@ -37,18 +37,21 @@ describe('StatefulTable tests with Mock reducer', () => {
     expect(statefulTable.find(EmptyTable)).toHaveLength(1);
     // First we're called by empty array
     expect(mockDispatch).toHaveBeenCalledWith({
-      payload: { data: [], isLoading: undefined, view: expect.any(Object) },
+      payload: { data: [], isLoading: undefined, view: expect.any(Object), totalItems: 0 },
       instanceId: null,
       type: 'TABLE_REGISTER',
-      totalItems: 0,
     });
     statefulTable.setProps({ data: initialState.data });
     // Then table dispatches another item with the real data
     expect(mockDispatch).toHaveBeenCalledWith({
-      payload: { data: initialState.data, isLoading: undefined, view: expect.any(Object) },
+      payload: {
+        data: initialState.data,
+        isLoading: undefined,
+        view: expect.any(Object),
+        totalItems: initialState.data.length,
+      },
       instanceId: null,
       type: 'TABLE_REGISTER',
-      totalItems: initialState.data.length,
     });
   });
   test('check callbacks are propagated up!', () => {

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -18,9 +18,9 @@ export const TABLE_SEARCH_APPLY = 'TABLE_SEARCH_APPLY';
 export const TABLE_EMPTY_STATE_ACTION = 'TABLE_EMPTY_STATE_ACTION';
 export const TABLE_LOADING_SET = 'TABLE_LOADING_SET';
 
-export const tableRegister = (data, totalItems, instanceId = null) => ({
+export const tableRegister = ({ data, isLoading, view, totalItems, instanceId = null }) => ({
   type: TABLE_REGISTER,
-  payload: data,
+  payload: { data, view, isLoading },
   totalItems,
   instanceId,
 });

--- a/src/components/Table/tableActionCreators.js
+++ b/src/components/Table/tableActionCreators.js
@@ -20,8 +20,7 @@ export const TABLE_LOADING_SET = 'TABLE_LOADING_SET';
 
 export const tableRegister = ({ data, isLoading, view, totalItems, instanceId = null }) => ({
   type: TABLE_REGISTER,
-  payload: { data, view, isLoading },
-  totalItems,
+  payload: { data, view, isLoading, totalItems },
   instanceId,
 });
 

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -215,10 +215,10 @@ export const tableReducer = (state = {}, action) => {
     // By default we need to setup our sorted and filteredData and turn off the loading state
     case TABLE_REGISTER: {
       const updatedData = action.payload.data || state.data;
-      const { view } = action.payload;
+      const { view, totalItems } = action.payload;
       const pagination = get(state, 'view.pagination')
         ? {
-            totalItems: { $set: updatedData.length },
+            totalItems: { $set: totalItems || updatedData.length },
           }
         : {};
       return update(state, {
@@ -236,7 +236,6 @@ export const tableReducer = (state = {}, action) => {
                 get(state, 'view.filters')
               ),
             },
-
             loadingState: {
               $set: {
                 isLoading: action.payload.isLoading,

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -216,11 +216,17 @@ export const tableReducer = (state = {}, action) => {
     case TABLE_REGISTER: {
       const updatedData = action.payload.data || state.data;
       const { view } = action.payload;
+      const pagination = get(state, 'view.pagination')
+        ? {
+            totalItems: { $set: updatedData.length },
+          }
+        : {};
       return update(state, {
         data: {
           $set: updatedData,
         },
         view: {
+          pagination,
           table: {
             filteredData: {
               $set: filterSearchAndSort(
@@ -230,6 +236,7 @@ export const tableReducer = (state = {}, action) => {
                 get(state, 'view.filters')
               ),
             },
+
             loadingState: {
               $set: {
                 isLoading: action.payload.isLoading,


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- If you late loaded a table, subsequent attempts to page through its data would fail.  This is because the totalItems bit wasn't being stored on the pagination widget
- Added a fix to pass along the totalItem count every time we called TABLE_REGISTER

**Acceptance Test (how to verify the PR)**

- Hard to verify locally unfortunately, but we saw this error in our dashbaord