### PR TITLE
fix(navbar): flip page hero to the top of the tabs

### DIFF
--- a/src/components/NavigationBar/NavigationBar.jsx
+++ b/src/components/NavigationBar/NavigationBar.jsx
@@ -55,7 +55,6 @@ const StyledTabChildren = styled.div`
   background: ${COLORS.superLightGray};
   padding-left: ${PADDING.horizontalWrapPadding};
   padding-right: ${PADDING.horizontalWrapPadding};
-  min-height: 100vh;
 `;
 
 const StyledActions = styled.div`

--- a/src/components/NavigationBar/NavigationBar.jsx
+++ b/src/components/NavigationBar/NavigationBar.jsx
@@ -121,6 +121,7 @@ const NavigationBar = ({ tabs, hero, actions, onSelectionChange, workArea, ...ot
     {workArea || null}
     <StyledNavigationContainer hasActions={actions.length > 0}>
       {workArea ? <StyledOverlay /> : null}
+      {hero}
       <StyledTabToContent>
         <Tabs
           {...others}
@@ -129,18 +130,19 @@ const NavigationBar = ({ tabs, hero, actions, onSelectionChange, workArea, ...ot
           {tabs.map(({ children, id, ...other }) => (
             <Tab key={id} {...other}>
               <StyledTabContent>
-                {hero}
                 <StyledTabChildren>{children}</StyledTabChildren>
               </StyledTabContent>
             </Tab>
           ))}
         </Tabs>
       </StyledTabToContent>
-      <StyledActions>
-        {actions.map(({ id, ...other }) => (
-          <Button key={id} {...other} />
-        ))}
-      </StyledActions>
+      {actions && actions.length > 0 ? (
+        <StyledActions>
+          {actions.map(({ id, ...other }) => (
+            <Button key={id} {...other} />
+          ))}
+        </StyledActions>
+      ) : null}
     </StyledNavigationContainer>
   </Fragment>
 );

--- a/src/components/NavigationBar/NavigationBar.story.jsx
+++ b/src/components/NavigationBar/NavigationBar.story.jsx
@@ -61,6 +61,7 @@ const StatefulNavigationBar = () => {
 
 storiesOf('NavigationBar', module)
   .add('normal', () => <NavigationBar {...navBarProps} />)
+  .add('start with tab 2 selected', () => <NavigationBar {...navBarProps} selected={1} />)
   .add('with actions', () => (
     <NavigationBar
       {...navBarProps}


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- summary_here

**Change List (commits, features, bugs, etc)**

- items_here

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#NUMBER

**Acceptance Test (how to verify the PR)**

- Verify that the hero is now on top of the Navigation bar
