### PR TITLE
feat(tooltip): add tooltip in hero

### DIFF
--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import { Breadcrumb, BreadcrumbItem } from 'carbon-components-react';
+import Info from '@carbon/icons-react/lib/information/20';
+import { Breadcrumb, BreadcrumbItem, Tooltip } from 'carbon-components-react';
 
 import { COLORS } from '../../styles/styles';
 
@@ -20,6 +21,11 @@ const propTypes = {
       isCurrentPage: PropTypes.bool, // defaults to false
     })
   ),
+  tooltip: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    href: PropTypes.string,
+    linkLabel: PropTypes.string,
+  }),
   className: PropTypes.string,
 };
 
@@ -29,6 +35,7 @@ const defaultProps = {
   className: null,
   rightContent: null,
   breadcrumb: [],
+  tooltip: null,
 };
 
 const StyledHero = styled.div`
@@ -85,7 +92,7 @@ const StyledBreadcrumb = styled(Breadcrumb)`
 /**
  * Renders the hero text and styles for the page.  Can either render Breadcrumb, Title with description and secundary nav.
  */
-const Hero = ({ title, description, className, rightContent, breadcrumb }) => (
+const Hero = ({ title, description, className, rightContent, breadcrumb, tooltip }) => (
   <StyledHero className={className}>
     <Fragment>
       <StyledTitleSection>
@@ -96,7 +103,27 @@ const Hero = ({ title, description, className, rightContent, breadcrumb }) => (
             </BreadcrumbItem>
           ))}
         </StyledBreadcrumb>
-        <StyledTitle>{title}</StyledTitle>
+        <StyledTitle>
+          {title}
+          {tooltip ? (
+            <Tooltip
+              clickToOpen
+              tabIndex={0}
+              triggerText=""
+              triggerId="tooltip"
+              renderIcon={React.forwardRef((props, ref) => (
+                <Info ref={ref} />
+              ))}
+            >
+              <p>{tooltip.message}</p>
+              <div className="bx--tooltip__footer">
+                <a href={tooltip.href} className="bx--link">
+                  {tooltip.linkLabel}
+                </a>
+              </div>
+            </Tooltip>
+          ) : null}
+        </StyledTitle>
         <StyledHeroWrap>
           {description ? <StyledPageDescription>{description}</StyledPageDescription> : null}
         </StyledHeroWrap>

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -99,7 +99,7 @@ const Hero = ({ title, description, className, rightContent, breadcrumb, tooltip
         <StyledBreadcrumb noTrailingSlash>
           {breadcrumb.map(({ href = undefined, isCurrentPage = false, label }) => (
             <BreadcrumbItem href={href} isCurrentPage={isCurrentPage}>
-              <span>{label}</span>
+              <a href={href}>{label}</a>
             </BreadcrumbItem>
           ))}
         </StyledBreadcrumb>
@@ -116,11 +116,13 @@ const Hero = ({ title, description, className, rightContent, breadcrumb, tooltip
               ))}
             >
               <p>{tooltip.message}</p>
-              <div className="bx--tooltip__footer">
-                <a href={tooltip.href} className="bx--link">
-                  {tooltip.linkLabel}
-                </a>
-              </div>
+              {tooltip.href && tooltip.linkLabel ? (
+                <div className="bx--tooltip__footer">
+                  <a href={tooltip.href} className="bx--link">
+                    {tooltip.linkLabel}
+                  </a>
+                </div>
+              ) : null}
             </Tooltip>
           ) : null}
         </StyledTitle>

--- a/src/components/Hero/Hero.jsx
+++ b/src/components/Hero/Hero.jsx
@@ -45,7 +45,6 @@ const StyledHero = styled.div`
   padding-right: 32px;
   padding-bottom: 24px;
   display: flex;
-  flex: 1 1;
   flex-flow: row nowrap;
 `;
 

--- a/src/components/Hero/Hero.story.jsx
+++ b/src/components/Hero/Hero.story.jsx
@@ -22,6 +22,7 @@ const tooltip = {
   href: '/',
   linkLabel: 'Learn more',
 };
+
 storiesOf('Hero (Experimental)', module)
   .add('normal', () => <Hero title="Explore" />)
   .add('with description', () => (
@@ -31,4 +32,7 @@ storiesOf('Hero (Experimental)', module)
   .add('with breadcrumb', () => <Hero {...commonPageHeroProps} breadcrumb={breadcrumb} />)
   .add('with tooltip', () => (
     <Hero {...commonPageHeroProps} breadcrumb={breadcrumb} tooltip={tooltip} />
+  ))
+  .add('with tooltip (no link)', () => (
+    <Hero {...commonPageHeroProps} breadcrumb={breadcrumb} tooltip={{ message: tooltip.message }} />
   ));

--- a/src/components/Hero/Hero.story.jsx
+++ b/src/components/Hero/Hero.story.jsx
@@ -16,10 +16,19 @@ const breadcrumb = [
   { label: 'Item 1', isCurrentPage: true },
 ];
 
+const tooltip = {
+  message:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In ut auctor tortor, et condimentum dolor.',
+  href: '/',
+  linkLabel: 'Learn more',
+};
 storiesOf('Hero (Experimental)', module)
   .add('normal', () => <Hero title="Explore" />)
   .add('with description', () => (
     <Hero title="Explore" description={commonPageHeroProps.description} />
   ))
   .add('with rigth content', () => <Hero {...commonPageHeroProps} />)
-  .add('with breadcrumb', () => <Hero {...commonPageHeroProps} breadcrumb={breadcrumb} />);
+  .add('with breadcrumb', () => <Hero {...commonPageHeroProps} breadcrumb={breadcrumb} />)
+  .add('with tooltip', () => (
+    <Hero {...commonPageHeroProps} breadcrumb={breadcrumb} tooltip={tooltip} />
+  ));


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

-  Tooltip in hero

![image](https://user-images.githubusercontent.com/22034430/61002447-f0345100-a337-11e9-9e34-329aac2a6ad9.png)


- CSS property update
- `BreadcrumbItem` with `<a href="">`in  content