### PR TITLE
fix(imagecard): show error when invalid image

### DIFF
--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -17,7 +17,8 @@ const ImageCard = ({ title, content, content: { data: image }, size, ...others }
     <Card title={title} size={size} {...others}>
       {!others.isLoading ? (
         <ContentWrapper>
-          <ImageHotspots src={image.src} alt={image.alt} />
+          {image && image.src && <ImageHotspots src={image.src} alt={image.alt} />}
+          <p>Error retrieving image.</p>
         </ContentWrapper>
       ) : null}
     </Card>

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -17,8 +17,11 @@ const ImageCard = ({ title, content, content: { data: image }, size, ...others }
     <Card title={title} size={size} {...others}>
       {!others.isLoading ? (
         <ContentWrapper>
-          {image && image.src && <ImageHotspots src={image.src} alt={image.alt} />}
-          <p>Error retrieving image.</p>
+          {image && image.src ? (
+            <ImageHotspots src={image.src} alt={image.alt} />
+          ) : (
+            <p>Error retrieving image.</p>
+          )}
         </ContentWrapper>
       ) : null}
     </Card>

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -18,7 +18,6 @@ storiesOf('ImageCard (Experimental)', module).add('basic', () => {
         title={text('title', 'Image')}
         id="image-hotspots"
         content={object('content', {
-          title: 'Image',
           data: image,
         })}
         breakpoint="lg"


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- ImageCard now shows an error when it can't load image.

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#395

**Acceptance Test (how to verify the PR)**

- yarn test
