### PR TITLE
fix(imagecard): restrict sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dnd-html5-backend": "2.5.1",
     "react-dnd-test-backend": "^7.2.0",
     "react-grid-layout": "^0.16.6",
-    "react-image-hotspots": "^1.0.6",
+    "react-image-hotspots": "^1.1.0",
     "react-resizable": "^1.8.0",
     "react-sizeme": "^2.6.3",
     "react-transition-group": "^2.6.0",

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -12,12 +12,22 @@ const ContentWrapper = styled.div`
   padding: 0 16px 16px 16px;
 `;
 
+const supportedSizes = [CARD_SIZES.MEDIUM, CARD_SIZES.WIDE, CARD_SIZES.LARGE, CARD_SIZES.XLARGE];
+
 const ImageCard = ({ title, content, content: { data: image }, size, ...others }) => {
   return (
     <Card title={title} size={size} {...others}>
       {!others.isLoading ? (
         <ContentWrapper>
-          <ImageHotspots src={image.src} alt={image.alt} />
+          {supportedSizes.includes(size) ? (
+            image && image.src ? (
+              <ImageHotspots src={image.src} alt={image.alt} />
+            ) : (
+              <p>Error retrieving image.</p>
+            )
+          ) : (
+            <p>Size not supported.</p>
+          )}
         </ContentWrapper>
       ) : null}
     </Card>

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -18,7 +18,6 @@ storiesOf('ImageCard (Experimental)', module).add('basic', () => {
         title={text('title', 'Image')}
         id="image-hotspots"
         content={object('content', {
-          title: 'Image',
           data: image,
         })}
         breakpoint="lg"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11638,10 +11638,10 @@ react-grid-layout@^0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
-react-image-hotspots@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/react-image-hotspots/-/react-image-hotspots-1.0.6.tgz#4c9eb14b60edfeec8559afea38e0963043b83102"
-  integrity sha512-5dcowhQ1wvqKYntqwavmqgOO9MeWUzW4mOCn4erzlYyaF01+mfhIiemdmWvI6VAYzyQR1i+u2NMReFsegGWPdQ==
+react-image-hotspots@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-image-hotspots/-/react-image-hotspots-1.1.0.tgz#2b1901337fde01d5fff3746a65ab825e853ef711"
+  integrity sha512-uD6SnorDiI5SRWx2fVoaVPPyyyUUhgKMl/DETXuM+yiXyWCSrwkx9PJLvW4gbfDeOewqmYnsPY27R4tr0DnovA==
 
 react-inspector@^2.3.0:
   version "2.3.1"


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Restrict card sizes for ImageCard

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#395

**Acceptance Test (how to verify the PR)**

- The smaller sizes shouldn't be accepted for ImageCard
