### PR TITLE
feat(tablecard): support editing dashboard with table cards

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -104,7 +104,7 @@ const StyledExpandedRowContent = styled.div`
 const TableCard = ({
   id,
   title,
-  content: { columns, showHeader, expandedRows, sort },
+  content: { columns = [], showHeader, expandedRows, sort },
   size,
   onCardAction,
   values: data,
@@ -295,10 +295,14 @@ const TableCard = ({
           },
           filters: [],
           table: {
-            sort: {
-              columnId: columnStartSort.id,
-              direction: sort,
-            },
+            ...(columnStartSort
+              ? {
+                  sort: {
+                    columnId: columnStartSort.id,
+                    direction: sort,
+                  },
+                }
+              : {}),
           },
         }}
         showHeader={showHeader !== undefined ? showHeader : true}

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -227,7 +227,7 @@ storiesOf('Table Card (Experimental)', module)
         ...item,
         values: {
           ...item.values,
-          alert: <a href="#">{item.values.alert}</a>,
+          alert: <a href="#">{item.values.alert}</a>, //eslint-disable-line
         },
       };
     });
@@ -276,6 +276,24 @@ storiesOf('Table Card (Experimental)', module)
           content={{
             columns: tableColumns,
           }}
+          onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
+          size={size}
+        />
+      </div>
+    );
+  })
+  .add('editable', () => {
+    const size = CARD_SIZES.LARGE;
+
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TableCard
+          title={text('title', 'Open Alerts')}
+          id="table-list"
+          content={{
+            columns: tableColumns,
+          }}
+          isEditable
           onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
           size={size}
         />

--- a/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import uuidv1 from 'uuid/v1';
 
 export const generateSampleValues = (series, timeDataSourceId) => {
   const attributeNames = series.map(line => line.dataSourceId);
@@ -9,6 +10,21 @@ export const generateSampleValues = (series, timeDataSourceId) => {
     ...attributeNames.reduce((allAttributes, attribute) => {
       allAttributes[attribute] = Math.random() * 100; // eslint-disable-line
       return allAttributes;
+    }, {}),
+  }));
+};
+
+/**
+ * Generate fake data to fill table columns for the preview mode of the table in the dashboard
+ * @param {*} columns
+ */
+export const generateTableSampleValues = columns => {
+  const sampleValues = Array(10).fill(1);
+  return sampleValues.map(() => ({
+    id: uuidv1(),
+    values: columns.reduce((obj, column) => {
+      obj[column] = '...'; // eslint-disable-line
+      return obj;
     }, {}),
   }));
 };

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -1,4 +1,6 @@
-import { generateSampleValues } from './timeSeriesUtils';
+import every from 'lodash/every';
+
+import { generateSampleValues, generateTableSampleValues } from './timeSeriesUtils';
 
 describe('timeSeriesUtils', () => {
   test('generateSampleValues', () => {
@@ -9,5 +11,14 @@ describe('timeSeriesUtils', () => {
     expect(sampleValues).toHaveLength(10);
     expect(sampleValues[0].temperature).toBeDefined();
     expect(sampleValues[0].pressure).toBeDefined();
+  });
+  test('generateTableSampleValues', () => {
+    const tableSampleValues = generateTableSampleValues(['column1', 'column2', 'column3']);
+    expect(tableSampleValues).toHaveLength(10);
+    expect(every(tableSampleValues, 'id')).toEqual(true); // every row should have its own id
+    expect(every(tableSampleValues, 'values')).toEqual(true); // every row should have its own values
+    expect(tableSampleValues[0].values).toHaveProperty('column1');
+    expect(tableSampleValues[0].values).toHaveProperty('column2');
+    expect(tableSampleValues[0].values).toHaveProperty('column3');
   });
 });


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- feat(tablecard) show sample values while the tablecard is being edited
- fix(tablecard): support empty column array by default (as the first time a tablecard is added to a dashboard it may not have columns)

**Acceptance Test (how to verify the PR)**

- Try out the new isEditable story for tablecard and make sure it shows sample data
