### PR TITLE
fix(timeseries): stop the x-axis label overlap on firefox

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -26,7 +26,7 @@ const LineChartWrapper = styled.div`
 
   &&& {
     .chart-wrapper g.x.axis g.tick text {
-      transform: initial !important;
+      transform: rotateY(0);
       text-anchor: initial !important;
     }
     .legend-wrapper {
@@ -34,6 +34,10 @@ const LineChartWrapper = styled.div`
       height: ${props => (!props.size === CARD_SIZES.MEDIUM ? '40px' : '20px')} !important;
     }
     .chart-holder {
+      width: 100%;
+      height: 100%;
+    }
+    .chart-svg {
       width: 100%;
       height: 100%;
     }


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Makes the x-axis on Firefox look the same as the x-axis on Chrome (i.e. not rotated)

![image](https://user-images.githubusercontent.com/6663002/61984775-f62a6300-afc2-11e9-8b85-102d100bea8b.png)


**Change List (commits, features, bugs, etc)**

- small style override

**Acceptance Test (how to verify the PR)**

- Verify all the TimeSeries stories in Chrome and Firefox
