### PR TITLE
fix(imagecard): hide controls for small images

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dnd-html5-backend": "2.5.1",
     "react-dnd-test-backend": "^7.2.0",
     "react-grid-layout": "^0.16.6",
-    "react-image-hotspots": "^1.4.0",
+    "react-image-hotspots": "^1.4.1",
     "react-resizable": "^1.8.0",
     "react-sizeme": "^2.6.3",
     "react-transition-group": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11649,10 +11649,10 @@ react-grid-layout@^0.16.6:
     react-draggable "3.x"
     react-resizable "1.x"
 
-react-image-hotspots@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-image-hotspots/-/react-image-hotspots-1.4.0.tgz#a34c20f5bcf9872d4804be5c6a9bc1fcad836cf7"
-  integrity sha512-h/3EQfQ2K+NOOYeNsgLBB/xAuSqsOyjoplJvrweinAR79/x826HXVkyxDs7eYhYQTwgWtDMccUE96sdJzxkKNA==
+react-image-hotspots@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-image-hotspots/-/react-image-hotspots-1.4.1.tgz#68e324cb93e99f3457ddcfb62fa4c255e6da5deb"
+  integrity sha512-osN1knFOHmIvuCTlHjQ9hrPPy+DjdSwqS2c6VQfHcAdgIv35MTilnv6aMBdbKJy7BVSs3FshddzTrU7ulaxN/A==
 
 react-inspector@^2.3.0:
   version "2.3.1"


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- ImageCard shouldn't show zoom controls for images that are smaller than container.

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes https://github.ibm.com/wiotp/monitoring-dashboard/issues/184

**Acceptance Test (how to verify the PR)**

- Specify an image smaller than container size for ImageCard