### PR TITLE
fix(imagecard): add Carbon icon to zoom to fit

### DIFF
--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon } from 'carbon-components-react';
 
 import Hotspot, { propTypes as HotspotPropTypes } from './Hotspot';
 
@@ -524,11 +525,15 @@ class ImageHotspots extends React.Component {
         {!hideZoomControls && (
           <>
             <div style={bottomControlsStyle}>
-              <button type="button" style={buttonStyle} onClick={() => this.zoom(1)}>
-                Fit
-              </button>
-              <br />
-              <br />
+              {draggable && (
+                <>
+                  <button type="button" style={buttonStyle} onClick={() => this.zoom(1)}>
+                    <Icon name="icon--minimize" width="100%" height="100%" />
+                  </button>
+                  <br />
+                  <br />
+                </>
+              )}
               <button type="button" style={buttonStyle} onClick={() => this.zoom(image.scale + 1)}>
                 +
               </button>


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Add Carbon icon to zoom to fit button.

**Acceptance Test (how to verify the PR)**

- Run ImageCard storybook and check if there's a Carbon icon in zoom to fit button.