### PR TITLE
fix(imagecard): change hotspots position to center

### DIFF
--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -32,8 +32,8 @@ const defaultProps = {
 const Hotspot = ({ x, y, content, icon, color, width, height, ...others }) => {
   const hotspotStyle = {
     position: 'absolute',
-    top: `${y}%`,
-    left: `${x}%`,
+    top: `calc(${y}% - ${height / 2}px)`,
+    left: `calc(${x}% - ${width / 2}px)`,
     fontFamily: 'Sans-Serif',
     pointerEvents: 'auto',
   };


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Change hotspots position in ImageCard to center them instead of using top left.

**Acceptance Test (how to verify the PR)**

- Check if hotspots position is relative to their center and not top left.
