### PR TITLE
feat(imagecard): support max zoom spec

### DIFF
--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -15,7 +15,7 @@ const ContentWrapper = styled.div`
 `;
 
 const ImageCard = ({ title, content, size, onCardAction, isEditable, ...others }) => {
-  const { src, alt, hotspots } = content;
+  const { src, alt, hotspots, zoomMax } = content;
   const supportedSizes = [CARD_SIZES.MEDIUM, CARD_SIZES.WIDE, CARD_SIZES.LARGE, CARD_SIZES.XLARGE];
   const supportedSize = supportedSizes.includes(size);
   const availableActions = { expand: supportedSize };
@@ -34,7 +34,7 @@ const ImageCard = ({ title, content, size, onCardAction, isEditable, ...others }
             isEditable && !src ? (
               <Image32 width="100%" height="100%" />
             ) : content && src ? (
-              <ImageHotspots src={src} alt={alt} hotspots={hotspots} />
+              <ImageHotspots src={src} alt={alt} hotspots={hotspots} zoomMax={zoomMax} />
             ) : (
               <p>Error retrieving image.</p>
             )

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -18,6 +18,7 @@ const content = {
     { x: 45, y: 50, content: <span style={{ padding: '10px' }}>Stairs</span> },
     { x: 45, y: 75, content: <span style={{ padding: '10px' }}>Stairs</span> },
   ],
+  zoomMax: 10,
 };
 
 storiesOf('ImageCard (Experimental)', module)

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -16,6 +16,7 @@ const propTypes = {
   hideHotspots: PropTypes.bool,
   hideMinimap: PropTypes.bool,
   background: PropTypes.string,
+  zoomMax: PropTypes.number,
 };
 
 const defaultProps = {
@@ -25,6 +26,7 @@ const defaultProps = {
   hideHotspots: false,
   hideMinimap: false,
   background: '#eee',
+  zoomMax: undefined,
 };
 
 class ImageHotspots extends React.Component {
@@ -75,13 +77,7 @@ class ImageHotspots extends React.Component {
   }
 
   componentDidMount = () => {
-    const {
-      hideZoomControls,
-      hideHotspots,
-      hideMinimap,
-      hotspots,
-      background
-    } = this.props;
+    const { hideZoomControls, hideHotspots, hideMinimap, hotspots, background } = this.props;
     const { offsetWidth: width, offsetHeight: height } = this.container.current;
     const orientation = width > height ? 'landscape' : 'portrait';
     const ratio = orientation === 'landscape' ? width / height : height / width;
@@ -265,6 +261,7 @@ class ImageHotspots extends React.Component {
   zoom = scale => {
     if (scale > 0) {
       const { container, image } = this.state;
+      const { zoomMax } = this.props;
 
       const width =
         container.orientation === image.orientation
@@ -292,7 +289,10 @@ class ImageHotspots extends React.Component {
           ? (container.width / image.ratio) * scale // landscape image and portrait container
           : container.height * scale; // portrait image and landscape container
 
-      if (image.initialWidth > width && image.initialHeight > height) {
+      if (
+        (zoomMax && scale < zoomMax) ||
+        (image.initialWidth > width && image.initialHeight > height)
+      ) {
         this.setState(prevState => ({
           image: {
             ...prevState.image,


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Users can optionally specify a max zoom for their images. If not specified the image will zoom in until its size is equal to the original image size.

**Acceptance Test (how to verify the PR)**

- Change `zoomMax` property using storybook and zoom in.
