### PR TITLE
fix(rollup): copy carbon-components vendor folder for publish

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,7 +73,7 @@ export default {
             'node_modules/carbon-components/scss/globals/scss/_layer.scss',
             'node_modules/carbon-components/scss/globals/scss/_spacing.scss',
             'node_modules/carbon-components/scss/globals/scss/_typography.scss',
-            'node_modules/carbon-components/scss/globals/scss/_vendor',
+            'node_modules/carbon-components/scss/globals/scss/vendor',
             'node_modules/carbon-components/scss/globals/scss/_css--reset.scss',
             'node_modules/carbon-components/scss/globals/scss/_css--font-face.scss',
             'node_modules/carbon-components/scss/globals/scss/_css--helpers.scss',


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Fixes a typo - vendor folder doesn't have an underscore. Was preventing consumers from importing partials, vendor files weren't resolving.

**Change List (commits, features, bugs, etc)**

- modify rollup config

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes #505 

**Acceptance Test (how to verify the PR)**

- pull down and run `yarn`, `./lib/scss/globals/scss` folder should now contain the `vendor` folder and associated partials
