### PR TITLE
fix(editpage): turn off the saving bit if onSave returns false

### DIFF
--- a/src/components/Page/EditPage.jsx
+++ b/src/components/Page/EditPage.jsx
@@ -79,9 +79,11 @@ const EditPage = ({
   const handleSave = async () => {
     setSaving(true);
     try {
-      // if they return false from onSave don't close
+      // if they return false from onSave don't close and clear the saving bit
       if (await onSave()) {
         onClose();
+      } else {
+        setSaving(false);
       }
     } catch {
       setSaving(false);


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- If onSave returns false, edit page didn't pass validation, so we should stop the Saving spinner

