### PR TITLE
feat(sass): provide central entrypoint

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,13 +81,14 @@ carbon-addons-iot-react/
 │       └── scss
 │           └── _vars.scss
 │           └── ...
+│   └── styles.scss (sass entrypoint)
 ```
 
 Compiled CSS files are provided for ease of use getting started.
 
-Using individual sass files (instead of the compiled .css) infers usage of a SCSS pre-processor. All Sass files use the `*.scss` file extension. For transpiling Sass code, use node-sass based Sass compilers, for example, WebPack sass-loader or gulp-sass. Make sure your build process uses autoprefixer to ensure vendor prefixes are automatically added to your output CSS.
+A sass entrypoint is availble at `lib/scss/styles.scss` for use in your project.
 
-At this time we only provide the individual partial files for `global` and `components`. This will require you to construct the central entrypoint in your application, such as the ./src/styles.scss file in this repo used to generate the provided .css files.
+Using sass files (instead of the compiled .css) infers usage of a SCSS pre-processor. All Sass files use the `*.scss` file extension. For transpiling Sass code, use node-sass based Sass compilers, for example, WebPack sass-loader or gulp-sass. Make sure your build process uses autoprefixer to ensure vendor prefixes are automatically added to your output CSS.
 
 Feedback and improvement requests regarding this configuration would be appreciated, [please contribute to this issue](https://github.com/IBM/carbon-addons-iot-react/issues/426).
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "homepage": "https://carbon-addons-iot-react.com",
   "scripts": {
-    "build": "rollup -c",
+    "build": "yarn build:pre && rollup -c",
+    "build:pre": "rm -rf lib storybook-static",
     "build:storybook": "build-storybook -s public/production",
     "format": "prettier --write \"**/*.{scss,css,js,jsx,md,ts}\"",
     "format:diff": "prettier --list-different \"**/*.{scss,css,js,jsx,md,ts}\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,7 +55,7 @@ export default {
     }),
     copy({
       targets: [
-        { src: 'styles.scss', dest: 'lib/scss/globals/scss' },
+        { src: 'src/styles.scss', dest: 'lib/scss' },
         {
           src: [
             // ---------------
@@ -95,8 +95,7 @@ export default {
             // ------------------------------
             // Carbon Components Proxy Styles
             // ------------------------------
-            // These are listed individually so that we can easily override
-            // these with our own versions of these files.
+            // These are listed individually so that we can easily disinclude individual files if we override them
             'node_modules/carbon-components/scss/components/button',
             'node_modules/carbon-components/scss/components/copy-button',
             'node_modules/carbon-components/scss/components/file-uploader',
@@ -130,7 +129,6 @@ export default {
             'node_modules/carbon-components/scss/components/tag',
             'node_modules/carbon-components/scss/components/pagination',
             'node_modules/carbon-components/scss/components/accordion',
-            'node_modules/carbon-components/scss/components/progress-indicator',
             'node_modules/carbon-components/scss/components/breadcrumb',
             'node_modules/carbon-components/scss/components/toolbar',
             'node_modules/carbon-components/scss/components/time-picker',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,18 @@ import autoprefixer from 'autoprefixer';
 const env = process.env.NODE_ENV || 'development';
 const prodSettings = env === 'development' ? [] : [uglify(), filesize()];
 
+// Converts `_component-name.scss` to `ComponentName/_component-name.scss`
+// and handles the word `ui` to be uppercase `UI`
+const sanitizeAndCamelCase = (fileName, extension) => {
+  return `${fileName
+    .replace('_', '')
+    .split('-')
+    .map(word =>
+      word === 'ui' ? `${word.toUpperCase()}` : `${word[0].toUpperCase() + word.substring(1)}`
+    )
+    .join('')}/${fileName}.${extension}`;
+};
+
 export default {
   input: 'src/index.js',
   output: {
@@ -55,100 +67,36 @@ export default {
     }),
     copy({
       targets: [
+        // Sass entrypoint
         { src: 'src/styles.scss', dest: 'lib/scss' },
+
+        // Sass globals
         {
-          src: [
-            // ---------------
-            // Carbon Globals
-            // ---------------
-            // These are listed individually so that we can easily override
-            // these with our own versions of these files.
-            '!node_modules/carbon-components/scss/globals/scss/styles.scss', // don't include Carbon's master sass file, we export our own
-            'node_modules/carbon-components/scss/globals/scss/vendor',
-            'node_modules/carbon-components/scss/globals/scss/_colors.scss',
-            'node_modules/carbon-components/scss/globals/scss/_css--body.scss',
-            'node_modules/carbon-components/scss/globals/scss/_css--font-face.scss',
-            'node_modules/carbon-components/scss/globals/scss/_css--helpers.scss',
-            'node_modules/carbon-components/scss/globals/scss/_css--reset.scss',
-            'node_modules/carbon-components/scss/globals/scss/_deprecate.scss',
-            'node_modules/carbon-components/scss/globals/scss/_feature-flags.scss',
-            'node_modules/carbon-components/scss/globals/scss/_functions.scss',
-            'node_modules/carbon-components/scss/globals/scss/_helper-classes.scss',
-            'node_modules/carbon-components/scss/globals/scss/_helper-mixins.scss',
-            'node_modules/carbon-components/scss/globals/scss/_import-once.scss',
-            'node_modules/carbon-components/scss/globals/scss/_layer.scss',
-            'node_modules/carbon-components/scss/globals/scss/_layout.scss',
-            'node_modules/carbon-components/scss/globals/scss/_mixins.scss',
-            'node_modules/carbon-components/scss/globals/scss/_motion.scss',
-            'node_modules/carbon-components/scss/globals/scss/_spacing.scss',
-            'node_modules/carbon-components/scss/globals/scss/_theme-tokens.scss',
-            'node_modules/carbon-components/scss/globals/scss/_theme.scss',
-            'node_modules/carbon-components/scss/globals/scss/_tooltip.scss',
-            'node_modules/carbon-components/scss/globals/scss/_typography.scss',
-            'node_modules/carbon-components/scss/globals/scss/_vars.scss',
-          ],
-          dest: 'lib/scss/globals/scss',
+          src: 'src/globals',
+          dest: 'lib/scss',
         },
-        { src: 'node_modules/carbon-components/scss/globals/grid', dest: 'lib/scss/globals' },
+
+        // Sass components
+        {
+          src: 'src/components/**/*.scss',
+          dest: 'lib/scss/components',
+          rename: (name, extension) => sanitizeAndCamelCase(name, extension),
+        },
+
+        // Carbon components proxy styles
         {
           src: [
-            // ------------------------------
-            // Carbon Components Proxy Styles
-            // ------------------------------
-            // These are listed individually so that we can easily disinclude individual files if we override them
-            'node_modules/carbon-components/scss/components/button',
-            'node_modules/carbon-components/scss/components/copy-button',
-            'node_modules/carbon-components/scss/components/file-uploader',
-            'node_modules/carbon-components/scss/components/checkbox',
-            'node_modules/carbon-components/scss/components/combo-box',
-            'node_modules/carbon-components/scss/components/radio-button',
-            'node_modules/carbon-components/scss/components/toggle',
-            'node_modules/carbon-components/scss/components/search',
-            'node_modules/carbon-components/scss/components/select',
-            'node_modules/carbon-components/scss/components/text-input',
-            'node_modules/carbon-components/scss/components/text-area',
-            'node_modules/carbon-components/scss/components/number-input',
-            'node_modules/carbon-components/scss/components/form',
-            'node_modules/carbon-components/scss/components/link',
             'node_modules/carbon-components/scss/components/list-box',
             'node_modules/carbon-components/scss/components/list',
             'node_modules/carbon-components/scss/components/data-table',
-            'node_modules/carbon-components/scss/components/structured-list',
-            'node_modules/carbon-components/scss/components/code-snippet',
-            'node_modules/carbon-components/scss/components/overflow-menu',
-            'node_modules/carbon-components/scss/components/content-switcher',
-            'node_modules/carbon-components/scss/components/date-picker',
-            'node_modules/carbon-components/scss/components/dropdown',
-            'node_modules/carbon-components/scss/components/loading',
-            'node_modules/carbon-components/scss/components/modal',
-            'node_modules/carbon-components/scss/components/multi-select',
-            'node_modules/carbon-components/scss/components/notification',
-            'node_modules/carbon-components/scss/components/notification',
-            'node_modules/carbon-components/scss/components/tooltip',
-            'node_modules/carbon-components/scss/components/tabs',
-            'node_modules/carbon-components/scss/components/tag',
-            'node_modules/carbon-components/scss/components/pagination',
-            'node_modules/carbon-components/scss/components/accordion',
-            'node_modules/carbon-components/scss/components/breadcrumb',
-            'node_modules/carbon-components/scss/components/toolbar',
-            'node_modules/carbon-components/scss/components/time-picker',
-            'node_modules/carbon-components/scss/components/slider',
-            'node_modules/carbon-components/scss/components/tile',
             'node_modules/carbon-components/scss/components/skeleton',
-            'node_modules/carbon-components/scss/components/inline-loading',
             'node_modules/carbon-components/scss/components/pagination-nav',
-            'node_modules/carbon-components/scss/components/ui-shell',
           ],
           dest: 'lib/scss/components',
+          rename: (name, extension) => sanitizeAndCamelCase(name, extension),
         },
-        { src: ['src/components/AddCard/_add-card.scss'], dest: 'lib/scss/components/AddCard' },
-        {
-          src: ['src/components/ProgressIndicator/_progress-indicator.scss'],
-          dest: 'lib/scss/components/ProgressIndicator',
-        },
-        { src: ['src/components/SideNav/_side-nav.scss'], dest: 'lib/scss/components/SideNav' },
       ],
-      verbose: env !== 'development', // output file copy list on production builds for easier debugging
+      verbose: env !== 'development', // logs the file copy list on production builds for easier debugging
     }),
     commonjs({
       namedExports: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,19 +82,6 @@ export default {
           dest: 'lib/scss/components',
           rename: (name, extension) => sanitizeAndCamelCase(name, extension),
         },
-
-        // Carbon components proxy styles
-        {
-          src: [
-            'node_modules/carbon-components/scss/components/list-box',
-            'node_modules/carbon-components/scss/components/list',
-            'node_modules/carbon-components/scss/components/data-table',
-            'node_modules/carbon-components/scss/components/skeleton',
-            'node_modules/carbon-components/scss/components/pagination-nav',
-          ],
-          dest: 'lib/scss/components',
-          rename: (name, extension) => sanitizeAndCamelCase(name, extension),
-        },
       ],
       verbose: env !== 'development', // logs the file copy list on production builds for easier debugging
     }),

--- a/src/components/Accordion/_accordion.scss
+++ b/src/components/Accordion/_accordion.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/accordion/accordion';

--- a/src/components/Breadcrumb/_breadcrumb.scss
+++ b/src/components/Breadcrumb/_breadcrumb.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/breadcrumb/breadcrumb';

--- a/src/components/Button/_button.scss
+++ b/src/components/Button/_button.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/button/button';

--- a/src/components/Checkbox/_checkbox.scss
+++ b/src/components/Checkbox/_checkbox.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/checkbox/checkbox';

--- a/src/components/CodeSnippet/_code-snippet.scss
+++ b/src/components/CodeSnippet/_code-snippet.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/code-snippet/code-snippet';

--- a/src/components/ComboBox/_combo-box.scss
+++ b/src/components/ComboBox/_combo-box.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/combo-box/combo-box';

--- a/src/components/ContentSwitcher/_content-switcher.scss
+++ b/src/components/ContentSwitcher/_content-switcher.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/content-switcher/content-switcher';

--- a/src/components/CopyButton/_copy-button.scss
+++ b/src/components/CopyButton/_copy-button.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/copy-button/copy-button';

--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/data-table/data-table';

--- a/src/components/DatePicker/_date-picker.scss
+++ b/src/components/DatePicker/_date-picker.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/date-picker/date-picker';

--- a/src/components/Dropdown/_dropdown.scss
+++ b/src/components/Dropdown/_dropdown.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/dropdown/dropdown';

--- a/src/components/FileUploader/_file-uploader.scss
+++ b/src/components/FileUploader/_file-uploader.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/file-uploader/file-uploader';

--- a/src/components/Form/_form.scss
+++ b/src/components/Form/_form.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/form/form';

--- a/src/components/InlineLoading/_inline-loading.scss
+++ b/src/components/InlineLoading/_inline-loading.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/inline-loading/inline-loading';

--- a/src/components/Link/_link.scss
+++ b/src/components/Link/_link.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/link/link';

--- a/src/components/List/_list.scss
+++ b/src/components/List/_list.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/list/list';

--- a/src/components/ListBox/_list-box.scss
+++ b/src/components/ListBox/_list-box.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/list-box/list-box';

--- a/src/components/Loading/_loading.scss
+++ b/src/components/Loading/_loading.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/loading/loading';

--- a/src/components/Modal/_modal.scss
+++ b/src/components/Modal/_modal.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/modal/modal';

--- a/src/components/MultiSelect/_multi-select.scss
+++ b/src/components/MultiSelect/_multi-select.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/multi-select/multi-select';

--- a/src/components/Notification/_inline-notification.scss
+++ b/src/components/Notification/_inline-notification.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/notification/inline-notification';

--- a/src/components/Notification/_toast-notification.scss
+++ b/src/components/Notification/_toast-notification.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/notification/toast-notification';

--- a/src/components/NumberInput/_number-input.scss
+++ b/src/components/NumberInput/_number-input.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/number-input/number-input';

--- a/src/components/OverflowMenu/_overflow-menu.scss
+++ b/src/components/OverflowMenu/_overflow-menu.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/overflow-menu/overflow-menu';

--- a/src/components/Pagination/_pagination.scss
+++ b/src/components/Pagination/_pagination.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/pagination/pagination';

--- a/src/components/PaginationNav/_pagination-nav.scss
+++ b/src/components/PaginationNav/_pagination-nav.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/pagination-nav/pagination-nav';

--- a/src/components/ProgressIndicator/_progress-indicator.scss
+++ b/src/components/ProgressIndicator/_progress-indicator.scss
@@ -1,3 +1,5 @@
+@import '~carbon-components/scss/components/progress-indicator/progress-indicator';
+
 .bx--skeleton .bx--progress-step {
   flex: unset;
 }

--- a/src/components/RadioButton/_radio-button.scss
+++ b/src/components/RadioButton/_radio-button.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/radio-button/radio-button';

--- a/src/components/Search/_search.scss
+++ b/src/components/Search/_search.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/search/search';

--- a/src/components/Select/_select.scss
+++ b/src/components/Select/_select.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/select/select';

--- a/src/components/Skeleton/_skeleton.scss
+++ b/src/components/Skeleton/_skeleton.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/skeleton/skeleton';

--- a/src/components/Slider/_slider.scss
+++ b/src/components/Slider/_slider.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/slider/slider';

--- a/src/components/StructuredList/_structured-list.scss
+++ b/src/components/StructuredList/_structured-list.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/structured-list/structured-list';

--- a/src/components/Tabs/_tabs.scss
+++ b/src/components/Tabs/_tabs.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/tabs/tabs';

--- a/src/components/Tag/_tag.scss
+++ b/src/components/Tag/_tag.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/tag/tag';

--- a/src/components/TextArea/_text-area.scss
+++ b/src/components/TextArea/_text-area.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/text-area/text-area';

--- a/src/components/TextInput/_text-input.scss
+++ b/src/components/TextInput/_text-input.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/text-input/text-input';

--- a/src/components/Tile/_tile.scss
+++ b/src/components/Tile/_tile.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/tile/tile';

--- a/src/components/TimePicker/_time-picker.scss
+++ b/src/components/TimePicker/_time-picker.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/time-picker/time-picker';

--- a/src/components/Toggle/_toggle.scss
+++ b/src/components/Toggle/_toggle.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/toggle/toggle';

--- a/src/components/Toolbar/_toolbar.scss
+++ b/src/components/Toolbar/_toolbar.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/toolbar/toolbar';

--- a/src/components/Tooltip/_tooltip.scss
+++ b/src/components/Tooltip/_tooltip.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/tooltip/tooltip';

--- a/src/components/UIShell/_ui-shell.scss
+++ b/src/components/UIShell/_ui-shell.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/components/ui-shell/ui-shell';

--- a/src/globals/_colors.scss
+++ b/src/globals/_colors.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/colors';

--- a/src/globals/_css--body.scss
+++ b/src/globals/_css--body.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/css--body';

--- a/src/globals/_css--font-face.scss
+++ b/src/globals/_css--font-face.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/css--font-face';

--- a/src/globals/_css--helpers.scss
+++ b/src/globals/_css--helpers.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/css--helpers';

--- a/src/globals/_css--reset.scss
+++ b/src/globals/_css--reset.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/css--reset';

--- a/src/globals/_feature-flags.scss
+++ b/src/globals/_feature-flags.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/feature-flags';

--- a/src/globals/_grid.scss
+++ b/src/globals/_grid.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/grid/grid';

--- a/src/globals/_import-once.scss
+++ b/src/globals/_import-once.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';

--- a/src/globals/_layer.scss
+++ b/src/globals/_layer.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/layer';

--- a/src/globals/_layout.scss
+++ b/src/globals/_layout.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/layout';

--- a/src/globals/_mixins.scss
+++ b/src/globals/_mixins.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/mixins';

--- a/src/globals/_spacing.scss
+++ b/src/globals/_spacing.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/spacing';

--- a/src/globals/_theme.scss
+++ b/src/globals/_theme.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/theme';

--- a/src/globals/_typography.scss
+++ b/src/globals/_typography.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/typography';

--- a/src/globals/_vars.scss
+++ b/src/globals/_vars.scss
@@ -1,0 +1,1 @@
+@import '~carbon-components/scss/globals/scss/vars';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -60,21 +60,21 @@ $carbon--theme: $carbon--theme--g10;
 // Use the gray 10 theme
 @include carbon--theme();
 
-@import '~carbon-components/scss/globals/scss/feature-flags';
-@import '~carbon-components/scss/globals/scss/vars';
-@import '~carbon-components/scss/globals/scss/colors';
-@import '~carbon-components/scss/globals/scss/theme';
-@import '~carbon-components/scss/globals/scss/mixins';
-@import '~carbon-components/scss/globals/scss/layout';
-@import '~carbon-components/scss/globals/scss/layer';
-@import '~carbon-components/scss/globals/scss/spacing';
-@import '~carbon-components/scss/globals/scss/typography';
-@import '~carbon-components/scss/globals/scss/vendor/@carbon/elements/scss/import-once/import-once';
-@import '~carbon-components/scss/globals/scss/css--reset';
-@import '~carbon-components/scss/globals/scss/css--font-face';
-@import '~carbon-components/scss/globals/scss/css--helpers';
-@import '~carbon-components/scss/globals/scss/css--body';
-@import '~carbon-components/scss/globals/grid/grid';
+@import 'globals/feature-flags';
+@import 'globals/vars';
+@import 'globals/colors';
+@import 'globals/theme';
+@import 'globals/mixins';
+@import 'globals/layout';
+@import 'globals/layer';
+@import 'globals/spacing';
+@import 'globals/typography';
+@import 'globals/import-once';
+@import 'globals/css--reset';
+@import 'globals/css--font-face';
+@import 'globals/css--helpers';
+@import 'globals/css--body';
+@import 'globals/grid';
 
 //-------------------------
 // ⚠️ Manage deprecations
@@ -108,52 +108,52 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 // 🍕 Components
 //-------------------------
 
-@import '~carbon-components/scss/components/button/button';
-@import '~carbon-components/scss/components/copy-button/copy-button';
-@import '~carbon-components/scss/components/file-uploader/file-uploader';
-@import '~carbon-components/scss/components/checkbox/checkbox';
-@import '~carbon-components/scss/components/combo-box/combo-box';
-@import '~carbon-components/scss/components/radio-button/radio-button';
-@import '~carbon-components/scss/components/toggle/toggle';
-@import '~carbon-components/scss/components/search/search';
-@import '~carbon-components/scss/components/select/select';
-@import '~carbon-components/scss/components/text-input/text-input';
-@import '~carbon-components/scss/components/text-area/text-area';
-@import '~carbon-components/scss/components/number-input/number-input';
-@import '~carbon-components/scss/components/form/form';
-@import '~carbon-components/scss/components/link/link';
-@import '~carbon-components/scss/components/list-box/list-box';
-@import '~carbon-components/scss/components/list/list';
-@import '~carbon-components/scss/components/data-table/data-table';
-@import '~carbon-components/scss/components/structured-list/structured-list';
-@import '~carbon-components/scss/components/code-snippet/code-snippet';
-@import '~carbon-components/scss/components/overflow-menu/overflow-menu';
-@import '~carbon-components/scss/components/content-switcher/content-switcher';
-@import '~carbon-components/scss/components/date-picker/date-picker';
-@import '~carbon-components/scss/components/dropdown/dropdown';
-@import '~carbon-components/scss/components/loading/loading';
-@import '~carbon-components/scss/components/modal/modal';
-@import '~carbon-components/scss/components/multi-select/multi-select';
-@import '~carbon-components/scss/components/notification/inline-notification';
-@import '~carbon-components/scss/components/notification/toast-notification';
-@import '~carbon-components/scss/components/tooltip/tooltip';
-@import '~carbon-components/scss/components/tabs/tabs';
-@import '~carbon-components/scss/components/tag/tag';
-@import '~carbon-components/scss/components/pagination/pagination';
-@import '~carbon-components/scss/components/accordion/accordion';
-@import '~carbon-components/scss/components/breadcrumb/breadcrumb';
-@import '~carbon-components/scss/components/toolbar/toolbar';
-@import '~carbon-components/scss/components/time-picker/time-picker';
-@import '~carbon-components/scss/components/slider/slider';
-@import '~carbon-components/scss/components/tile/tile';
-@import '~carbon-components/scss/components/skeleton/skeleton';
-@import '~carbon-components/scss/components/inline-loading/inline-loading';
-@import '~carbon-components/scss/components/pagination-nav/pagination-nav';
+@import 'components/Button/button';
+@import 'components/CopyButton/copy-button';
+@import 'components/FileUploader/file-uploader';
+@import 'components/Checkbox/checkbox';
+@import 'components/ComboBox/combo-box';
+@import 'components/RadioButton/radio-button';
+@import 'components/Toggle/toggle';
+@import 'components/Search/search';
+@import 'components/Select/select';
+@import 'components/TextInput/text-input';
+@import 'components/TextArea/text-area';
+@import 'components/NumberInput/number-input';
+@import 'components/Form/form';
+@import 'components/Link/link';
+@import '~carbon-components/scss/components/list-box/list-box'; // ???
+@import '~carbon-components/scss/components/list/list'; // ???
+@import '~carbon-components/scss/components/data-table/data-table'; // ???
+@import 'components/StructuredList/structured-list';
+@import 'components/CodeSnippet/code-snippet';
+@import 'components/OverflowMenu/overflow-menu';
+@import 'components/ContentSwitcher/content-switcher';
+@import 'components/DatePicker/date-picker';
+@import 'components/Dropdown/dropdown';
+@import 'components/Loading/loading';
+@import 'components/Modal/modal';
+@import 'components/MultiSelect/multi-select';
+@import 'components/Notification/inline-notification';
+@import 'components/Notification/toast-notification';
+@import 'components/Tooltip/tooltip';
+@import 'components/Tabs/tabs';
+@import 'components/Tag/tag';
+@import 'components/Pagination/pagination';
+@import 'components/Accordion/accordion';
+@import 'components/Breadcrumb/breadcrumb';
+@import 'components/Toolbar/toolbar';
+@import 'components/TimePicker/time-picker';
+@import 'components/Slider/slider';
+@import 'components/Tile/tile';
+@import '~carbon-components/scss/components/skeleton/skeleton'; // ???
+@import 'components/InlineLoading/inline-loading';
+@import '~carbon-components/scss/components/pagination-nav/pagination-nav'; // ???
 
 //-------------------------------------
 // 🔬 Experimental
 //-------------------------------------
-@import '~carbon-components/scss/components/ui-shell/ui-shell';
+@import 'components/UIShell/ui-shell';
 
 //-------------------------------------
 // 🙈 Hidden (Not exposed on website)

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -141,7 +141,6 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import '~carbon-components/scss/components/tag/tag';
 @import '~carbon-components/scss/components/pagination/pagination';
 @import '~carbon-components/scss/components/accordion/accordion';
-@import '~carbon-components/scss/components/progress-indicator/progress-indicator';
 @import '~carbon-components/scss/components/breadcrumb/breadcrumb';
 @import '~carbon-components/scss/components/toolbar/toolbar';
 @import '~carbon-components/scss/components/time-picker/time-picker';
@@ -174,6 +173,6 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 //-------------------------------------
 // carbon-addons-iot-react components
 //-------------------------------------
-@import './components/AddCard/add-card';
-@import './components/ProgressIndicator/progress-indicator';
-@import './components/SideNav/side-nav';
+@import 'components/AddCard/add-card';
+@import 'components/ProgressIndicator/progress-indicator';
+@import 'components/SideNav/side-nav';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -122,9 +122,9 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/NumberInput/number-input';
 @import 'components/Form/form';
 @import 'components/Link/link';
-@import '~carbon-components/scss/components/list-box/list-box'; // ???
-@import '~carbon-components/scss/components/list/list'; // ???
-@import '~carbon-components/scss/components/data-table/data-table'; // ???
+@import 'components/ListBox/list-box';
+@import 'components/List/list';
+@import 'components/DataTable/data-table';
 @import 'components/StructuredList/structured-list';
 @import 'components/CodeSnippet/code-snippet';
 @import 'components/OverflowMenu/overflow-menu';
@@ -146,9 +146,9 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/TimePicker/time-picker';
 @import 'components/Slider/slider';
 @import 'components/Tile/tile';
-@import '~carbon-components/scss/components/skeleton/skeleton'; // ???
+@import 'components/Skeleton/skeleton';
 @import 'components/InlineLoading/inline-loading';
-@import '~carbon-components/scss/components/pagination-nav/pagination-nav'; // ???
+@import 'components/PaginationNav/pagination-nav';
 
 //-------------------------------------
 // 🔬 Experimental


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- add an `index.scss` for use in consuming projects

**Change List (commits, features, bugs, etc)**

- modify import paths in styles.scss
- add .scss files to import component styles so we're not copying as many files from `node_modules` on build
- modify rollup build to copy appropriate files to globals, components, and styles.scss
  - added a rename helper function to assist with this
- add new step to build scrips to `rm -rf` remove generated directories before a new build

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- #426 

**Acceptance Test (how to verify the PR)**

- pull down the branch, run `yarn`, view the `./lib` folder
- please double check the new component scss files for proper import paths. 
  - ex: `_accordion.scss` actually imports `@import '~carbon-components/scss/components/accordion/accordion';` and not some other component by accident.
- Are we missing anything?
