### PR TITLE
[tablecard]: i18n fixes for the Table card severity strings.  use numbers instead

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -294,7 +294,7 @@ const TableCard = ({
                   </g>
                 </g>
               </svg>
-              <StyledSpan>Low</StyledSpan>
+              <StyledSpan>3</StyledSpan>
             </StyledIconDiv>
           );
           break;
@@ -332,7 +332,7 @@ const TableCard = ({
                   </g>
                 </g>
               </svg>
-              <StyledSpan>High</StyledSpan>
+              <StyledSpan>1</StyledSpan>
             </StyledIconDiv>
           );
           break;
@@ -364,7 +364,7 @@ const TableCard = ({
                   </g>
                 </g>
               </svg>
-              <StyledSpan>Medium</StyledSpan>
+              <StyledSpan>2</StyledSpan>
             </StyledIconDiv>
           );
           break;
@@ -408,12 +408,12 @@ const TableCard = ({
         label: uniqueThresholds[index].label
           ? uniqueThresholds[index].label
           : `${capitalize(columnId)} Severity`,
-        width: '120px',
+        width: '140px',
         isSortable: true,
         renderDataFunction: renderThresholdIcon,
         priority: 1,
         filter: {
-          placeholderText: 'Severity',
+          placeholderText: '1, 2, 3',
           options: [
             {
               id: '1',

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -352,8 +352,8 @@ storiesOf('Table Card', module)
             columns: tableColumns,
             expandedRows: [{}],
             thresholds: [
-              { dataSourceId: 'count', comparison: '>', value: 0, severity: 3 },
-              { dataSourceId: 'count', comparison: '>', value: 2, severity: 1 },
+              { dataSourceId: 'count', comparison: '>', value: 0, severity: 3, label: 'Severity' },
+              { dataSourceId: 'count', comparison: '>', value: 2, severity: 1, label: 'Severity' },
             ],
           }}
           values={tableData.map(i => ({ id: i.id, values: i.values }))}


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- small fix to use numbers in the filter column text and as the labeled spans in the severity column

