### PR TITLE
fix(imagecard): make non-icon hotspots transparent

### DIFF
--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -318,10 +318,30 @@ const originalCards = [
     },
     values: {
       hotspots: [
-        { x: 35, y: 65, content: <span style={{ padding: '10px' }}>Elevators</span> },
-        { x: 45, y: 25, content: <span style={{ padding: '10px' }}>Stairs</span> },
-        { x: 45, y: 50, content: <span style={{ padding: '10px' }}>Stairs</span> },
-        { x: 45, y: 75, content: <span style={{ padding: '10px' }}>Stairs</span> },
+        {
+          x: 35,
+          y: 65,
+          icon: 'icon--arrow--down',
+          content: <span style={{ padding: '10px' }}>Elevators</span>,
+        },
+        {
+          x: 45,
+          y: 25,
+          color: '#0f0',
+          content: <span style={{ padding: '10px' }}>Stairs</span>,
+        },
+        {
+          x: 45,
+          y: 50,
+          color: '#00f',
+          content: <span style={{ padding: '10px' }}>Vent Fan</span>,
+        },
+        {
+          x: 45,
+          y: 75,
+          icon: 'icon--arrow--up',
+          content: <span style={{ padding: '10px' }}>Humidity Sensor</span>,
+        },
       ],
     },
   },

--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -39,12 +39,17 @@ const StyledHotspot = styled(({ className, children }) => (
   pointer-events: auto;
 
   .bx--tooltip__label {
-    border: solid 1px #aaa;
-    padding: 4px;
-    background: white;
-    opacity: 0.9;
-    border-radius: 4px;
-    box-shadow: 0 0 8px #777;
+    ${props =>
+      props.icon
+        ? `
+      border: solid 1px #aaa;
+      padding: 4px;
+      background: white;
+      opacity: 0.9;
+      border-radius: 4px;
+      box-shadow: 0 0 8px #777;
+    `
+        : ``}
   }
 `;
 
@@ -58,7 +63,7 @@ const Hotspot = ({ x, y, content, icon, color, width, height, ...others }) => {
         cx={width / 2}
         cy={height / 2}
         r={width / 2}
-        stroke="black"
+        stroke={color}
         strokeWidth="1"
         fill={color}
         opacity="1"
@@ -67,7 +72,7 @@ const Hotspot = ({ x, y, content, icon, color, width, height, ...others }) => {
   );
 
   return (
-    <StyledHotspot x={x} y={y} width={width} height={height}>
+    <StyledHotspot x={x} y={y} width={width} height={height} icon={icon}>
       <Tooltip
         {...others}
         triggerText={

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -26,13 +26,13 @@ const values = {
     {
       x: 45,
       y: 25,
-      icon: 'icon--arrow--left',
+      color: '#0f0',
       content: <span style={{ padding: '10px' }}>Stairs</span>,
     },
     {
       x: 45,
       y: 50,
-      icon: 'icon--arrow--right',
+      color: '#00f',
       content: <span style={{ padding: '10px' }}>Vent Fan</span>,
     },
     {


### PR DESCRIPTION
**Summary**

- Make non-icon hotspots have transparent background and no border -- this supports a "heat map" use case by default.

![image](https://user-images.githubusercontent.com/2175647/64876455-ba039e00-d614-11e9-9b6d-04f0fbd8ebe0.png)

**Acceptance Test (how to verify the PR)**

- Check ImageCard and Dashboard (basic) stories for an example. (or look at the image above)
