### PR TITLE
fix(notification): sass entrypoint and build styles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,9 +78,15 @@ export default {
 
         // Sass components
         {
-          src: 'src/components/**/*.scss',
+          src: ['src/components/**/*.scss', '!src/components/Notification/*.scss'],
           dest: 'lib/scss/components',
           rename: (name, extension) => sanitizeAndCamelCase(name, extension),
+        },
+
+        // Sass components with non-standard folder structure, or multiple files per folder
+        {
+          src: 'src/components/Notification/*.scss',
+          dest: 'lib/scss/components/Notification',
         },
       ],
       verbose: env !== 'development', // logs the file copy list on production builds for easier debugging


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Modify how Notification styles are added to final build to preserve folder structure for imports.

**Change List (commits, features, bugs, etc)**

- disinclude Notifications from going through the sanitize/camelCase function

Final output from copy logging on my local build:
```
  src/components/Notification/_inline-notification.scss → lib/scss/components/Notification/_inline-notification.scss
  src/components/Notification/_toast-notification.scss → lib/scss/components/Notification/_toast-notification.scss
```