### PR TITLE
Fix card overlap

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -40,7 +40,6 @@ const OptimizedSkeletonText = pure(SkeletonText);
 const CardWrapper = styled.div`
   background: white;
   height: ${props => props.dimensions.y}px;
-  min-width: ${props => props.dimensions.x}px;
   ${props => (props.isExpanded ? 'height: 100%; width: 100%;' : '')};
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Remove min-width calculation from cards... not necessary when rendered inside of a Dashboard, and the values were off (resulting in some horizontal overlap at the edges of breakpoints)

![image](https://media.github.ibm.com/user/699/files/6ba10a00-d875-11e9-9d80-66fd10b8fb76)

