### PR TITLE
fix(imagecard): non-icons need white border

### DIFF
--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -43,13 +43,19 @@ const StyledHotspot = styled(({ className, children }) => (
       props.icon
         ? `
       border: solid 1px #aaa;
+      cursor: pointer;
       padding: 4px;
       background: white;
       opacity: 0.9;
       border-radius: 4px;
       box-shadow: 0 0 8px #777;
     `
-        : ``}
+        : `
+      cursor: pointer;
+      box-shadow: 0 0 4px #999;
+      border-radius: 13px;
+      background: none;
+        `}
   }
 `;
 
@@ -62,11 +68,19 @@ const Hotspot = ({ x, y, content, icon, color, width, height, ...others }) => {
       <circle
         cx={width / 2}
         cy={height / 2}
-        r={width / 2}
-        stroke={color}
-        strokeWidth="1"
-        fill={color}
+        r={width / 2 - 1}
+        stroke="white"
+        strokeWidth="2"
+        fill="none"
         opacity="1"
+      />
+      <circle
+        cx={width / 2}
+        cy={height / 2}
+        r={width / 2 - 1}
+        stroke="none"
+        fill={color}
+        opacity="0.7"
       />
     </svg>
   );


### PR DESCRIPTION
**Summary**

- Added opacity, solid white border to non-icon hotspots (circles)

![image](https://user-images.githubusercontent.com/2175647/65002575-1fc48400-d8ba-11e9-84a5-bbe26f9710de.png)

- added `cursor: pointer` to all hotspot tooltip buttons
