### PR TITLE
fix(pagetitlebar): tooltip rendering logic when no description

### DIFF
--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -75,7 +75,7 @@ const PageTitleBar = ({
         <div className="page-title-bar-title">
           <div className="page-title-bar-title--text">
             <h2>{title}</h2>
-            {collapsed || tabs ? (
+            {description && (collapsed || tabs) ? (
               <Tooltip tabIndex={0} triggerText="" triggerId="tooltip" renderIcon={Information24}>
                 <p>{description}</p>
               </Tooltip>

--- a/src/components/PageTitleBar/PageTitleBar.test.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.test.jsx
@@ -61,6 +61,43 @@ describe('PageTitleBar', () => {
     expect(wrapper.find('.page-title-bar-tabs')).toHaveLength(1);
   });
 
+  test('Does not render tooltip when no description', () => {
+    const wrapper = mount(
+      <PageTitleBar
+        title={commonPageTitleBarProps.title}
+        breadcrumb={pageTitleBarBreadcrumb}
+        collapsed
+      />
+    );
+    expect(wrapper.find('.bx--tooltip__label')).toHaveLength(0);
+    expect(wrapper.find('.page-title-bar-description')).toHaveLength(0);
+  });
+
+  test('Does not render tooltip when no description with tabs', () => {
+    const wrapper = mount(
+      <PageTitleBar
+        title={commonPageTitleBarProps.title}
+        breadcrumb={pageTitleBarBreadcrumb}
+        tabs={
+          <Tabs>
+            <Tab label="Tab 1">
+              <div>Content for first tab.</div>
+            </Tab>
+            <Tab label="Tab 2">
+              <div>Content for second tab.</div>
+            </Tab>
+            <Tab label="Tab 3">
+              <div>Content for third tab.</div>
+            </Tab>
+          </Tabs>
+        }
+      />
+    );
+    expect(wrapper.find('.bx--tooltip__label')).toHaveLength(0);
+    expect(wrapper.find('.page-title-bar-description')).toHaveLength(0);
+    expect(wrapper.find('.page-title-bar-tabs')).toHaveLength(1);
+  });
+
   describe('Renders editable title as expected', () => {
     const onEdit = jest.fn();
     const wrapper = mount(


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Improve PageTitleBar to not render tooltip icon when no description is given. Added tests to cover this as well.

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes #552 

**Acceptance Test (how to verify the PR)**

- This small fix to logic didn't need a new story, so it's not "visible" in the storybook. For temporary testing, remove the `description` prop from the PageTitleBar `with tabs as children` story and view the result. It shouldn't render the tooltip icon.
