### PR TITLE
fix(card): thresholds shouldn't apply if the value is null

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -170,21 +170,23 @@ const defaultProps = {
 export const findMatchingThresholds = (thresholds, item, columnId) => {
   return thresholds
     .filter(t => {
+      const { comparison, value, dataSourceId } = t;
       // Does the threshold apply to the current column?
-      if (columnId && !columnId.includes(t.dataSourceId)) {
+      if (columnId && !columnId.includes(dataSourceId)) {
         return false;
       }
-      switch (t.comparison) {
+
+      switch (comparison) {
         case '<':
-          return parseFloat(item[t.dataSourceId]) < t.value;
+          return !isNil(item[dataSourceId]) && parseFloat(item[dataSourceId]) < value;
         case '>':
-          return parseFloat(item[t.dataSourceId]) > t.value;
+          return parseFloat(item[dataSourceId]) > value;
         case '=':
-          return parseFloat(item[t.dataSourceId]) === t.value;
+          return parseFloat(item[dataSourceId]) === value;
         case '<=':
-          return parseFloat(item[t.dataSourceId]) <= t.value;
+          return !isNil(item[dataSourceId]) && parseFloat(item[dataSourceId]) <= value;
         case '>=':
-          return parseFloat(item[t.dataSourceId]) >= t.value;
+          return parseFloat(item[dataSourceId]) >= value;
         default:
           return false;
       }

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -41,6 +41,23 @@ describe('TableCard', () => {
     expect(twoMatchingThresholds[1].severity).toEqual(1);
     expect(twoMatchingThresholds[1].dataSourceId).toEqual('airflow_max');
   });
+  test('findMatchingThresholds no column', () => {
+    const thresholds = [{ comparison: '<', dataSourceId: 'airflow_mean', severity: 1, value: 4.5 }];
+    const oneMatchingThreshold = findMatchingThresholds(thresholds, { airflow_mean: 4 });
+    expect(oneMatchingThreshold).toHaveLength(1);
+    // The highest severity should match
+    expect(oneMatchingThreshold[0].severity).toEqual(1);
+
+    // shouldn't match on null values
+    const zeroMatchingThreshold = findMatchingThresholds(thresholds, { airflow_mean: null });
+    expect(zeroMatchingThreshold).toHaveLength(0);
+    // shouldn't match on null values
+    const zeroMatchingThreshold2 = findMatchingThresholds(
+      [{ comparison: '<=', dataSourceId: 'airflow_mean', severity: 1, value: 4.5 }],
+      { airflow_mean: null }
+    );
+    expect(zeroMatchingThreshold2).toHaveLength(0);
+  });
   test('Clicked row actions', () => {
     const onCardAction = jest.fn();
 

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -222,12 +222,15 @@ const TimeSeriesCard = ({
 
   const lines = series.map(line => ({ ...line, color: !isEditable ? line.color : 'gray' }));
 
-  useDeepCompareEffect(() => {
-    if (chartRef && chartRef.chart) {
-      const chartData = formatChartData(labels, lines, values);
-      chartRef.chart.setData(chartData);
-    }
-  }, [values, labels, lines]);
+  useDeepCompareEffect(
+    () => {
+      if (chartRef && chartRef.chart) {
+        const chartData = formatChartData(labels, lines, values);
+        chartRef.chart.setData(chartData);
+      }
+    },
+    [values, labels, lines]
+  );
 
   const chartData = useMemo(() => formatChartData(labels, lines, values), [labels, lines, values]);
   return (

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -118,13 +118,13 @@ const Attribute = ({
     .filter(t => {
       switch (t.comparison) {
         case '<':
-          return value < t.value;
+          return !isNil(value) && value < t.value;
         case '>':
           return value > t.value;
         case '=':
           return value === t.value;
         case '<=':
-          return value <= t.value;
+          return !isNil(value) && value <= t.value;
         case '>=':
           return value >= t.value;
         default:

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -449,7 +449,7 @@ storiesOf('ValueCard', module)
           size={size}
           values={{
             comfortLevel: number('comfortLevel', 89),
-            averageTemp: number('averageTemp', 76.7),
+            averageTemp: number('averageTemp', null),
             humidity: number('humidity', 76.7),
           }}
         />

--- a/src/index.js
+++ b/src/index.js
@@ -46,3 +46,4 @@ export {
   DASHBOARD_BREAKPOINTS,
   DASHBOARD_SIZES,
 } from './constants/LayoutConstants';
+export { findMatchingThresholds } from './components/TableCard/TableCard';


### PR DESCRIPTION
In the value and Image Card, thresholds were triggering even if the value was null.

I fixed the Value card in Attribute,  but for the Image Card, I'm doing some of the work downstream.  I've exported the findMatchingThresholds helper function so that external consumers can use it.