### PR TITLE
fix(tablecard): don't override height when empty

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -106,16 +106,14 @@ const StyledStatefulTable = styled(({ showHeader, data, ...rest }) => (
     margin-left: 1rem;
   }
   .bx--data-table-v2-container {
-    /* if the table is empty, go fullscreen */
-    ${props =>
-      props.data && props.data.length > 0 && !props.isExpanded
-        ? `max-height: 435px;`
-        : props.isExpanded
-        ? `height: 90%`
-        : `height: 100%`}
+    ${props => (props.data && props.data.length > 0 ? `max-height: 435px;` : `height: 90%;`)}
   }
   .bx--data-table-v2 {
-    ${props => (props.data && props.data.length > 0 ? `height: initial` : `height: 100%`)}
+    /* if the table is empty, remove border */
+    ${props =>
+      props.data && props.data.length > 0
+        ? `height: initial;`
+        : `height: 100%;border-bottom: unset;`}
   }
 `;
 


### PR DESCRIPTION
table card is overlaying other cards when empty.

The original fix was to try and make the border line inside the table go away. This just unsets the border