### PR TITLE
fix(sizeme): turn off placeholders

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -340,7 +340,7 @@ const Card = ({
     );
 
   return (
-    <SizeMe.SizeMe>
+    <SizeMe.SizeMe disablePlaceholder>
       {({ size: sizeWidth }) => (
         <CardWrapper
           id={id}

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -340,7 +340,7 @@ const Card = ({
     );
 
   return (
-    <SizeMe.SizeMe disablePlaceholder>
+    <SizeMe.SizeMe>
       {({ size: sizeWidth }) => (
         <CardWrapper
           id={id}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,8 @@
+// Needed so that any component that uses sizeme can be jest tested
+import sizeMe from 'react-sizeme';
+
+sizeMe.noPlaceholders = true;
+
 // Widgets
 export ButtonEnhanced from './components/ButtonEnhanced';
 export Table from './components/Table';


### PR DESCRIPTION
turning off placeholders allows downstream consumers to use these components in their testcases