### PR TITLE
chore(tests): separate storyshots into individual tests

### DIFF
--- a/src/components/AddCard/__snapshots__/AddCard.story.storyshot
+++ b/src/components/AddCard/__snapshots__/AddCard.story.storyshot
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|AddCard handles click 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <a
+      className="bx--link bx--tile bx--tile--clickable add-card"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      <p
+        className="title"
+      >
+        Click me
+      </p>
+      <svg
+        aria-hidden={true}
+        description="Click me"
+        fill="#171717"
+        focusable="false"
+        height={20}
+        preserveAspectRatio="xMidYMid meet"
+        style={
+          Object {
+            "willChange": "transform",
+          }
+        }
+        viewBox="0 0 32 32"
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+        />
+      </svg>
+    </a>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/Button/__snapshots__/Button.story.storyshot
+++ b/src/components/Button/__snapshots__/Button.story.storyshot
@@ -1,0 +1,221 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Button loading 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary bx--btn--disabled"
+      disabled={true}
+      onClick={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        aria-label="Active loading indicator"
+        aria-live="assertive"
+        className="bx--loading bx--loading--small"
+      >
+        <svg
+          className="bx--loading__svg"
+          viewBox="-75 -75 150 150"
+        >
+          <title>
+            Active loading indicator
+          </title>
+          <circle
+            className="bx--loading__background"
+            cx="0"
+            cy="0"
+            r="37.5"
+          />
+          <circle
+            className="bx--loading__stroke"
+            cx="0"
+            cy="0"
+            r="37.5"
+          />
+        </svg>
+      </div>
+      Test Button
+    </button>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Button loading with secondary 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary bx--btn--disabled"
+      disabled={true}
+      onClick={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        aria-label="Active loading indicator"
+        aria-live="assertive"
+        className="bx--loading bx--loading--small"
+      >
+        <svg
+          className="bx--loading__svg"
+          viewBox="-75 -75 150 150"
+        >
+          <title>
+            Active loading indicator
+          </title>
+          <circle
+            className="bx--loading__background"
+            cx="0"
+            cy="0"
+            r="37.5"
+          />
+          <circle
+            className="bx--loading__stroke"
+            cx="0"
+            cy="0"
+            r="37.5"
+          />
+        </svg>
+      </div>
+      Test Button
+    </button>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Button not loading 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <button
+      className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+      disabled={false}
+      onClick={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      Test Button
+    </button>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
+++ b/src/components/ComposedModal/__snapshots__/ComposedModal.story.storyshot
@@ -1,0 +1,1143 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal add translated description 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Add translation
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Dialog with translated string for close icon
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Translated string"
+            type="button"
+          >
+            <svg
+              aria-label="Translated string"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal big modal 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible big-modal ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Big Modal
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Needs a lot of space to contain all the info
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-content"
+        >
+          Lots of really wide content here...
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal custom footer 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Custom footer
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Custom footer element
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal error states 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={[Function]}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            DataError
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Cannot communicate with server
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--inline-notification bx--inline-notification--error ComposedModal__StyledMessageBox-sc-12pj5f-1 cLnoHJ"
+          kind="error"
+          role="alert"
+        >
+          <div
+            className="bx--inline-notification__details"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--inline-notification__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 20 20"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm3.5 13.5l-8-8 1-1 8 8-1 1z"
+              />
+              <path
+                d="M13.5 14.5l-8-8 1-1 8 8-1 1z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                closes notification
+              </title>
+            </svg>
+            <div
+              className="bx--inline-notification__text-wrapper"
+            >
+              <p
+                className="bx--inline-notification__title"
+              >
+                Error sending data to server
+              </p>
+              <div
+                className="bx--inline-notification__subtitle"
+              >
+                
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="closes notification"
+            className="bx--inline-notification__close-button"
+            onClick={[Function]}
+            title="closes notification"
+            type="button"
+          >
+            <svg
+              aria-label="close notification"
+              className="bx--inline-notification__close-icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal fetching data 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--loading-overlay"
+    >
+      <div
+        aria-label="Active loading indicator"
+        aria-live="assertive"
+        className="bx--loading"
+      >
+        <svg
+          className="bx--loading__svg"
+          viewBox="-75 -75 150 150"
+        >
+          <title>
+            Active loading indicator
+          </title>
+          <circle
+            className="bx--loading__stroke"
+            cx="0"
+            cy="0"
+            r="37.5"
+          />
+        </svg>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal i18n 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            My Cancel
+          </button>
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            My Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal no footer 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            No footer
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Dialog without footer
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal sending data 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Sending data
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            We are submitting data to the backend
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary bx--btn--disabled"
+            disabled={true}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <div
+              aria-label="Active loading indicator"
+              aria-live="assertive"
+              className="bx--loading bx--loading--small"
+            >
+              <svg
+                className="bx--loading__svg"
+                viewBox="-75 -75 150 150"
+              >
+                <title>
+                  Active loading indicator
+                </title>
+                <circle
+                  className="bx--loading__background"
+                  cx="0"
+                  cy="0"
+                  r="37.5"
+                />
+                <circle
+                  className="bx--loading__stroke"
+                  cx="0"
+                  cy="0"
+                  r="37.5"
+                />
+              </svg>
+            </div>
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedModal warning dialog 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible error-modal ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Scary Operation
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Delete Stuff
+          </p>
+          <p
+            className="bx--modal-content__text"
+          >
+            Deleting stuff can be hazardous to your health..
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--danger"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/ComposedStructuredList/__snapshots__/ComposedStructuredList.story.storyshot
+++ b/src/components/ComposedStructuredList/__snapshots__/ComposedStructuredList.story.storyshot
@@ -1,0 +1,897 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedStructuredList (Deprecated) custom cell renderer 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      aria-label="Structured list section"
+      className="bx--structured-list ComposedStructuredList__StructuredListWrapperStyled-oz9xih-0 bQEmNU bx--structured-list--selection"
+    >
+      <div
+        className="bx--structured-list-thead"
+      >
+        <div
+          className="bx--structured-list-row bx--structured-list-row--header-row"
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="A"
+          >
+            A
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="B"
+          >
+            B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="C"
+          >
+            C
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--structured-list-tbody"
+        onKeyDown={[Function]}
+      >
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title={null}
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              <div />
+            </span>
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey B"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey B
+            </span>
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey C"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey C
+            </span>
+          </div>
+        </div>
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey A again fixed column width"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey A again fixed column width
+            </span>
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey B again"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey B again
+            </span>
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey C again"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey C again
+            </span>
+          </div>
+        </div>
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey A"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey hey A
+            </span>
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey B"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey hey B
+            </span>
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey C"
+          >
+            <span
+              style={
+                Object {
+                  "color": "blue",
+                }
+              }
+            >
+              hey hey C
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedStructuredList (Deprecated) default  1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      aria-label="Structured list section"
+      className="bx--structured-list ComposedStructuredList__StructuredListWrapperStyled-oz9xih-0 bQEmNU bx--structured-list--selection"
+    >
+      <div
+        className="bx--structured-list-thead"
+      >
+        <div
+          className="bx--structured-list-row bx--structured-list-row--header-row"
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="A"
+          >
+            A
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="B"
+          >
+            B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="C"
+          >
+            C
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--structured-list-tbody"
+        onKeyDown={[Function]}
+      >
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title={null}
+          >
+            <div />
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey B"
+          >
+            hey B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey C"
+          >
+            hey C
+          </div>
+        </div>
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey A again fixed column width"
+          >
+            hey A again fixed column width
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey B again"
+          >
+            hey B again
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey C again"
+          >
+            hey C again
+          </div>
+        </div>
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey A"
+          >
+            hey hey A
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey B"
+          >
+            hey hey B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey C"
+          >
+            hey hey C
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedStructuredList (Deprecated) with empty state 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      aria-label="Structured list section"
+      className="bx--structured-list ComposedStructuredList__StructuredListWrapperStyled-oz9xih-0 bQEmNU bx--structured-list--selection"
+    >
+      <div
+        className="bx--structured-list-thead"
+      >
+        <div
+          className="bx--structured-list-row bx--structured-list-row--header-row"
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="A"
+          >
+            A
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="B"
+          >
+            B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 eMheOS bx--structured-list-th"
+            title="C"
+          >
+            C
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--structured-list-tbody"
+        onKeyDown={[Function]}
+      />
+      <div
+        className="ComposedStructuredList__EmptyContent-oz9xih-1 foGiwV"
+      >
+        <svg
+          aria-hidden={true}
+          fill="#5a6872"
+          focusable="false"
+          height={100}
+          preserveAspectRatio="xMidYMid meet"
+          style={
+            Object {
+              "willChange": "transform",
+            }
+          }
+          viewBox="0 0 32 32"
+          width={100}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+          />
+        </svg>
+        <div
+          className="ComposedStructuredList__LoadingDiv-oz9xih-2 bGZVQQ"
+        >
+          No data is available yet.
+        </div>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedStructuredList (Deprecated) with empty state with fixed column width 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      aria-label="Structured list section"
+      className="bx--structured-list ComposedStructuredList__StructuredListWrapperStyled-oz9xih-0 bmhAOa bx--structured-list--selection"
+    >
+      <div
+        className="bx--structured-list-thead"
+      >
+        <div
+          className="bx--structured-list-row bx--structured-list-row--header-row"
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 jXwlwq bx--structured-list-th"
+            title="A"
+            width="10rem"
+          >
+            A
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 cxDUvP bx--structured-list-th"
+            title="B"
+            width="12rem"
+          >
+            B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 uqYLz bx--structured-list-th"
+            title="C"
+            width="14rem"
+          >
+            C
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--structured-list-tbody"
+        onKeyDown={[Function]}
+      />
+      <div
+        className="ComposedStructuredList__EmptyContent-oz9xih-1 foGiwV"
+      >
+        <svg
+          aria-hidden={true}
+          fill="#5a6872"
+          focusable="false"
+          height={100}
+          preserveAspectRatio="xMidYMid meet"
+          style={
+            Object {
+              "willChange": "transform",
+            }
+          }
+          viewBox="0 0 32 32"
+          width={100}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+          />
+        </svg>
+        <div
+          className="ComposedStructuredList__LoadingDiv-oz9xih-2 bGZVQQ"
+        >
+          No data is available yet.
+        </div>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedStructuredList (Deprecated) with fixed column widths 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      aria-label="Structured list section"
+      className="bx--structured-list ComposedStructuredList__StructuredListWrapperStyled-oz9xih-0 bmhAOa bx--structured-list--selection"
+    >
+      <div
+        className="bx--structured-list-thead"
+      >
+        <div
+          className="bx--structured-list-row bx--structured-list-row--header-row"
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 jXwlwq bx--structured-list-th"
+            title="A"
+            width="10rem"
+          >
+            A
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 cxDUvP bx--structured-list-th"
+            title="B"
+            width="12rem"
+          >
+            B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 uqYLz bx--structured-list-th"
+            title="C"
+            width="14rem"
+          >
+            C
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--structured-list-tbody"
+        onKeyDown={[Function]}
+      >
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 jXwlwq bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title={null}
+            width="10rem"
+          >
+            <div />
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 cxDUvP bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey B"
+            width="12rem"
+          >
+            hey B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 uqYLz bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey C"
+            width="14rem"
+          >
+            hey C
+          </div>
+        </div>
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 jXwlwq bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey A again fixed column width"
+            width="10rem"
+          >
+            hey A again fixed column width
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 cxDUvP bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey B again"
+            width="12rem"
+          >
+            hey B again
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 uqYLz bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey C again"
+            width="14rem"
+          >
+            hey C again
+          </div>
+        </div>
+        <div
+          className="bx--structured-list-row"
+          onClick={[Function]}
+        >
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 jXwlwq bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey A"
+            width="10rem"
+          >
+            hey hey A
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 cxDUvP bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey B"
+            width="12rem"
+          >
+            hey hey B
+          </div>
+          <div
+            className="ComposedStructuredList__StyledStructuredListCell-oz9xih-3 uqYLz bx--structured-list-td bx--structured-list-content--nowrap"
+            style={Object {}}
+            title="hey hey C"
+            width="14rem"
+          >
+            hey hey C
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ComposedStructuredList (Deprecated) ️⛔ Deprecation Notice  1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--toast-notification bx--toast-notification--warning"
+      kind="warning"
+      role="alert"
+      style={
+        Object {
+          "marginBottom": ".5rem",
+          "minWidth": "30rem",
+        }
+      }
+      timeout={0}
+    >
+      <svg
+        aria-hidden={true}
+        className="bx--toast-notification__icon"
+        focusable="false"
+        height={20}
+        preserveAspectRatio="xMidYMid meet"
+        style={
+          Object {
+            "willChange": "transform",
+          }
+        }
+        viewBox="0 0 20 20"
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm-.8 4h1.5v7H9.2V5zm.8 11c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"
+        />
+        <path
+          d="M9.2 5h1.5v7H9.2V5zm.8 11c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"
+          data-icon-path="inner-path"
+          opacity="0"
+        />
+        <title>
+          
+        </title>
+      </svg>
+      <div
+        className="bx--toast-notification__details"
+      >
+        <h3
+          className="bx--toast-notification__title"
+        >
+          Deprecation Notice
+        </h3>
+        <div
+          className="bx--toast-notification__subtitle"
+        >
+          ComposedStructuredList has been deprecated and will be removed in the next major version of carbon-addons-iot-react.
+        </div>
+        <div
+          className="bx--toast-notification__caption"
+        >
+          Refactor usages of ComposedStructuredList to use StructuredList instead.
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/FileDrop/__snapshots__/FileDrop.story.storyshot
+++ b/src/components/FileDrop/__snapshots__/FileDrop.story.storyshot
@@ -1,0 +1,560 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|FileDrop Accept JSON 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <strong
+        className="bx--label"
+      >
+        Upload Files
+      </strong>
+      <input
+        accept={
+          Array [
+            "json",
+          ]
+        }
+        multiple={true}
+        onChange={[Function]}
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
+        type="file"
+      />
+      <div
+        className="FileDrop__Text-xfd081-2 iynxPm"
+        onDragLeave={[Function]}
+        onDragOver={[Function]}
+        onDrop={[Function]}
+        style={
+          Object {
+            "border": "1px dashed #8C8C8C",
+          }
+        }
+      >
+        <div>
+          Drag and drop your file here or 
+          <span
+            onClick={[Function]}
+            role="presentation"
+          >
+            <button
+              className="FileDrop__LinkButton-xfd081-1 jAHgUA"
+            >
+              Try it out!
+            </button>
+          </span>
+          <div>
+            Only JSON can be uploaded
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--file-container"
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|FileDrop Browse 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--form-item"
+      id="FileUploader"
+    >
+      <strong
+        className="bx--label"
+      >
+        Upload Files
+      </strong>
+      <p
+        className="bx--label-description"
+      >
+        Any file can be uploaded.  Feel free to upload more than one!
+      </p>
+      <label
+        className="bx--btn bx--btn--sm bx--btn--secondary"
+        htmlFor="id1"
+        onChange={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        Try it out!
+      </label>
+      <input
+        accept={Array []}
+        className="bx--visually-hidden"
+        disabled={false}
+        id="id1"
+        multiple={true}
+        onChange={[Function]}
+        onClick={[Function]}
+        tabIndex="-1"
+        type="file"
+      />
+      <div
+        className="bx--file-container"
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|FileDrop Browse only one 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--form-item"
+      id="FileUploader"
+    >
+      <strong
+        className="bx--label"
+      >
+        Upload Files
+      </strong>
+      <p
+        className="bx--label-description"
+      >
+        Only one file can be uploaded
+      </p>
+      <label
+        className="bx--btn bx--btn--sm bx--btn--secondary"
+        htmlFor="id2"
+        onChange={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        Try it out!
+      </label>
+      <input
+        accept={Array []}
+        className="bx--visually-hidden"
+        disabled={false}
+        id="id2"
+        multiple={false}
+        onChange={[Function]}
+        onClick={[Function]}
+        tabIndex="-1"
+        type="file"
+      />
+      <div
+        className="bx--file-container"
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|FileDrop Drag and drop 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <strong
+        className="bx--label"
+      >
+        Upload Files
+      </strong>
+      <input
+        accept={Array []}
+        multiple={true}
+        onChange={[Function]}
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
+        type="file"
+      />
+      <div
+        className="FileDrop__Text-xfd081-2 iynxPm"
+        onDragLeave={[Function]}
+        onDragOver={[Function]}
+        onDrop={[Function]}
+        style={
+          Object {
+            "border": "1px dashed #8C8C8C",
+          }
+        }
+      >
+        <div>
+          Drag and drop your file here or 
+          <span
+            onClick={[Function]}
+            role="presentation"
+          >
+            <button
+              className="FileDrop__LinkButton-xfd081-1 jAHgUA"
+            >
+              Try it out!
+            </button>
+          </span>
+          <div>
+            Any file can be uploaded.  Feel free to upload more than one!
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--file-container"
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|FileDrop Drag only one file 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <strong
+        className="bx--label"
+      >
+        Upload Files
+      </strong>
+      <input
+        accept={Array []}
+        multiple={false}
+        onChange={[Function]}
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
+        type="file"
+      />
+      <div
+        className="FileDrop__Text-xfd081-2 iynxPm"
+        onDragLeave={[Function]}
+        onDragOver={[Function]}
+        onDrop={[Function]}
+        style={
+          Object {
+            "border": "1px dashed #8C8C8C",
+          }
+        }
+      >
+        <div>
+          Drag and drop your file here or 
+          <span
+            onClick={[Function]}
+            role="presentation"
+          >
+            <button
+              className="FileDrop__LinkButton-xfd081-1 jAHgUA"
+            >
+              Try it out!
+            </button>
+          </span>
+          <div>
+            Only one file can be uploaded
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--file-container"
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|FileDrop Show files false 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <strong
+        className="bx--label"
+      >
+        Upload Files
+      </strong>
+      <input
+        accept={Array []}
+        multiple={false}
+        onChange={[Function]}
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
+        type="file"
+      />
+      <div
+        className="FileDrop__Text-xfd081-2 iynxPm"
+        onDragLeave={[Function]}
+        onDragOver={[Function]}
+        onDrop={[Function]}
+        style={
+          Object {
+            "border": "1px dashed #8C8C8C",
+          }
+        }
+      >
+        <div>
+          Drag and drop your file here or 
+          <span
+            onClick={[Function]}
+            role="presentation"
+          >
+            <button
+              className="FileDrop__LinkButton-xfd081-1 jAHgUA"
+            >
+              Try it out!
+            </button>
+          </span>
+          <div>
+            Only one file can be uploaded
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/Header/__snapshots__/Header.story.storyshot
+++ b/src/components/Header/__snapshots__/Header.story.storyshot
@@ -1,0 +1,541 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Header Header action buttons with dropdowns 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <header
+      aria-label="main header"
+      className="bx--header custom-class-name Headerstory__StyledHeader-st8jpc-0 hBPBX Header__StyledHeader-sc-14tpcyv-0 hmKiPy"
+      role="banner"
+    >
+      <a
+        className="bx--skip-to-content"
+        href="#main-content"
+        tabIndex="0"
+      >
+        Skip to main content
+      </a>
+      <button
+        aria-label="Open menu"
+        className="bx--header__action bx--header__menu-trigger bx--header__menu-toggle bx--header__menu-toggle__hidden"
+        onClick={null}
+        title="Open menu"
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          focusable="false"
+          height={20}
+          preserveAspectRatio="xMidYMid meet"
+          style={
+            Object {
+              "willChange": "transform",
+            }
+          }
+          viewBox="0 0 20 20"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 14.8h16V16H2zm0-3.6h16v1.2H2zm0-3.6h16v1.2H2zM2 4h16v1.2H2z"
+          />
+        </svg>
+      </button>
+      <a
+        className="bx--header__name"
+        href="#"
+      >
+        <span
+          className="bx--header__name--prefix"
+        >
+          IBM
+        </span>
+         
+        Watson IoT Platform 
+      </a>
+      <div
+        className="bx--header__global"
+      >
+        <button
+          aria-label="alerts"
+          className="Header__StyledGlobalAction-sc-14tpcyv-1 hzqpaE bx--header__action"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            description="Icon"
+            fill="white"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M28.7 20.3L26 17.6V13a10.07 10.07 0 0 0-9-10V1h-2v2a10.15 10.15 0 0 0-9 10v4.6l-2.7 2.7a.91.91 0 0 0-.3.7v3a.94.94 0 0 0 1 1h7a5 5 0 0 0 10 0h7a.94.94 0 0 0 1-1v-3a.91.91 0 0 0-.3-.7zM16 28a3 3 0 0 1-3-3h6a3 3 0 0 1-3 3zm11-5H5v-1.6l2.7-2.7A.91.91 0 0 0 8 18v-5a8 8 0 0 1 16 0v5a.91.91 0 0 0 .3.7l2.7 2.7z"
+            />
+          </svg>
+        </button>
+        <div
+          className="bx--header__submenu"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+           
+          <a
+            aria-expanded={false}
+            aria-haspopup="menu"
+            aria-label="help"
+            className="bx--header__menu-item bx--header__menu-title"
+            href="javascript:void(0)"
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex={0}
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--header__menu-item bx--header__menu-title"
+              description="Icon"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2zm0 26a12 12 0 1 1 12-12 12 12 0 0 1-12 12z"
+              />
+              <circle
+                cx="16"
+                cy="23.5"
+                r="1.5"
+              />
+              <path
+                d="M17 8h-1.5a4.49 4.49 0 0 0-4.5 4.5v.5h2v-.5a2.5 2.5 0 0 1 2.5-2.5H17a2.5 2.5 0 0 1 0 5h-2v4.5h2V17a4.5 4.5 0 0 0 0-9z"
+              />
+            </svg>
+          </a>
+          <ul
+            aria-label="help"
+            className="bx--header__menu"
+            role="menu"
+          >
+            <li
+              role="none"
+            >
+              <a
+                className="bx--header__menu-item"
+                href="http://google.com"
+                rel="noopener noreferrer"
+                role="menuitem"
+                tabIndex={0}
+                target="_blank"
+                title="this is a title"
+              >
+                <span
+                  className="bx--text-truncate--end"
+                >
+                  this is my message to you
+                </span>
+              </a>
+            </li>
+            <li
+              className="this"
+              role="none"
+            >
+              <button
+                className="bx--header__menu-item"
+                onClick={[Function]}
+                role="menuitem"
+                tabIndex={0}
+              >
+                <span
+                  className="bx--text-truncate--end"
+                >
+                  <span>
+                    JohnDoe@ibm.com
+                    <svg
+                      aria-hidden={true}
+                      description="Icon"
+                      fill="white"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2zm-6 24.38v-2A3.22 3.22 0 0 1 13 21h6a3.22 3.22 0 0 1 3 3.39v2a11.92 11.92 0 0 1-12 0zm14-1.46v-.61A5.21 5.21 0 0 0 19 19h-6a5.2 5.2 0 0 0-5 5.31v.59a12 12 0 1 1 16 0z"
+                      />
+                      <path
+                        d="M16 7a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </button>
+            </li>
+          </ul>
+           
+        </div>
+        <div
+          className="bx--header__submenu"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+           
+          <a
+            aria-expanded={false}
+            aria-haspopup="menu"
+            aria-label="user"
+            className="bx--header__menu-item bx--header__menu-title"
+            href="javascript:void(0)"
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex={0}
+          >
+            <p
+              className="Headerstory__User-st8jpc-1 eiViqx"
+            >
+              JohnDoe@ibm.com
+              <span>
+                TenantId: Acme
+              </span>
+            </p>
+            <svg
+              aria-hidden={true}
+              description="Icon"
+              fill="white"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2zm-6 24.38v-2A3.22 3.22 0 0 1 13 21h6a3.22 3.22 0 0 1 3 3.39v2a11.92 11.92 0 0 1-12 0zm14-1.46v-.61A5.21 5.21 0 0 0 19 19h-6a5.2 5.2 0 0 0-5 5.31v.59a12 12 0 1 1 16 0z"
+              />
+              <path
+                d="M16 7a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3z"
+              />
+            </svg>
+          </a>
+          <ul
+            aria-label="user"
+            className="bx--header__menu"
+            role="menu"
+          >
+            <li
+              role="none"
+            >
+              <a
+                className="bx--header__menu-item"
+                href="http://google.com"
+                rel="noopener noreferrer"
+                role="menuitem"
+                tabIndex={0}
+                target="_blank"
+                title="this is a title"
+              >
+                <span
+                  className="bx--text-truncate--end"
+                >
+                  this is my message to you
+                </span>
+              </a>
+            </li>
+            <li
+              className="this"
+              role="none"
+            >
+              <button
+                className="bx--header__menu-item"
+                onClick={[Function]}
+                role="menuitem"
+                tabIndex={0}
+              >
+                <span
+                  className="bx--text-truncate--end"
+                >
+                  JohnDoe@ibm.com
+                  <svg
+                    aria-hidden={true}
+                    description="Icon"
+                    fill="white"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2zm-6 24.38v-2A3.22 3.22 0 0 1 13 21h6a3.22 3.22 0 0 1 3 3.39v2a11.92 11.92 0 0 1-12 0zm14-1.46v-.61A5.21 5.21 0 0 0 19 19h-6a5.2 5.2 0 0 0-5 5.31v.59a12 12 0 1 1 16 0z"
+                    />
+                    <path
+                      d="M16 7a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </li>
+          </ul>
+           
+        </div>
+        <button
+          aria-label="header-panel-trigger"
+          className="Header__StyledGlobalAction-sc-14tpcyv-1 hzqpaE bx--header__action"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden={true}
+            description="Icon"
+            fill="white"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 20 20"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15.5 15.5H18V18h-2.5zm-6.75 0h2.5V18h-2.5zM2 15.5h2.5V18H2zm13.5-6.75H18v2.5h-2.5zm-6.75 0h2.5v2.5h-2.5zM2 8.75h2.5v2.5H2zM15.5 2H18v2.5h-2.5zM8.75 2h2.5v2.5h-2.5zM2 2h2.5v2.5H2z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-label="Header Panel"
+        className="bx--header-panel header-panel"
+      >
+        <div>
+          <a
+            href="#"
+          >
+            Header panel content
+          </a>
+        </div>
+      </div>
+    </header>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Header Header no submenu 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <header
+      aria-label="main header"
+      className="bx--header custom-class-name Headerstory__StyledHeader-st8jpc-0 hBPBX Header__StyledHeader-sc-14tpcyv-0 hmKiPy"
+      role="banner"
+    >
+      <a
+        className="bx--skip-to-content"
+        href="#main-content"
+        tabIndex="0"
+      >
+        Skip to main content
+      </a>
+      <button
+        aria-label="Open menu"
+        className="bx--header__action bx--header__menu-trigger bx--header__menu-toggle bx--header__menu-toggle__hidden"
+        onClick={null}
+        title="Open menu"
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          focusable="false"
+          height={20}
+          preserveAspectRatio="xMidYMid meet"
+          style={
+            Object {
+              "willChange": "transform",
+            }
+          }
+          viewBox="0 0 20 20"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 14.8h16V16H2zm0-3.6h16v1.2H2zm0-3.6h16v1.2H2zM2 4h16v1.2H2z"
+          />
+        </svg>
+      </button>
+      <a
+        className="bx--header__name"
+        href="#"
+      >
+        <span
+          className="bx--header__name--prefix"
+        >
+          IBM
+        </span>
+         
+        Watson IoT Platform 
+      </a>
+      <div
+        className="bx--header__global"
+      >
+        <button
+          aria-label="user"
+          className="Header__StyledGlobalAction-sc-14tpcyv-1 hzqpaE bx--header__action"
+          onClick={[Function]}
+          type="button"
+        >
+          <p
+            className="Headerstory__User-st8jpc-1 eiViqx"
+          >
+            JohnDoe@ibm.com
+            <span>
+              TenantId: Acme
+            </span>
+          </p>
+          <svg
+            aria-hidden={true}
+            description="Icon"
+            fill="white"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16 2a14 14 0 1 0 14 14A14 14 0 0 0 16 2zm-6 24.38v-2A3.22 3.22 0 0 1 13 21h6a3.22 3.22 0 0 1 3 3.39v2a11.92 11.92 0 0 1-12 0zm14-1.46v-.61A5.21 5.21 0 0 0 19 19h-6a5.2 5.2 0 0 0-5 5.31v.59a12 12 0 1 1 16 0z"
+            />
+            <path
+              d="M16 7a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm0 8a3 3 0 1 1 3-3 3 3 0 0 1-3 3z"
+            />
+          </svg>
+        </button>
+      </div>
+    </header>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
+++ b/src/components/NavigationBar/__snapshots__/NavigationBar.story.storyshot
@@ -1,0 +1,877 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|NavigationBar example with workArea 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="NavigationBarstory__StyledDirections-sbka37-0 vDQxp"
+    >
+      To interact with the workarea, click the New Entity Type button. To close the workarea, click the Cancel button or finish the flow.
+    </div>
+    <div
+      className="NavigationBar__StyledNavigationContainer-bw68kq-0 cAEAQd"
+    >
+      <div
+        className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+      >
+        <div
+          className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+        >
+          <div
+            className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+          >
+            <h1
+              className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+            >
+              <span
+                className="PageTitle__StyledPageSection-sc-1x4wg61-1 dUHWaW"
+              >
+                Explore /
+              </span>
+              Your Devices
+            </h1>
+          </div>
+          <div
+            className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+          >
+            <p
+              className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+            >
+              Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+            </p>
+          </div>
+        </div>
+        <div
+          className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+        >
+          <div>
+            Right Content
+          </div>
+        </div>
+      </div>
+      <div
+        className="NavigationBar__StyledTabToContent-bw68kq-2 buJmsc"
+      >
+        <div
+          className="bx--tabs"
+          hidden={false}
+          role="navigation"
+          selected={0}
+        >
+          <div
+            aria-label="listbox"
+            className="bx--tabs-trigger"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="listbox"
+            tabIndex={0}
+          >
+            <a
+              className="bx--tabs-trigger-text"
+              href="#"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              Tab 1
+            </a>
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={6}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 10 6"
+              width={10}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
+              />
+              <title>
+                show menu options
+              </title>
+            </svg>
+          </div>
+          <ul
+            className="bx--tabs__nav bx--tabs__nav--hidden"
+            role="tablist"
+          >
+            <li
+              className="bx--tabs__nav-item bx--tabs__nav-item--selected"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={true}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={true}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={0}
+              >
+                Tab 1
+              </a>
+            </li>
+            <li
+              className="bx--tabs__nav-item"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={false}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={false}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={-1}
+              >
+                Tab 2
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div
+          aria-hidden={false}
+          hidden={false}
+          selected={true}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden={true}
+          hidden={true}
+          selected={false}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content2
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="NavigationBar__StyledActions-bw68kq-5 dbjlRW"
+      >
+        <button
+          className="bx--btn bx--btn--primary"
+          disabled={false}
+          onClick={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          New Entity Type
+        </button>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|NavigationBar normal 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="NavigationBar__StyledNavigationContainer-bw68kq-0 cAEAQd"
+    >
+      <div
+        className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+      >
+        <div
+          className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+        >
+          <div
+            className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+          >
+            <h1
+              className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+            >
+              <span
+                className="PageTitle__StyledPageSection-sc-1x4wg61-1 dUHWaW"
+              >
+                Explore /
+              </span>
+              Your Devices
+            </h1>
+          </div>
+          <div
+            className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+          >
+            <p
+              className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+            >
+              Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+            </p>
+          </div>
+        </div>
+        <div
+          className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+        >
+          <div>
+            Right Content
+          </div>
+        </div>
+      </div>
+      <div
+        className="NavigationBar__StyledTabToContent-bw68kq-2 buJmsc"
+      >
+        <div
+          className="bx--tabs"
+          hidden={false}
+          role="navigation"
+          selected={0}
+        >
+          <div
+            aria-label="listbox"
+            className="bx--tabs-trigger"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="listbox"
+            tabIndex={0}
+          >
+            <a
+              className="bx--tabs-trigger-text"
+              href="#"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              Tab 1
+            </a>
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={6}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 10 6"
+              width={10}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
+              />
+              <title>
+                show menu options
+              </title>
+            </svg>
+          </div>
+          <ul
+            className="bx--tabs__nav bx--tabs__nav--hidden"
+            role="tablist"
+          >
+            <li
+              className="bx--tabs__nav-item bx--tabs__nav-item--selected"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={true}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={true}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={0}
+              >
+                Tab 1
+              </a>
+            </li>
+            <li
+              className="bx--tabs__nav-item"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={false}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={false}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={-1}
+              >
+                Tab 2
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div
+          aria-hidden={false}
+          hidden={false}
+          selected={true}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden={true}
+          hidden={true}
+          selected={false}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content2
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|NavigationBar start with tab 2 selected 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="NavigationBar__StyledNavigationContainer-bw68kq-0 cAEAQd"
+    >
+      <div
+        className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+      >
+        <div
+          className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+        >
+          <div
+            className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+          >
+            <h1
+              className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+            >
+              <span
+                className="PageTitle__StyledPageSection-sc-1x4wg61-1 dUHWaW"
+              >
+                Explore /
+              </span>
+              Your Devices
+            </h1>
+          </div>
+          <div
+            className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+          >
+            <p
+              className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+            >
+              Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+            </p>
+          </div>
+        </div>
+        <div
+          className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+        >
+          <div>
+            Right Content
+          </div>
+        </div>
+      </div>
+      <div
+        className="NavigationBar__StyledTabToContent-bw68kq-2 buJmsc"
+      >
+        <div
+          className="bx--tabs"
+          hidden={false}
+          role="navigation"
+          selected={1}
+        >
+          <div
+            aria-label="listbox"
+            className="bx--tabs-trigger"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="listbox"
+            tabIndex={0}
+          >
+            <a
+              className="bx--tabs-trigger-text"
+              href="#"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              Tab 2
+            </a>
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={6}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 10 6"
+              width={10}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
+              />
+              <title>
+                show menu options
+              </title>
+            </svg>
+          </div>
+          <ul
+            className="bx--tabs__nav bx--tabs__nav--hidden"
+            role="tablist"
+          >
+            <li
+              className="bx--tabs__nav-item"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={false}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={false}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={-1}
+              >
+                Tab 1
+              </a>
+            </li>
+            <li
+              className="bx--tabs__nav-item bx--tabs__nav-item--selected"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={true}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={true}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={0}
+              >
+                Tab 2
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div
+          aria-hidden={true}
+          hidden={true}
+          selected={false}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden={false}
+          hidden={false}
+          selected={true}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content2
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|NavigationBar with actions 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="NavigationBar__StyledNavigationContainer-bw68kq-0 cAEAQd"
+    >
+      <div
+        className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+      >
+        <div
+          className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+        >
+          <div
+            className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+          >
+            <h1
+              className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+            >
+              <span
+                className="PageTitle__StyledPageSection-sc-1x4wg61-1 dUHWaW"
+              >
+                Explore /
+              </span>
+              Your Devices
+            </h1>
+          </div>
+          <div
+            className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+          >
+            <p
+              className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+            >
+              Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+            </p>
+          </div>
+        </div>
+        <div
+          className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+        >
+          <div>
+            Right Content
+          </div>
+        </div>
+      </div>
+      <div
+        className="NavigationBar__StyledTabToContent-bw68kq-2 buJmsc"
+      >
+        <div
+          className="bx--tabs"
+          hidden={false}
+          role="navigation"
+          selected={0}
+        >
+          <div
+            aria-label="listbox"
+            className="bx--tabs-trigger"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="listbox"
+            tabIndex={0}
+          >
+            <a
+              className="bx--tabs-trigger-text"
+              href="#"
+              onClick={[Function]}
+              tabIndex={-1}
+            >
+              Tab 1
+            </a>
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={6}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 10 6"
+              width={10}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
+              />
+              <title>
+                show menu options
+              </title>
+            </svg>
+          </div>
+          <ul
+            className="bx--tabs__nav bx--tabs__nav--hidden"
+            role="tablist"
+          >
+            <li
+              className="bx--tabs__nav-item bx--tabs__nav-item--selected"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={true}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={true}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={0}
+              >
+                Tab 1
+              </a>
+            </li>
+            <li
+              className="bx--tabs__nav-item"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="presentation"
+              selected={false}
+              tabIndex={-1}
+            >
+              <a
+                aria-selected={false}
+                className="bx--tabs__nav-link"
+                href="#"
+                role="tab"
+                tabIndex={-1}
+              >
+                Tab 2
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div
+          aria-hidden={false}
+          hidden={false}
+          selected={true}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content
+            </div>
+          </div>
+        </div>
+        <div
+          aria-hidden={true}
+          hidden={true}
+          selected={false}
+        >
+          <div
+            className="NavigationBar__StyledTabContent-bw68kq-3 bDLdHq"
+          >
+            <div
+              className="NavigationBar__StyledTabChildren-bw68kq-4 dtUnfM"
+            >
+              my content2
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="NavigationBar__StyledActions-bw68kq-5 dbjlRW"
+      >
+        <button
+          className="bx--btn bx--btn--primary"
+          disabled={false}
+          onClick={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          New Entity Type
+        </button>
+        <button
+          className="bx--btn bx--btn--secondary"
+          disabled={false}
+          onClick={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          Button 2
+        </button>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/Page/__snapshots__/PageHero.story.storyshot
+++ b/src/components/Page/__snapshots__/PageHero.story.storyshot
@@ -1,0 +1,552 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageHero (Deprecated) has breadcrumb 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+    >
+      <div>
+        breadcrumb/mybread
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageHero (Deprecated) has left content 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+    >
+      <div
+        className="PageHero__StyledLeftContent-sc-1k4oefb-5 nKrTg"
+      >
+        <div>
+          Left Content
+        </div>
+      </div>
+      <div
+        className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+      >
+        <div
+          className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+        >
+          <h1
+            className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+          >
+            Your Devices
+          </h1>
+        </div>
+        <div
+          className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+        >
+          <p
+            className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+          >
+            Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+          </p>
+        </div>
+      </div>
+      <div
+        className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+      >
+        <div
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          Right Content
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageHero (Deprecated) normal 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+    >
+      <div
+        className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+      >
+        <div
+          className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+        >
+          <h1
+            className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+          >
+            Your Devices
+          </h1>
+        </div>
+        <div
+          className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+        >
+          <p
+            className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+          >
+            Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+          </p>
+        </div>
+      </div>
+      <div
+        className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+      >
+        <div
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          Right Content
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageHero (Deprecated) normal with content switcher 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+    >
+      <div
+        className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+      >
+        <div
+          className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+        >
+          <h1
+            className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+          >
+            Your Devices
+          </h1>
+        </div>
+        <div
+          className="bx--content-switcher PageSwitcher__StyledContentSwitcher-sc-1dcz28n-0 horTRL"
+          onChange={[Function]}
+        >
+          <button
+            aria-selected={false}
+            className="bx--content-switcher-btn"
+            data-tip="All Devices"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex="-1"
+          >
+            <span
+              className="bx--content-switcher__label"
+            >
+              All Devices
+            </span>
+          </button>
+          <button
+            aria-selected={true}
+            className="bx--content-switcher-btn bx--content-switcher--selected"
+            data-tip="Diagnose"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex="0"
+          >
+            <span
+              className="bx--content-switcher__label"
+            >
+              Diagnose
+            </span>
+          </button>
+        </div>
+        <div
+          className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+        >
+          <p
+            className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+          >
+            Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+          </p>
+        </div>
+      </div>
+      <div
+        className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+      >
+        <div
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          Right Content
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageHero (Deprecated) with section 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="PageHero__StyledPageHero-sc-1k4oefb-0 jZTvNr"
+    >
+      <div
+        className="PageHero__StyledTitle-sc-1k4oefb-3 dijkPK"
+      >
+        <div
+          className="PageTitle__StyledPageTitle-sc-1x4wg61-0 MhXQw"
+        >
+          <h1
+            className="PageTitle__StyledPageTitleH1-sc-1x4wg61-2 uwbjE"
+          >
+            <span
+              className="PageTitle__StyledPageSection-sc-1x4wg61-1 dUHWaW"
+            >
+              Explore /
+            </span>
+            Your Devices
+          </h1>
+        </div>
+        <div
+          className="PageHero__StyledPageHeroWrap-sc-1k4oefb-1 dymYXa"
+        >
+          <p
+            className="PageHero__StyledPageBlurb-sc-1k4oefb-2 jjUFol"
+          >
+            Your data lake displays a detailed view of the entity types that are connected in Watson IoT Platform. To explore the metrics and dimensions of your entities in more detail, select Entities. To start applying calculations and analyzing your entity data, select Data.
+          </p>
+        </div>
+      </div>
+      <div
+        className="PageHero__StyledRightContent-sc-1k4oefb-4 jzJCmH"
+      >
+        <div
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          Right Content
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageHero (Deprecated) ️⛔ Deprecation Notice  1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--toast-notification bx--toast-notification--warning"
+      kind="warning"
+      role="alert"
+      style={
+        Object {
+          "marginBottom": ".5rem",
+          "minWidth": "30rem",
+        }
+      }
+      timeout={0}
+    >
+      <svg
+        aria-hidden={true}
+        className="bx--toast-notification__icon"
+        focusable="false"
+        height={20}
+        preserveAspectRatio="xMidYMid meet"
+        style={
+          Object {
+            "willChange": "transform",
+          }
+        }
+        viewBox="0 0 20 20"
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm-.8 4h1.5v7H9.2V5zm.8 11c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"
+        />
+        <path
+          d="M9.2 5h1.5v7H9.2V5zm.8 11c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"
+          data-icon-path="inner-path"
+          opacity="0"
+        />
+        <title>
+          
+        </title>
+      </svg>
+      <div
+        className="bx--toast-notification__details"
+      >
+        <h3
+          className="bx--toast-notification__title"
+        >
+          Deprecation Notice
+        </h3>
+        <div
+          className="bx--toast-notification__subtitle"
+        >
+          PageHero has been deprecated and will be removed in the next major version of carbon-addons-iot-react.
+        </div>
+        <div
+          className="bx--toast-notification__caption"
+        >
+          Refactor usages of PageHero to use Hero instead.
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -1,0 +1,1003 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar base 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-title"
+        >
+          <div
+            className="page-title-bar-title--text"
+          >
+            <h2>
+              Page title
+            </h2>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar isLoading 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <p
+          className="bx--skeleton__text bx--skeleton__heading page-title-bar-loading"
+          style={
+            Object {
+              "width": "30%",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar with breadcrumb 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-breadcrumb"
+        >
+          <nav
+            className="bx--breadcrumb"
+          >
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <a
+                className="bx--link"
+                href="/"
+              >
+                Home
+              </a>
+            </div>
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <a
+                className="bx--link"
+                href="/"
+              >
+                Type
+              </a>
+            </div>
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <span
+                className="bx--link"
+              >
+                Instance
+              </span>
+            </div>
+          </nav>
+        </div>
+        <div
+          className="page-title-bar-title"
+        >
+          <div
+            className="page-title-bar-title--text"
+          >
+            <h2>
+              Page title
+            </h2>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar with description 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-title"
+        >
+          <div
+            className="page-title-bar-title--text"
+          >
+            <h2>
+              Page title
+            </h2>
+          </div>
+        </div>
+        <p
+          className="page-title-bar-description"
+        >
+          Descriptive text about this page and what the user can or should do on it
+        </p>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar with editable title bar 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-title"
+        >
+          <div
+            className="page-title-bar-title--text"
+          >
+            <h2>
+              Page title
+            </h2>
+            <button
+              className="page-title-bar-title--edit Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-bottom"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              <span
+                className="bx--assistive-text"
+              >
+                Edit page title
+              </span>
+              <svg
+                aria-hidden={true}
+                aria-label="Edit page title"
+                className="bx--btn__icon"
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 27h28v2H2zM25.41 9a2 2 0 0 0 0-2.83l-3.58-3.58a2 2 0 0 0-2.83 0l-15 15V24h6.41zm-5-5L24 7.59l-3 3L17.41 7zM6 22v-3.59l10-10L19.59 12l-10 10z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <p
+          className="page-title-bar-description"
+        >
+          Descriptive text about this page and what the user can or should do on it
+        </p>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar with rich content 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-title"
+        >
+          <div
+            className="page-title-bar-title--text"
+          >
+            <h2>
+              Page title
+            </h2>
+            <div
+              className="bx--tooltip__label"
+              id="tooltip"
+            >
+              
+              <div
+                aria-expanded={false}
+                aria-haspopup="true"
+                className="bx--tooltip__trigger"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-hidden={true}
+                  description={null}
+                  focusable="false"
+                  height={24}
+                  preserveAspectRatio="xMidYMid meet"
+                  role={null}
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                  />
+                  <path
+                    d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <button
+            className="some-right-content Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+            disabled={false}
+            tabIndex={0}
+            type="button"
+          >
+            Right Content
+            <svg
+              aria-hidden={true}
+              className="bx--btn__icon"
+              focusable="false"
+              height={24}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar with tabs as children 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-breadcrumb"
+        >
+          <nav
+            className="bx--breadcrumb"
+          >
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <a
+                className="bx--link"
+                href="/"
+              >
+                Home
+              </a>
+            </div>
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <a
+                className="bx--link"
+                href="/"
+              >
+                Type
+              </a>
+            </div>
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <span
+                className="bx--link"
+              >
+                Instance
+              </span>
+            </div>
+          </nav>
+        </div>
+        <div
+          className="page-title-bar-title"
+        >
+          <div
+            className="page-title-bar-title--text"
+          >
+            <h2>
+              Page title
+            </h2>
+            <div
+              className="bx--tooltip__label"
+              id="tooltip"
+            >
+              
+              <div
+                aria-expanded={false}
+                aria-haspopup="true"
+                className="bx--tooltip__trigger"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-hidden={true}
+                  description={null}
+                  focusable="false"
+                  height={24}
+                  preserveAspectRatio="xMidYMid meet"
+                  role={null}
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                  />
+                  <path
+                    d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="page-title-bar-tabs"
+        >
+          <div
+            className="bx--tabs"
+            role="navigation"
+            selected={0}
+          >
+            <div
+              aria-label="listbox"
+              className="bx--tabs-trigger"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="listbox"
+              tabIndex={0}
+            >
+              <a
+                className="bx--tabs-trigger-text"
+                href="#"
+                onClick={[Function]}
+                tabIndex={-1}
+              >
+                Tab 1
+              </a>
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={6}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 10 6"
+                width={10}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
+                />
+                <title>
+                  show menu options
+                </title>
+              </svg>
+            </div>
+            <ul
+              className="bx--tabs__nav bx--tabs__nav--hidden"
+              role="tablist"
+            >
+              <li
+                className="bx--tabs__nav-item bx--tabs__nav-item--selected"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="presentation"
+                selected={true}
+                tabIndex={-1}
+              >
+                <a
+                  aria-selected={true}
+                  className="bx--tabs__nav-link"
+                  href="#"
+                  role="tab"
+                  tabIndex={0}
+                >
+                  Tab 1
+                </a>
+              </li>
+              <li
+                className="bx--tabs__nav-item"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="presentation"
+                selected={false}
+                tabIndex={-1}
+              >
+                <a
+                  aria-selected={false}
+                  className="bx--tabs__nav-link"
+                  href="#"
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  Tab 2
+                </a>
+              </li>
+              <li
+                className="bx--tabs__nav-item"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="presentation"
+                selected={false}
+                tabIndex={-1}
+              >
+                <a
+                  aria-selected={false}
+                  className="bx--tabs__nav-link"
+                  href="#"
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  Tab 3
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div
+            aria-hidden={false}
+            hidden={false}
+            selected={true}
+          >
+            <div>
+              Content for first tab.
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
+          >
+            <div>
+              Content for second tab.
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
+          >
+            <div>
+              Content for third tab.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar with tooltip description 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-breadcrumb"
+        >
+          <nav
+            className="bx--breadcrumb"
+          >
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <a
+                className="bx--link"
+                href="/"
+              >
+                Home
+              </a>
+            </div>
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <a
+                className="bx--link"
+                href="/"
+              >
+                Type
+              </a>
+            </div>
+            <div
+              className="bx--breadcrumb-item"
+            >
+              <span
+                className="bx--link"
+              >
+                Instance
+              </span>
+            </div>
+          </nav>
+        </div>
+        <div
+          className="page-title-bar-title"
+        >
+          <div
+            className="page-title-bar-title--text"
+          >
+            <h2>
+              Page title
+            </h2>
+            <div
+              className="bx--tooltip__label"
+              id="tooltip"
+            >
+              
+              <div
+                aria-expanded={false}
+                aria-haspopup="true"
+                className="bx--tooltip__trigger"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-hidden={true}
+                  description={null}
+                  focusable="false"
+                  height={24}
+                  preserveAspectRatio="xMidYMid meet"
+                  role={null}
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                  />
+                  <path
+                    d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.story.storyshot
+++ b/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.story.storyshot
@@ -1,0 +1,1041 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ProgressIndicator Stateful 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <ul
+      className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+      onChange={[Function]}
+    >
+      <li
+        className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+            <title>
+              This is displayed when step icon is hovered
+            </title>
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            First step
+          </p>
+          <p
+            className="bx--progress-optional"
+          >
+            secondary label
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Second Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Second Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Third Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Third Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fourth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fourth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fifth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fifth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Sixth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Sixth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+    </ul>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ProgressIndicator hideLabels and default stepWidth 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <ul
+      className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+      onChange={[Function]}
+    >
+      <li
+        className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            aria-label="This is displayed when step icon is hovered"
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+            <path
+              d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+            />
+            <title>
+              This is displayed when step icon is hovered
+            </title>
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            First step
+          </p>
+          <p
+            className="bx--progress-optional"
+          >
+            secondary label
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+            <title>
+              Second Step
+            </title>
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Second Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Third Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Third Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fourth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fourth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fifth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fifth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Sixth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Sixth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+    </ul>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ProgressIndicator presentation 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <ul
+      className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+      onChange={[Function]}
+    >
+      <li
+        className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+            <title>
+              This is displayed when step icon is hovered
+            </title>
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            First step
+          </p>
+          <p
+            className="bx--progress-optional"
+          >
+            secondary label
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Second Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Second Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Third Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Third Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fourth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fourth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fifth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fifth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Sixth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Sixth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+    </ul>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ProgressIndicator presentation vertical 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <ul
+      className="bx--progress  bx--progress--vertical ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 fvWusc"
+      onChange={[Function]}
+    >
+      <li
+        className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fdqlBz"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+            <title>
+              This is displayed when step icon is hovered
+            </title>
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            First step
+          </p>
+          <p
+            className="bx--progress-optional"
+          >
+            secondary label
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fdqlBz"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Second Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Second Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fdqlBz"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Third Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Third Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fdqlBz"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fourth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fourth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fdqlBz"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Fifth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Fifth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fdqlBz"
+      >
+        <div
+          className="bx--progress-step-button"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg>
+            <title>
+              Sixth Step
+            </title>
+            <path
+              d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          >
+            Sixth Step
+          </p>
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+    </ul>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ProgressIndicator skeleton 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <ul
+      className="bx--progress bx--skeleton"
+    >
+      <li
+        className="bx--progress-step bx--progress-step--incomplete"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          />
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          />
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          />
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+      <li
+        className="bx--progress-step bx--progress-step--incomplete"
+      >
+        <div
+          className="bx--progress-step-button bx--progress-step-button--unclickable"
+        >
+          <svg>
+            <path
+              d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+            />
+          </svg>
+          <p
+            className="bx--progress-label"
+          />
+          <span
+            className="bx--progress-line"
+          />
+        </div>
+      </li>
+    </ul>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/ResourceList/__snapshots__/ResourceList.story.storyshot
+++ b/src/components/ResourceList/__snapshots__/ResourceList.story.storyshot
@@ -1,0 +1,688 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ResourceList default 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      className="bx--structured-list bx--structured-list--border bx--structured-list--selection ResourceList__ResourceListSection-sc-27rnbq-0 gAnvjz"
+    >
+      <div
+        className="bx--structured-list-tbody"
+      >
+        <label
+          aria-label="Item A"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item A
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <input
+            checked={false}
+            className="bx--structured-list-input"
+            readOnly={true}
+            tabIndex={-1}
+            title="Item A"
+            type="radio"
+            value="Item A"
+          />
+          <div
+            className="bx--structured-list-td"
+            style={
+              Object {
+                "verticalAlign": "middle",
+              }
+            }
+          >
+            <svg
+              className="bx--structured-list-svg"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </label>
+        <label
+          aria-label="Item B"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={1}
+        >
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item B
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <input
+            checked={false}
+            className="bx--structured-list-input"
+            readOnly={true}
+            tabIndex={-1}
+            title="Item B"
+            type="radio"
+            value="Item B"
+          />
+          <div
+            className="bx--structured-list-td"
+            style={
+              Object {
+                "verticalAlign": "middle",
+              }
+            }
+          >
+            <svg
+              className="bx--structured-list-svg"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </label>
+        <label
+          aria-label="Item C"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={2}
+        >
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item C
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed. Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <input
+            checked={false}
+            className="bx--structured-list-input"
+            readOnly={true}
+            tabIndex={-1}
+            title="Item C"
+            type="radio"
+            value="Item C"
+          />
+          <div
+            className="bx--structured-list-td"
+            style={
+              Object {
+                "verticalAlign": "middle",
+              }
+            }
+          >
+            <svg
+              className="bx--structured-list-svg"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </label>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ResourceList with action 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      className="bx--structured-list bx--structured-list--border bx--structured-list--selection ResourceList__ResourceListSection-sc-27rnbq-0 gAnvjz"
+    >
+      <div
+        className="bx--structured-list-tbody"
+      >
+        <label
+          aria-label="Item A"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={-1}
+        >
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item A
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap ResourceList__CustomActionDiv-sc-27rnbq-2 gHaTLR"
+            role="presentation"
+          >
+            <button
+              className="bx--btn bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Configure
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 13h14v1H1zm11.7-8.5c.4-.4.4-1 0-1.4l-1.8-1.8c-.4-.4-1-.4-1.4 0L2 8.8V12h3.2l7.5-7.5zM10.2 2L12 3.8l-1.5 1.5-1.8-1.8L10.2 2zM3 11V9.2l5-5L9.8 6l-5 5H3z"
+                />
+              </svg>
+            </button>
+          </div>
+        </label>
+        <label
+          aria-label="Item B"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={-1}
+        >
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item B
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap ResourceList__CustomActionDiv-sc-27rnbq-2 gHaTLR"
+            role="presentation"
+          >
+            <button
+              className="bx--btn bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Configure
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 13h14v1H1zm11.7-8.5c.4-.4.4-1 0-1.4l-1.8-1.8c-.4-.4-1-.4-1.4 0L2 8.8V12h3.2l7.5-7.5zM10.2 2L12 3.8l-1.5 1.5-1.8-1.8L10.2 2zM3 11V9.2l5-5L9.8 6l-5 5H3z"
+                />
+              </svg>
+            </button>
+          </div>
+        </label>
+        <label
+          aria-label="Item C"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={-1}
+        >
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item C
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed. Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap ResourceList__CustomActionDiv-sc-27rnbq-2 gHaTLR"
+            role="presentation"
+          >
+            <button
+              className="bx--btn bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Configure
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M1 13h14v1H1zm11.7-8.5c.4-.4.4-1 0-1.4l-1.8-1.8c-.4-.4-1-.4-1.4 0L2 8.8V12h3.2l7.5-7.5zM10.2 2L12 3.8l-1.5 1.5-1.8-1.8L10.2 2zM3 11V9.2l5-5L9.8 6l-5 5H3z"
+                />
+              </svg>
+            </button>
+          </div>
+        </label>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ResourceList with extra content 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <section
+      className="bx--structured-list bx--structured-list--border bx--structured-list--selection ResourceList__ResourceListSection-sc-27rnbq-0 gAnvjz"
+    >
+      <div
+        className="bx--structured-list-tbody"
+      >
+        <label
+          aria-label="Item A"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--structured-list-td"
+          >
+            <div>
+              <h5>
+                row-0
+              </h5>
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={32}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={32}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item A
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <input
+            checked={false}
+            className="bx--structured-list-input"
+            readOnly={true}
+            tabIndex={-1}
+            title="Item A"
+            type="radio"
+            value="Item A"
+          />
+          <div
+            className="bx--structured-list-td"
+            style={
+              Object {
+                "verticalAlign": "middle",
+              }
+            }
+          >
+            <svg
+              className="bx--structured-list-svg"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </label>
+        <label
+          aria-label="Item B"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={1}
+        >
+          <div
+            className="bx--structured-list-td"
+          >
+            <div>
+              <h5>
+                row-1
+              </h5>
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={32}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={32}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item B
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <input
+            checked={false}
+            className="bx--structured-list-input"
+            readOnly={true}
+            tabIndex={-1}
+            title="Item B"
+            type="radio"
+            value="Item B"
+          />
+          <div
+            className="bx--structured-list-td"
+            style={
+              Object {
+                "verticalAlign": "middle",
+              }
+            }
+          >
+            <svg
+              className="bx--structured-list-svg"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </label>
+        <label
+          aria-label="Item C"
+          className=" bx--structured-list-row"
+          onClick={[Function]}
+          tabIndex={2}
+        >
+          <div
+            className="bx--structured-list-td"
+          >
+            <div>
+              <h5>
+                row-2
+              </h5>
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={32}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={32}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            className="bx--structured-list-td bx--structured-list-content--nowrap"
+          >
+            <strong>
+              Item C
+            </strong>
+          </div>
+          <div
+            className="bx--structured-list-td"
+          >
+            Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed. Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.Lorem ipsun dolor sit amet, consectetur adipiscing elit. Nunc dui magna, finibus id tortor sed.
+          </div>
+          <input
+            checked={false}
+            className="bx--structured-list-input"
+            readOnly={true}
+            tabIndex={-1}
+            title="Item C"
+            type="radio"
+            value="Item C"
+          />
+          <div
+            className="bx--structured-list-td"
+            style={
+              Object {
+                "verticalAlign": "middle",
+              }
+            }
+          >
+            <svg
+              className="bx--structured-list-svg"
+              height="16"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <path
+                d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.646-10.854L6.75 10.043 4.354 7.646l-.708.708 3.104 3.103 5.604-5.603-.708-.708z"
+                fillRule="evenodd"
+              />
+            </svg>
+          </div>
+        </label>
+      </div>
+    </section>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/SideNav/__snapshots__/SideNav.story.storyshot
+++ b/src/components/SideNav/__snapshots__/SideNav.story.storyshot
@@ -1,0 +1,319 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|SideNav SideNav component 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <header
+      aria-label="main header"
+      className="bx--header custom-class-name Header__StyledHeader-sc-14tpcyv-0 hmKiPy"
+      role="banner"
+    >
+      <a
+        className="bx--skip-to-content"
+        href="#main-content"
+        tabIndex="0"
+      >
+        Skip to main content
+      </a>
+      <button
+        aria-label="Open menu"
+        className="bx--header__action bx--header__menu-trigger bx--header__menu-toggle bx--header__menu-toggle__hidden"
+        onClick={[Function]}
+        title="Open menu"
+        type="button"
+      >
+        <svg
+          aria-hidden={true}
+          focusable="false"
+          height={20}
+          preserveAspectRatio="xMidYMid meet"
+          style={
+            Object {
+              "willChange": "transform",
+            }
+          }
+          viewBox="0 0 20 20"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M2 14.8h16V16H2zm0-3.6h16v1.2H2zm0-3.6h16v1.2H2zM2 4h16v1.2H2z"
+          />
+        </svg>
+      </button>
+      <a
+        className="bx--header__name"
+        href="#"
+      >
+        <span
+          className="bx--header__name--prefix"
+        >
+          IBM
+        </span>
+         
+        Watson IoT Platform 
+      </a>
+      <div
+        className="bx--header__global"
+      >
+        <button
+          aria-label="user"
+          className="Header__StyledGlobalAction-sc-14tpcyv-1 hzqpaE bx--header__action"
+          onClick={[Function]}
+          type="button"
+        >
+          <p
+            className="SideNavstory__User-sc-1xuki3-0 izjVyE"
+          >
+            JohnDoe@ibm.com
+            <span>
+              TenantId: Acme
+            </span>
+          </p>
+          <svg
+            aria-hidden={true}
+            className="bx--header__menu-item bx--header__menu-title"
+            description="Icon"
+            fill="white"
+            focusable="false"
+            height={24}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={24}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M31 30h-2v-3a3 3 0 0 0-3-3h-4a3 3 0 0 0-3 3v3h-2v-3a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5zm-7-18a3 3 0 1 1-3 3 3 3 0 0 1 3-3m0-2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm-9 12h-2v-3a3 3 0 0 0-3-3H6a3 3 0 0 0-3 3v3H1v-3a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5zM8 4a3 3 0 1 1-3 3 3 3 0 0 1 3-3m0-2a5 5 0 1 0 5 5 5 5 0 0 0-5-5z"
+            />
+          </svg>
+        </button>
+      </div>
+    </header>
+    <div
+      className="bx--side-nav__overlay"
+    />
+    <nav
+      aria-label="Side navigation"
+      className="bx--side-nav__navigation bx--side-nav bx--side-nav--ux"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <ul
+        className="bx--side-nav__items"
+      >
+        <li
+          className="bx--side-nav__item"
+        >
+          <div
+            aria-label="Boards"
+            className="bx--side-nav__link disabled"
+            label="Boards"
+            onClick={[Function]}
+            tabIndex={0}
+          >
+            <div
+              className="bx--side-nav__icon bx--side-nav__icon--small"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 24 24"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M18 18h3v3h-3zm-7.5 0h3v3h-3zM3 18h3v3H3zm15-7.5h3v3h-3zm-7.5 0h3v3h-3zm-7.5 0h3v3H3zM18 3h3v3h-3zm-7.5 0h3v3h-3zM3 3h3v3H3z"
+                />
+              </svg>
+            </div>
+            <span
+              className="bx--side-nav__link-text"
+            >
+              Boards
+            </span>
+          </div>
+        </li>
+        <li
+          className="bx--side-nav__item"
+        >
+          <a
+            aria-label="Devices"
+            className="bx--side-nav__link disabled"
+            href="https://google.com"
+            label="Devices"
+            target="_blank"
+          >
+            <div
+              className="bx--side-nav__icon bx--side-nav__icon--small"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 11v10h10V11zm8 8h-6v-6h6z"
+                />
+                <path
+                  d="M30 13v-2h-4V8a2 2 0 0 0-2-2h-3V2h-2v4h-6V2h-2v4H8a2 2 0 0 0-2 2v3H2v2h4v6H2v2h4v3a2 2 0 0 0 2 2h3v4h2v-4h6v4h2v-4h3a2 2 0 0 0 2-2v-3h4v-2h-4v-6zm-6 11H8V8h16z"
+                />
+              </svg>
+            </div>
+            <span
+              className="bx--side-nav__link-text"
+            >
+              Devices
+            </span>
+          </a>
+        </li>
+        <li
+          className="bx--side-nav__item bx--side-nav__item--active bx--side-nav__item--icon disabled"
+        >
+          <button
+            aria-expanded={false}
+            aria-haspopup="true"
+            className="bx--side-nav__submenu"
+            onClick={[Function]}
+            type="button"
+          >
+            <div
+              className="bx--side-nav__icon"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={24}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M31 30h-2v-3a3 3 0 0 0-3-3h-4a3 3 0 0 0-3 3v3h-2v-3a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5zm-7-18a3 3 0 1 1-3 3 3 3 0 0 1 3-3m0-2a5 5 0 1 0 5 5 5 5 0 0 0-5-5zm-9 12h-2v-3a3 3 0 0 0-3-3H6a3 3 0 0 0-3 3v3H1v-3a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5zM8 4a3 3 0 1 1-3 3 3 3 0 0 1 3-3m0-2a5 5 0 1 0 5 5 5 5 0 0 0-5-5z"
+                />
+              </svg>
+            </div>
+            <span
+              className="bx--side-nav__submenu-title"
+            >
+              Members
+            </span>
+            <div
+              className="bx--side-nav__icon bx--side-nav__icon--small bx--side-nav__submenu-chevron"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 22L6 12l1.4-1.4 8.6 8.6 8.6-8.6L26 12z"
+                />
+              </svg>
+            </div>
+          </button>
+          <ul
+            className="bx--side-nav__menu"
+            role="menu"
+          >
+            <li
+              className="bx--side-nav__menu-item"
+              role="none"
+            >
+              <button
+                className="bx--side-nav__link bx--side-nav__link--current"
+                label="Devices"
+                onClick={[Function]}
+                role="menuitem"
+              >
+                <span
+                  className="bx--side-nav__link-text"
+                >
+                  Yet another link
+                </span>
+              </button>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/SimplePagination/__snapshots__/SimplePagination.story.storyshot
+++ b/src/components/SimplePagination/__snapshots__/SimplePagination.story.storyshot
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|SimplePagination default 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="SimplePaginationstory__StyledSimplePagination-sc-17bs5nv-0 eccRzy"
+    >
+      <div
+        className="SimplePagination__StyledContainer-l7ezj3-0 bzKmAQ"
+      >
+        <span
+          className="SimplePagination__StyledPageLabel-l7ezj3-1 hybMqK"
+        >
+          Page 1 of 4
+        </span>
+        <div
+          className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 bxiYjR"
+          role="button"
+          tabIndex={-1}
+        >
+          <svg
+            aria-hidden={true}
+            description="Prev page"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 23l-8-7 8-7v14z"
+            />
+          </svg>
+        </div>
+        <div
+          className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 gxHBrs"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            aria-hidden={true}
+            description="Next page"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13 9l8 7-8 7V9z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/StorybookSnapshots.test.js
+++ b/src/components/StorybookSnapshots.test.js
@@ -1,4 +1,4 @@
-import initStoryshots, { snapshotWithOptions } from '@storybook/addon-storyshots';
+import initStoryshots, { multiSnapshotWithOptions } from '@storybook/addon-storyshots';
 import ReactDOM from 'react-dom';
 // Needed to give more information about the styled component differences in the jest snapshots
 import 'jest-styled-components';
@@ -64,7 +64,7 @@ describe(`Storybook Snapshot tests and console checks`, () => {
   });
   initStoryshots({
     storyKindRegex: /^Watson\sIoT/,
-    test: snapshotWithOptions(story => ({
+    test: multiSnapshotWithOptions(story => ({
       createNodeMock: element => {
         // https://github.com/storybookjs/storybook/tree/next/addons/storyshots/storyshots-core#using-createnodemock-to-mock-refs
         // fallback is to mock something, otherwise our refs are invalid

--- a/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -1,0 +1,556 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableBodyRow normal 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--data-table-container"
+    >
+      <table
+        className="bx--data-table bx--data-table--no-border"
+      >
+        <tbody
+          aria-live="polite"
+        >
+          <tr
+            className="TableBodyRow__StyledTableRow-sc-103itxu-1 cqZfoF"
+            onClick={[Function]}
+          >
+            <td
+              className="TableBodyRow__StyledTableCellRow-sc-103itxu-6 cAOSTW"
+              data-column="string"
+              data-offset={0}
+              id="cell-rowId-string"
+              offset={0}
+            >
+              <span
+                className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+              >
+                <span
+                  title="My String"
+                >
+                  My String
+                </span>
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableBodyRow rowActions 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--data-table-container"
+    >
+      <table
+        className="bx--data-table bx--data-table--no-border"
+      >
+        <tbody
+          aria-live="polite"
+        >
+          <tr
+            className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 fkcPSV"
+            data-child-count={0}
+            data-nesting-offset={0}
+            data-parent-row={true}
+            onClick={[Function]}
+          >
+            <td
+              className="bx--table-expand"
+              headers="expand"
+            >
+              <button
+                aria-label="Click to expand."
+                className="bx--table-expand__button"
+                onClick={[Function]}
+                title="Click to expand."
+              >
+                <svg
+                  aria-label="Click to expand."
+                  className="bx--table-expand__svg"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              className="TableBodyRow__StyledTableCellRow-sc-103itxu-6 cAOSTW"
+              data-column="string"
+              data-offset={0}
+              id="cell-rowId-string"
+              offset={0}
+            >
+              <span
+                className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+              >
+                <span
+                  title="My String"
+                >
+                  My String
+                </span>
+              </span>
+            </td>
+            <td
+              className="RowActionsCell__StyledTableCell-sc-1toqqj7-0 bGkBkT"
+            >
+              <div
+                className="RowActionsCell__RowActionsContainer-sc-1toqqj7-1 hHPyiu"
+              >
+                <button
+                  className="bx--btn bx--btn--ghost"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-label="More actions"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={32}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={32}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableBodyRow rowActions error 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--data-table-container"
+    >
+      <table
+        className="bx--data-table bx--data-table--no-border"
+      >
+        <tbody
+          aria-live="polite"
+        >
+          <tr
+            className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 fkcPSV"
+            data-child-count={0}
+            data-nesting-offset={0}
+            data-parent-row={true}
+            onClick={[Function]}
+          >
+            <td
+              className="bx--table-expand"
+              headers="expand"
+            >
+              <button
+                aria-label="Click to expand."
+                className="bx--table-expand__button"
+                onClick={[Function]}
+                title="Click to expand."
+              >
+                <svg
+                  aria-label="Click to expand."
+                  className="bx--table-expand__svg"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              className="TableBodyRow__StyledTableCellRow-sc-103itxu-6 cAOSTW"
+              data-column="string"
+              data-offset={0}
+              id="cell-rowId-string"
+              offset={0}
+            >
+              <span
+                className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+              >
+                <span
+                  title="My String"
+                >
+                  My String
+                </span>
+              </span>
+            </td>
+            <td
+              className="RowActionsCell__StyledTableCell-sc-1toqqj7-0 bGkBkT"
+            >
+              <div
+                className="RowActionsCell__RowActionsContainer-sc-1toqqj7-1 jEXYjq"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="tooltip-error"
+                >
+                  
+                  <div
+                    aria-expanded={false}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M14.5 14h-13c-.2 0-.3-.1-.4-.2-.1-.2-.1-.3 0-.5l6.5-12c.1-.3.4-.4.6-.2.1 0 .2.1.2.2l6.5 12c.1.2.1.3 0 .5 0 .1-.2.2-.4.2zM2.3 13h11.3L8 2.5 2.3 13z"
+                      />
+                      <path
+                        d="M7.5 6h1v3.5h-1zm.5 4.8c-.4 0-.8.3-.8.8s.3.8.8.8c.4 0 .8-.3.8-.8s-.4-.8-.8-.8z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <span
+                  className="RowActionsError__StyledSpan-sc-1htz5gr-0 gQemCK"
+                >
+                  Action failed
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableBodyRow rowActions running 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--data-table-container"
+    >
+      <table
+        className="bx--data-table bx--data-table--no-border"
+      >
+        <tbody
+          aria-live="polite"
+        >
+          <tr
+            className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 fkcPSV"
+            data-child-count={0}
+            data-nesting-offset={0}
+            data-parent-row={true}
+            onClick={[Function]}
+          >
+            <td
+              className="bx--table-expand"
+              headers="expand"
+            >
+              <button
+                aria-label="Click to expand."
+                className="bx--table-expand__button"
+                onClick={[Function]}
+                title="Click to expand."
+              >
+                <svg
+                  aria-label="Click to expand."
+                  className="bx--table-expand__svg"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              className="TableBodyRow__StyledTableCellRow-sc-103itxu-6 cAOSTW"
+              data-column="string"
+              data-offset={0}
+              id="cell-rowId-string"
+              offset={0}
+            >
+              <span
+                className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+              >
+                <span
+                  title="My String"
+                >
+                  My String
+                </span>
+              </span>
+            </td>
+            <td
+              className="RowActionsCell__StyledTableCell-sc-1toqqj7-0 bGkBkT"
+            >
+              <div
+                className="RowActionsCell__RowActionsContainer-sc-1toqqj7-1 jEXYjq"
+              >
+                <div
+                  aria-label="Active loading indicator"
+                  aria-live="assertive"
+                  className="bx--loading bx--loading--small"
+                >
+                  <svg
+                    className="bx--loading__svg"
+                    viewBox="-75 -75 150 150"
+                  >
+                    <title>
+                      Active loading indicator
+                    </title>
+                    <circle
+                      className="bx--loading__background"
+                      cx="0"
+                      cy="0"
+                      r="37.5"
+                    />
+                    <circle
+                      className="bx--loading__stroke"
+                      cx="0"
+                      cy="0"
+                      r="37.5"
+                    />
+                  </svg>
+                </div>
+                In progress
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/Table/TableDetailWizard/__snapshots__/TableDetailWizard.story.storyshot
+++ b/src/components/Table/TableDetailWizard/__snapshots__/TableDetailWizard.story.storyshot
@@ -1,0 +1,896 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableDetailWizard Stateful example 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TableDetailWizard__StyledWizardWrapper-sc-15frmjo-0 fotMIZ"
+    >
+      <div
+        className="TableDetailWizardHeader__StyledDivWizardHeader-sc-1pa3n63-0 hKHZJV"
+      >
+        <h2
+          className="TableDetailWizardHeader__StyledDivHeading-sc-1pa3n63-1 eKyans"
+        >
+          Create Physical Interface
+        </h2>
+        <div
+          className="TableDetailWizardHeader__StyledButton-sc-1pa3n63-2 jNjnLX"
+        >
+          <button
+            className="bx--btn bx--btn--ghost"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        className="TableDetailWizard__StyledWizardContainer-sc-15frmjo-1 kjwloH"
+      >
+        <div
+          className="TableDetailWizardSidebar__StyledDivWizardHeader-sc-1wxoi33-0 fSDZCW"
+        >
+          <div
+            className="WizardSidebar__StyledSidebar-sc-1bufur3-0 hklDaT"
+            width={250}
+          >
+            <ul
+              className="bx--progress  bx--progress--vertical ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 fvWusc"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      Identity
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Identity
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      State Model
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    State Model
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Notifications
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Notifications
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Final step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          className="TableDetailWizard__StyledContentContainer-sc-15frmjo-4 hxUSxO"
+        >
+          <div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#eaeaea",
+                }
+              }
+            >
+              <div>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Excepturi, corrupti laboriosam, culpa similique quae dolorum provident vitae iusto at velit dignissimos reiciendis maiores voluptate fugit dolore harum unde laborum facilis! Lorem ipsum dolor sit amet consectetur adipisicing elit. Et soluta placeat explicabo! Necessitatibus id neque accusantium molestiae officiis ducimus! Suscipit quae perferendis officiis vel, magnam est error! Vel, accusantium quas enim inventore natus adipisci autem at modi dolores assumenda mollitia ut facilis, deleniti aspernatur? Fuga at in expedita tempora cum quasi nemo neque alias id ullam omnis similique placeat provident, eum totam itaque perferendis, reiciendis laboriosam ducimus sunt facilis amet? Cupiditate voluptatem et, voluptas maxime sunt possimus repudiandae nisi necessitatibus?
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="TableDetailWizard__StyledFooter-sc-15frmjo-3 dZaQHZ"
+      >
+        <div
+          className="bx--modal-footer"
+        >
+          <div
+            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          >
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableDetailWizard Static 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TableDetailWizard__StyledWizardWrapper-sc-15frmjo-0 fotMIZ"
+    >
+      <div
+        className="TableDetailWizardHeader__StyledDivWizardHeader-sc-1pa3n63-0 hKHZJV"
+      >
+        <h2
+          className="TableDetailWizardHeader__StyledDivHeading-sc-1pa3n63-1 eKyans"
+        >
+          Create Physical Interface
+        </h2>
+        <div
+          className="TableDetailWizardHeader__StyledButton-sc-1pa3n63-2 jNjnLX"
+        >
+          <button
+            className="bx--btn bx--btn--ghost"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        className="TableDetailWizard__StyledWizardContainer-sc-15frmjo-1 kjwloH"
+      >
+        <div
+          className="TableDetailWizardSidebar__StyledDivWizardHeader-sc-1wxoi33-0 fSDZCW"
+        >
+          <div
+            className="WizardSidebar__StyledSidebar-sc-1bufur3-0 hklDaT"
+            width={250}
+          >
+            <ul
+              className="bx--progress  bx--progress--vertical ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 fvWusc"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Identity"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                    <path
+                      d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+                    />
+                    <title>
+                      Identity
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Identity
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      State Model
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    State Model
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Notifications
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Notifications
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Final step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          className="TableDetailWizard__StyledContentContainer-sc-15frmjo-4 hxUSxO"
+        >
+          <div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#dceadd",
+                  "padding": "70px 30px",
+                }
+              }
+            >
+              <div>
+                Lorem ipsum dolor sit amet consectetur, adipisicing elit. Illum mollitia repellendus assumenda fuga inventore nisi, minus optio ullam voluptas eveniet dolore dolorem vitae, neque suscipit labore at. Voluptatum, nobis perferendis!
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="TableDetailWizard__StyledFooter-sc-15frmjo-3 dZaQHZ"
+      >
+        <div
+          className="bx--modal-footer"
+        >
+          <div
+            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          >
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Back
+            </button>
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableDetailWizard with error 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TableDetailWizard__StyledWizardWrapper-sc-15frmjo-0 fotMIZ"
+    >
+      <div
+        className="TableDetailWizardHeader__StyledDivWizardHeader-sc-1pa3n63-0 hKHZJV"
+      >
+        <h2
+          className="TableDetailWizardHeader__StyledDivHeading-sc-1pa3n63-1 eKyans"
+        >
+          Create Physical Interface
+        </h2>
+        <div
+          className="TableDetailWizardHeader__StyledButton-sc-1pa3n63-2 jNjnLX"
+        >
+          <button
+            className="bx--btn bx--btn--ghost"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        className="TableDetailWizard__StyledWizardContainer-sc-15frmjo-1 kjwloH"
+      >
+        <div
+          className="TableDetailWizardSidebar__StyledDivWizardHeader-sc-1wxoi33-0 fSDZCW"
+        >
+          <div
+            className="WizardSidebar__StyledSidebar-sc-1bufur3-0 hklDaT"
+            width={250}
+          >
+            <ul
+              className="bx--progress  bx--progress--vertical ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 fvWusc"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      Identity
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Identity
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      State Model
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    State Model
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Notifications
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Notifications
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 jNikwx"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Final step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          className="TableDetailWizard__StyledContentContainer-sc-15frmjo-4 hxUSxO"
+        >
+          <div>
+            <div
+              style={
+                Object {
+                  "backgroundColor": "#eaeaea",
+                }
+              }
+            >
+              <div>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Excepturi, corrupti laboriosam, culpa similique quae dolorum provident vitae iusto at velit dignissimos reiciendis maiores voluptate fugit dolore harum unde laborum facilis! Lorem ipsum dolor sit amet consectetur adipisicing elit. Et soluta placeat explicabo! Necessitatibus id neque accusantium molestiae officiis ducimus! Suscipit quae perferendis officiis vel, magnam est error! Vel, accusantium quas enim inventore natus adipisci autem at modi dolores assumenda mollitia ut facilis, deleniti aspernatur? Fuga at in expedita tempora cum quasi nemo neque alias id ullam omnis similique placeat provident, eum totam itaque perferendis, reiciendis laboriosam ducimus sunt facilis amet? Cupiditate voluptatem et, voluptas maxime sunt possimus repudiandae nisi necessitatibus?
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="bx--inline-notification bx--inline-notification--error TableDetailWizard__StyledMessageBox-sc-15frmjo-2 bHjJtp"
+        kind="error"
+        role="alert"
+      >
+        <div
+          className="bx--inline-notification__details"
+        >
+          <svg
+            aria-hidden={true}
+            className="bx--inline-notification__icon"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 20 20"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm3.5 13.5l-8-8 1-1 8 8-1 1z"
+            />
+            <path
+              d="M13.5 14.5l-8-8 1-1 8 8-1 1z"
+              data-icon-path="inner-path"
+              opacity="0"
+            />
+            <title>
+              closes notification
+            </title>
+          </svg>
+          <div
+            className="bx--inline-notification__text-wrapper"
+          >
+            <p
+              className="bx--inline-notification__title"
+            >
+              Error on the form
+            </p>
+            <div
+              className="bx--inline-notification__subtitle"
+            >
+              
+            </div>
+          </div>
+        </div>
+        <button
+          aria-label="closes notification"
+          className="bx--inline-notification__close-button"
+          onClick={[Function]}
+          title="closes notification"
+          type="button"
+        >
+          <svg
+            aria-label="close notification"
+            className="bx--inline-notification__close-icon"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        className="TableDetailWizard__StyledFooter-sc-15frmjo-3 dZaQHZ"
+      >
+        <div
+          className="bx--modal-footer"
+        >
+          <div
+            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          >
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
+++ b/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
@@ -1,0 +1,2645 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog async loaded wait one second 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+    >
+      <div
+        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+      />
+      <div
+        className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
+      >
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileGroup__StyledGreedyTile-eak4ed-1 eTCDyV"
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog default 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+    >
+      <div
+        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+      />
+      <div
+        className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
+      >
+        <input
+          checked={true}
+          className="bx--tile-input"
+          id="test1"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test1"
+        />
+        <label
+          className="bx--tile bx--tile--selectable bx--tile--is-selected"
+          htmlFor="test1"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile with really long title that should wrap"
+                  >
+                    Test Tile with really long title that should wrap
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test2"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test2"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test2"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile2"
+                  >
+                    Test Tile2
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test3"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test3"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test3"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile3"
+                  >
+                    Test Tile3
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Tile contents
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test4"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test4"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test4"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile4"
+                  >
+                    Test Tile4
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test5"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test5"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test5"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile5"
+                  >
+                    Test Tile5
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test6"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test6"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test6"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile6"
+                  >
+                    Test Tile6
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test7"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test7"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test7"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile7"
+                  >
+                    Test Tile7
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <div
+          className="bx--tile TileGroup__StyledGreedyTile-eak4ed-1 eTCDyV"
+        />
+      </div>
+      <div
+        className="SimplePagination__StyledContainer-l7ezj3-0 bzKmAQ"
+      >
+        <span
+          className="SimplePagination__StyledPageLabel-l7ezj3-1 hybMqK"
+        >
+          Page 1 of 1
+        </span>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog error 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+      >
+        <div
+          className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+        />
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          In error state
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog loading 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+    >
+      <div
+        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+      />
+      <div
+        className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
+      >
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+        >
+          <p
+            className="bx--skeleton__text"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="bx--tile TileGroup__StyledGreedyTile-eak4ed-1 eTCDyV"
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog with pages 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+    >
+      <div
+        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+      />
+      <div
+        className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
+      >
+        <input
+          checked={true}
+          className="bx--tile-input"
+          id="test1"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test1"
+        />
+        <label
+          className="bx--tile bx--tile--selectable bx--tile--is-selected"
+          htmlFor="test1"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile with really long title that should wrap"
+                  >
+                    Test Tile with really long title that should wrap
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test2"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test2"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test2"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile2"
+                  >
+                    Test Tile2
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test3"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test3"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test3"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile3"
+                  >
+                    Test Tile3
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Tile contents
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test4"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test4"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test4"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile4"
+                  >
+                    Test Tile4
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test5"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test5"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test5"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile5"
+                  >
+                    Test Tile5
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test6"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test6"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test6"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile6"
+                  >
+                    Test Tile6
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <div
+          className="bx--tile TileGroup__StyledGreedyTile-eak4ed-1 eTCDyV"
+        />
+      </div>
+      <div
+        className="SimplePagination__StyledContainer-l7ezj3-0 bzKmAQ"
+      >
+        <span
+          className="SimplePagination__StyledPageLabel-l7ezj3-1 hybMqK"
+        >
+          Page 1 of 2
+        </span>
+        <div
+          className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 bxiYjR"
+          role="button"
+          tabIndex={-1}
+        >
+          <svg
+            aria-hidden={true}
+            description="Prev page"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 23l-8-7 8-7v14z"
+            />
+          </svg>
+        </div>
+        <div
+          className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 gxHBrs"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            aria-hidden={true}
+            description="Next page"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13 9l8 7-8 7V9z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog with search 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+    >
+      <div
+        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+      >
+        <div
+          className="bx--toolbar-action bx--toolbar-search-container-expandable"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          role="searchbox"
+          tabIndex="0"
+        >
+          <div
+            aria-labelledby="entityType-searchbox-label"
+            className="bx--search bx--search--sm bx--search-maginfier"
+            role="search"
+          >
+            <svg
+              aria-label="Search catalog"
+              className="bx--search-magnifier"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
+              />
+            </svg>
+            <label
+              className="bx--label"
+              htmlFor="entityType-searchbox"
+              id="entityType-searchbox-label"
+            >
+              Search catalog
+            </label>
+            <input
+              aria-hidden={true}
+              className="bx--search-input"
+              id="entityType-searchbox"
+              onChange={[Function]}
+              placeholder="Search catalog"
+              type="text"
+              value=""
+            />
+            <button
+              className="bx--search-close bx--search-close--hidden"
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
+      >
+        <input
+          checked={true}
+          className="bx--tile-input"
+          id="test1"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test1"
+        />
+        <label
+          className="bx--tile bx--tile--selectable bx--tile--is-selected"
+          htmlFor="test1"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile with really long title that should wrap"
+                  >
+                    Test Tile with really long title that should wrap
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test2"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test2"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test2"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile2"
+                  >
+                    Test Tile2
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test3"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test3"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test3"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile3"
+                  >
+                    Test Tile3
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Tile contents
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test4"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test4"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test4"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile4"
+                  >
+                    Test Tile4
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test5"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test5"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test5"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile5"
+                  >
+                    Test Tile5
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test6"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test6"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test6"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile6"
+                  >
+                    Test Tile6
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <div
+          className="bx--tile TileGroup__StyledGreedyTile-eak4ed-1 eTCDyV"
+        />
+      </div>
+      <div
+        className="SimplePagination__StyledContainer-l7ezj3-0 bzKmAQ"
+      >
+        <span
+          className="SimplePagination__StyledPageLabel-l7ezj3-1 hybMqK"
+        >
+          Page 1 of 2
+        </span>
+        <div
+          className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 bxiYjR"
+          role="button"
+          tabIndex={-1}
+        >
+          <svg
+            aria-hidden={true}
+            description="Prev page"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 23l-8-7 8-7v14z"
+            />
+          </svg>
+        </div>
+        <div
+          className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 gxHBrs"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            aria-hidden={true}
+            description="Next page"
+            focusable="false"
+            height={20}
+            preserveAspectRatio="xMidYMid meet"
+            style={
+              Object {
+                "willChange": "transform",
+              }
+            }
+            viewBox="0 0 32 32"
+            width={20}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13 9l8 7-8 7V9z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
+++ b/src/components/WizardInline/__snapshots__/WizardInline.story.storyshot
@@ -1,0 +1,1532 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardInline Stateful example 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="WizardInline__StyledWizardWrapper-sc-8orpb0-0 hExrwn"
+    >
+      <div
+        className="bx--modal-container"
+        data-id="WizardInlineContainer"
+      >
+        <div
+          className="WizardHeader__StyledDivWizardHeader-zafbe2-0 kZNhvb"
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <div
+              className="WizardHeader__StyledDivHeading-zafbe2-1 fyqjyb"
+            >
+              <p
+                className="bx--modal-header__heading bx--type-beta"
+              >
+                I am a title
+              </p>
+            </div>
+            <ul
+              className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      First step
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    First step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Device Information step goes here
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Device Information step goes here
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Long step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Long step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 fHtWSy"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Final step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-label="close modal"
+              className="bx--modal-close"
+              data-modal-close={true}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div>
+            My long blurb to explain what is going on
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledWizardContainer-sc-8orpb0-1 jxomPl"
+        >
+          <div
+            className="WizardSidebar__StyledSidebar-sc-1bufur3-0 bJpUtv"
+            width={200}
+          >
+            <div>
+              sidebar
+            </div>
+          </div>
+          <div
+            className="bx--modal-content"
+            data-id="WizardInlineContent"
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "#eaeaea",
+                  }
+                }
+              >
+                <div>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit. Excepturi, corrupti laboriosam, culpa similique quae dolorum provident vitae iusto at velit dignissimos reiciendis maiores voluptate fugit dolore harum unde laborum facilis! Lorem ipsum dolor sit amet consectetur adipisicing elit. Et soluta placeat explicabo! Necessitatibus id neque accusantium molestiae officiis ducimus! Suscipit quae perferendis officiis vel, magnam est error! Vel, accusantium quas enim inventore natus adipisci autem at modi dolores assumenda mollitia ut facilis, deleniti aspernatur? Fuga at in expedita tempora cum quasi nemo neque alias id ullam omnis similique placeat provident, eum totam itaque perferendis, reiciendis laboriosam ducimus sunt facilis amet? Cupiditate voluptatem et, voluptas maxime sunt possimus repudiandae nisi necessitatibus?
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledFooter-sc-8orpb0-3 dNYflQ"
+        >
+          <div
+            className="bx--modal-footer"
+            data-id="WizardInlineFooter"
+          >
+            <div
+              className="WizardInline-custom-footer-content"
+            >
+              <p
+                className="WizardInlinestory__StyledFooterContent-j3mhhx-0 hZOfgn"
+              >
+                this is footer content
+              </p>
+            </div>
+            <div
+              className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            >
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardInline Static 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="WizardInline__StyledWizardWrapper-sc-8orpb0-0 hExrwn"
+    >
+      <div
+        className="bx--modal-container"
+        data-id="WizardInlineContainer"
+      >
+        <div
+          className="WizardHeader__StyledDivWizardHeader-zafbe2-0 kZNhvb"
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <div
+              className="WizardHeader__StyledDivHeading-zafbe2-1 fyqjyb"
+            >
+              <p
+                className="bx--modal-header__heading bx--type-beta"
+              >
+                Static Wizard
+              </p>
+            </div>
+            <ul
+              className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="First step"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                    <path
+                      d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+                    />
+                    <title>
+                      First step
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    First step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      Device Information step goes here
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Device Information step goes here
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Long step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Long step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Final step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-label="close modal"
+              className="bx--modal-close"
+              data-modal-close={true}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledWizardContainer-sc-8orpb0-1 jxomPl"
+        >
+          <div
+            className="bx--modal-content"
+            data-id="WizardInlineContent"
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "#dceadd",
+                    "padding": "70px 30px",
+                  }
+                }
+              >
+                <div>
+                  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Illum mollitia repellendus assumenda fuga inventore nisi, minus optio ullam voluptas eveniet dolore dolorem vitae, neque suscipit labore at. Voluptatum, nobis perferendis!
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledFooter-sc-8orpb0-3 dNYflQ"
+        >
+          <div
+            className="bx--modal-footer"
+            data-id="WizardInlineFooter"
+          >
+            <div
+              className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            >
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Back
+              </button>
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardInline Static with Footer 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="WizardInline__StyledWizardWrapper-sc-8orpb0-0 hExrwn"
+    >
+      <div
+        className="bx--modal-container"
+        data-id="WizardInlineContainer"
+      >
+        <div
+          className="WizardHeader__StyledDivWizardHeader-zafbe2-0 kZNhvb"
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <div
+              className="WizardHeader__StyledDivHeading-zafbe2-1 fyqjyb"
+            >
+              <p
+                className="bx--modal-header__heading bx--type-beta"
+              >
+                Static Wizard
+              </p>
+            </div>
+            <ul
+              className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="First step"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                    <path
+                      d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+                    />
+                    <title>
+                      First step
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    First step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Device Information step goes here"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                    <path
+                      d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+                    />
+                    <title>
+                      Device Information step goes here
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Device Information step goes here
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="Long step"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                    <path
+                      d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+                    />
+                    <title>
+                      Long step
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Long step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      Final step
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-label="close modal"
+              className="bx--modal-close"
+              data-modal-close={true}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledWizardContainer-sc-8orpb0-1 jxomPl"
+        >
+          <div
+            className="bx--modal-content"
+            data-id="WizardInlineContent"
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "#ae9e8e",
+                    "padding": "70px 30px",
+                  }
+                }
+              >
+                <div>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit. Tenetur deserunt eius ad sequi provident, corporis rerum expedita amet enim perferendis?
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledFooter-sc-8orpb0-3 dNYflQ"
+        >
+          <div
+            className="bx--modal-footer"
+            data-id="WizardInlineFooter"
+          >
+            <div
+              className="WizardInline-custom-footer-content"
+            >
+              <p
+                className="WizardInlinestory__StyledFooterContent-j3mhhx-0 hZOfgn"
+              >
+                this is footer content
+              </p>
+            </div>
+            <div
+              className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            >
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Back
+              </button>
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardInline Static with Sidebar 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="WizardInline__StyledWizardWrapper-sc-8orpb0-0 hExrwn"
+    >
+      <div
+        className="bx--modal-container"
+        data-id="WizardInlineContainer"
+      >
+        <div
+          className="WizardHeader__StyledDivWizardHeader-zafbe2-0 kZNhvb"
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <div
+              className="WizardHeader__StyledDivHeading-zafbe2-1 fyqjyb"
+            >
+              <p
+                className="bx--modal-header__heading bx--type-beta"
+              >
+                Static Wizard
+              </p>
+            </div>
+            <ul
+              className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      First step
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    First step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Device Information step goes here
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Device Information step goes here
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Long step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Long step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Final step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-label="close modal"
+              className="bx--modal-close"
+              data-modal-close={true}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledWizardContainer-sc-8orpb0-1 jxomPl"
+        >
+          <div
+            className="WizardSidebar__StyledSidebar-sc-1bufur3-0 bJpUtv"
+            width={200}
+          >
+            <div>
+              sidebar
+            </div>
+          </div>
+          <div
+            className="bx--modal-content"
+            data-id="WizardInlineContent"
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "#eaeaea",
+                  }
+                }
+              >
+                <div>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit. Excepturi, corrupti laboriosam, culpa similique quae dolorum provident vitae iusto at velit dignissimos reiciendis maiores voluptate fugit dolore harum unde laborum facilis! Lorem ipsum dolor sit amet consectetur adipisicing elit. Et soluta placeat explicabo! Necessitatibus id neque accusantium molestiae officiis ducimus! Suscipit quae perferendis officiis vel, magnam est error! Vel, accusantium quas enim inventore natus adipisci autem at modi dolores assumenda mollitia ut facilis, deleniti aspernatur? Fuga at in expedita tempora cum quasi nemo neque alias id ullam omnis similique placeat provident, eum totam itaque perferendis, reiciendis laboriosam ducimus sunt facilis amet? Cupiditate voluptatem et, voluptas maxime sunt possimus repudiandae nisi necessitatibus?
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledFooter-sc-8orpb0-3 dNYflQ"
+        >
+          <div
+            className="bx--modal-footer"
+            data-id="WizardInlineFooter"
+          >
+            <div
+              className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            >
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardInline with error 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="WizardInline__StyledWizardWrapper-sc-8orpb0-0 hExrwn"
+    >
+      <div
+        className="bx--modal-container"
+        data-id="WizardInlineContainer"
+      >
+        <div
+          className="WizardHeader__StyledDivWizardHeader-zafbe2-0 kZNhvb"
+        >
+          <div
+            className="bx--modal-header"
+          >
+            <div
+              className="WizardHeader__StyledDivHeading-zafbe2-1 fyqjyb"
+            >
+              <p
+                className="bx--modal-header__heading bx--type-beta"
+              >
+                Static Wizard
+              </p>
+            </div>
+            <ul
+              className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+              onChange={[Function]}
+            >
+              <li
+                className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button bx--progress-step-button--unclickable"
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={-1}
+                >
+                  <svg>
+                    <path
+                      d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                    />
+                    <title>
+                      First step
+                    </title>
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    First step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Device Information step goes here
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Device Information step goes here
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Long step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Long step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+              <li
+                className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 IPBkT"
+              >
+                <div
+                  className="bx--progress-step-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg>
+                    <title>
+                      Final step
+                    </title>
+                    <path
+                      d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                    />
+                  </svg>
+                  <p
+                    className="bx--progress-label"
+                  >
+                    Final step
+                  </p>
+                  <span
+                    className="bx--progress-line"
+                  />
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-label="close modal"
+              className="bx--modal-close"
+              data-modal-close={true}
+              onClick={[Function]}
+              type="button"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--modal-close__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="bx--inline-notification bx--inline-notification--error WizardInline__StyledMessageBox-sc-8orpb0-2 jGtpBI"
+          kind="error"
+          role="alert"
+        >
+          <div
+            className="bx--inline-notification__details"
+          >
+            <svg
+              aria-hidden={true}
+              className="bx--inline-notification__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 20 20"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 1c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm3.5 13.5l-8-8 1-1 8 8-1 1z"
+              />
+              <path
+                d="M13.5 14.5l-8-8 1-1 8 8-1 1z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                closes notification
+              </title>
+            </svg>
+            <div
+              className="bx--inline-notification__text-wrapper"
+            >
+              <p
+                className="bx--inline-notification__title"
+              >
+                Error on the form
+              </p>
+              <div
+                className="bx--inline-notification__subtitle"
+              >
+                
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="closes notification"
+            className="bx--inline-notification__close-button"
+            onClick={[Function]}
+            title="closes notification"
+            type="button"
+          >
+            <svg
+              aria-label="close notification"
+              className="bx--inline-notification__close-icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="WizardInline__StyledWizardContainer-sc-8orpb0-1 jxomPl"
+        >
+          <div
+            className="bx--modal-content"
+            data-id="WizardInlineContent"
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "backgroundColor": "#eaeaea",
+                  }
+                }
+              >
+                <div>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit. Excepturi, corrupti laboriosam, culpa similique quae dolorum provident vitae iusto at velit dignissimos reiciendis maiores voluptate fugit dolore harum unde laborum facilis! Lorem ipsum dolor sit amet consectetur adipisicing elit. Et soluta placeat explicabo! Necessitatibus id neque accusantium molestiae officiis ducimus! Suscipit quae perferendis officiis vel, magnam est error! Vel, accusantium quas enim inventore natus adipisci autem at modi dolores assumenda mollitia ut facilis, deleniti aspernatur? Fuga at in expedita tempora cum quasi nemo neque alias id ullam omnis similique placeat provident, eum totam itaque perferendis, reiciendis laboriosam ducimus sunt facilis amet? Cupiditate voluptatem et, voluptas maxime sunt possimus repudiandae nisi necessitatibus?
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="WizardInline__StyledFooter-sc-8orpb0-3 dNYflQ"
+        >
+          <div
+            className="bx--modal-footer"
+            data-id="WizardInlineFooter"
+          >
+            <div
+              className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+            >
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
+++ b/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
@@ -1,0 +1,761 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardModal basic wizard modal 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible WizardModal__StyledModal-sc-4j7w2v-0 eknHny ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      currentStepIndex={0}
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Basic Wizard
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Gimme 3 Steps
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-content"
+        >
+          <ul
+            className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+            onChange={[Function]}
+          >
+            <li
+              className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+            >
+              <div
+                className="bx--progress-step-button bx--progress-step-button--unclickable"
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={-1}
+              >
+                <svg>
+                  <path
+                    d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                  />
+                  <title>
+                    step1
+                  </title>
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step1
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+            <li
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+            >
+              <div
+                className="bx--progress-step-button"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg>
+                  <title>
+                    step2
+                  </title>
+                  <path
+                    d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                  />
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step2
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+            <li
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+            >
+              <div
+                className="bx--progress-step-button"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg>
+                  <title>
+                    step3
+                  </title>
+                  <path
+                    d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                  />
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step3
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+          </ul>
+          <div
+            className="WizardModal__StyledWizardContent-sc-4j7w2v-1 gdiPpx"
+          >
+            page 1
+          </div>
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <div
+            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          >
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Cancel
+            </button>
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardModal custom footer 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible WizardModalstory__StyledWizard-sc-1z46gj-0 eiobyI WizardModal__StyledModal-sc-4j7w2v-0 eknHny ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      currentStepIndex={0}
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Wizard With Custom Footer 
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Gimme 3 Steps
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-content"
+        >
+          <ul
+            className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+            onChange={[Function]}
+          >
+            <li
+              className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+            >
+              <div
+                className="bx--progress-step-button bx--progress-step-button--unclickable"
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={-1}
+              >
+                <svg>
+                  <path
+                    d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                  />
+                  <title>
+                    step1
+                  </title>
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step1
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+            <li
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+            >
+              <div
+                className="bx--progress-step-button"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg>
+                  <title>
+                    step2
+                  </title>
+                  <path
+                    d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                  />
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step2
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+            <li
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+            >
+              <div
+                className="bx--progress-step-button"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg>
+                  <title>
+                    step3
+                  </title>
+                  <path
+                    d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                  />
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step3
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+          </ul>
+          <div
+            className="WizardModal__StyledWizardContent-sc-4j7w2v-1 gdiPpx"
+          >
+            page 1
+          </div>
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <div
+            className="WizardInline-custom-footer-content"
+          >
+            <p>
+              Custom content
+            </p>
+          </div>
+          <div
+            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          >
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              I18N Cancel
+            </button>
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              I18N Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|WizardModal sending data 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--modal is-visible WizardModal__StyledModal-sc-4j7w2v-0 eknHny ComposedModal__StyledModal-sc-12pj5f-0 eVCcTg"
+      currentStepIndex={2}
+      invalid={false}
+      onBlur={[Function]}
+      onClearError={null}
+      onClick={[Function]}
+      onClose={[Function]}
+      onKeyDown={[Function]}
+      onTransitionEnd={[Function]}
+      open={true}
+      role="presentation"
+      submitFailed={false}
+      tabIndex={-1}
+    >
+      <div
+        className="bx--modal-container"
+      >
+        <div
+          className="bx--modal-header"
+        >
+          <p
+            className="bx--modal-header__label bx--type-delta"
+          >
+            Basic Wizard
+          </p>
+          <p
+            className="bx--modal-header__heading bx--type-beta"
+          >
+            Gimme 3 Steps
+          </p>
+          <button
+            className="bx--modal-close"
+            onClick={[Function]}
+            title="Close"
+            type="button"
+          >
+            <svg
+              aria-label="Close"
+              className="bx--modal-close__icon"
+              focusable="false"
+              height={20}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 32 32"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4l6.6 6.6L8 22.6 9.4 24l6.6-6.6 6.6 6.6 1.4-1.4-6.6-6.6L24 9.4z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="bx--modal-content"
+        >
+          <ul
+            className="bx--progress   ProgressIndicator__StyledProgressIndicator-sc-1sy51cd-0 egbeyA"
+            onChange={[Function]}
+          >
+            <li
+              className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+            >
+              <div
+                className="bx--progress-step-button"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="step1"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                  />
+                  <path
+                    d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+                  />
+                  <title>
+                    step1
+                  </title>
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step1
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+            <li
+              className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+            >
+              <div
+                className="bx--progress-step-button"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="step2"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                  />
+                  <path
+                    d="M7 10.8L4.5 8.3l.8-.8L7 9.2l3.7-3.7.8.8z"
+                  />
+                  <title>
+                    step2
+                  </title>
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step2
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+            <li
+              className="bx--progress-step bx--progress-step--current ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
+            >
+              <div
+                className="bx--progress-step-button bx--progress-step-button--unclickable"
+                onKeyDown={[Function]}
+                role="button"
+                tabIndex={-1}
+              >
+                <svg>
+                  <path
+                    d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                  />
+                  <title>
+                    step3
+                  </title>
+                </svg>
+                <p
+                  className="bx--progress-label"
+                >
+                  step3
+                </p>
+                <span
+                  className="bx--progress-line"
+                />
+              </div>
+            </li>
+          </ul>
+          <div
+            className="WizardModal__StyledWizardContent-sc-4j7w2v-1 gdiPpx"
+          >
+            page 3
+          </div>
+        </div>
+        <div
+          className="bx--modal-footer ComposedModal__StyledModalFooter-sc-12pj5f-2 ctEQpf"
+        >
+          <div
+            className="WizardFooter__StyledFooterButtons-sc-18uwrwe-0 jSocgX"
+          >
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--secondary"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              Previous
+            </button>
+            <button
+              className="Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary bx--btn--disabled"
+              disabled={true}
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              <div
+                aria-label="Active loading indicator"
+                aria-live="assertive"
+                className="bx--loading bx--loading--small"
+              >
+                <svg
+                  className="bx--loading__svg"
+                  viewBox="-75 -75 150 150"
+                >
+                  <title>
+                    Active loading indicator
+                  </title>
+                  <circle
+                    className="bx--loading__background"
+                    cx="0"
+                    cy="0"
+                    r="37.5"
+                  />
+                  <circle
+                    className="bx--loading__stroke"
+                    cx="0"
+                    cy="0"
+                    r="37.5"
+                  />
+                </svg>
+              </div>
+              Submit
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Switch out `snapshotWithOptions()` for [`multiSnapshotWithOptions()`](https://www.npmjs.com/package/@storybook/addon-storyshots#multisnapshotwithoptionsoptions)
  - > _"Like snapshotWithOptions, but generate a separate snapshot file for each stories file rather than a single monolithic file (as is the convention in Jest). This makes it dramatically easier to review changes."_
- Also improves test time by ~30%! Should also speed up our Travis CI builds a bit.

**Change List (commits, features, bugs, etc)**

- Switch out function
- Update snapshots, deletes the old monolithic file, creates new separate files.

**Acceptance Test (how to verify the PR)**

- Does this update miss any previous components that were included in the monolithic file?
