### PR TITLE
fix(dashboard): improve performance by memoizing the CardRenderer

### DIFF
--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -47,7 +47,7 @@ const CardRenderer = React.memo(
   ({
     style, // eslint-disable-line
     card, // eslint-disable-line
-    card: { availableActions, type, dataSource, isExpanded, ...others }, // eslint-disable-line
+    card: { availableActions, type, dataSource, ...others }, // eslint-disable-line
     onCardAction, // eslint-disable-line
     i18n, // eslint-disable-line
     dashboardBreakpoints, // eslint-disable-line
@@ -73,8 +73,9 @@ const CardRenderer = React.memo(
     );
 
     const cachedExpandedStyle = useMemo(
-      () => (isExpanded ? merge({ height: '100%', width: '100%', padding: '50' }, style) : style),
-      [isExpanded, style]
+      () =>
+        card.isExpanded ? merge({ height: '100%', width: '100%', padding: '50px' }, style) : style,
+      [card.isExpanded, style]
     );
 
     return (
@@ -203,4 +204,7 @@ const CardRenderer = React.memo(
     );
   }
 );
+CachedCardRenderer.defaultProps = {
+  style: {},
+};
 export default CachedCardRenderer;

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -14,7 +14,6 @@ import { CARD_TYPES } from '../../constants/LayoutConstants';
 
 const CachedCardRenderer = ({
   style, //eslint-disable-line
-  card, // eslint-disable-line
   onCardAction, //eslint-disable-line
   isLoading, // eslint-disable-line
   ...others
@@ -26,14 +25,13 @@ const CachedCardRenderer = ({
     },
     [style] // need to do a deep compare on style
   );
-  // Have to reset the card action callback once the dashboard has finished loading
-  const cachedOnCardAction = useCallback(onCardAction, [card, isLoading]);
+  // Have to reset the card action callback once the whole dashboard has finished loading to get the latest dashboard
+  const cachedOnCardAction = useCallback(onCardAction, [isLoading]);
   return (
     <CardRenderer
       {...others}
       isLoading={isLoading}
       onCardAction={cachedOnCardAction}
-      card={card}
       style={cachedStyle}
     />
   );
@@ -88,7 +86,6 @@ const CardRenderer = React.memo(
             dataSource={dataSource}
             type={type}
             i18n={i18n}
-            isLoading={card.isLoading || isLoading}
             isEditable={isEditable}
             onCardAction={onCardAction}
             breakpoint={breakpoint}
@@ -105,7 +102,6 @@ const CardRenderer = React.memo(
             dataSource={dataSource}
             type={type}
             i18n={i18n}
-            isLoading={card.isLoading || isLoading}
             isEditable={isEditable}
             onCardAction={onCardAction}
             breakpoint={breakpoint}
@@ -122,7 +118,6 @@ const CardRenderer = React.memo(
             dataSource={dataSource}
             type={type}
             i18n={i18n}
-            isLoading={card.isLoading || isLoading}
             isEditable={isEditable}
             onCardAction={onCardAction}
             breakpoint={breakpoint}
@@ -139,7 +134,6 @@ const CardRenderer = React.memo(
             dataSource={dataSource}
             type={type}
             i18n={i18n}
-            isLoading={card.isLoading || isLoading}
             isEditable={isEditable}
             onCardAction={onCardAction}
             breakpoint={breakpoint}
@@ -156,7 +150,6 @@ const CardRenderer = React.memo(
             dataSource={dataSource}
             type={type}
             i18n={i18n}
-            isLoading={card.isLoading || isLoading}
             isEditable={isEditable}
             onCardAction={onCardAction}
             breakpoint={breakpoint}
@@ -173,7 +166,6 @@ const CardRenderer = React.memo(
             dataSource={dataSource}
             type={type}
             i18n={i18n}
-            isLoading={card.isLoading || isLoading}
             isEditable={isEditable}
             onCardAction={onCardAction}
             breakpoint={breakpoint}
@@ -190,7 +182,6 @@ const CardRenderer = React.memo(
             dataSource={dataSource}
             type={type}
             i18n={i18n}
-            isLoading={card.isLoading || isLoading}
             isEditable={isEditable}
             onCardAction={onCardAction}
             breakpoint={breakpoint}

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import merge from 'lodash/merge';
 import isEmpty from 'lodash/isEmpty';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import ValueCard from '../ValueCard/ValueCard';
 import ImageCard from '../ImageCard/ImageCard';
@@ -11,164 +12,195 @@ import PieCard from '../PieCard/PieCard';
 import TimeSeriesCard from '../TimeSeriesCard/TimeSeriesCard';
 import { CARD_TYPES } from '../../constants/LayoutConstants';
 
+const CachedCardRenderer = ({
+  style, //eslint-disable-line
+  card, // eslint-disable-line
+  onCardAction, //eslint-disable-line
+  isLoading, // eslint-disable-line
+  ...others
+}) => {
+  const [cachedStyle, setCachedStyle] = useState(style);
+  useDeepCompareEffect(
+    () => {
+      setCachedStyle(style);
+    },
+    [style] // need to do a deep compare on style
+  );
+  // Have to reset the card action callback once the dashboard has finished loading
+  const cachedOnCardAction = useCallback(onCardAction, [card, isLoading]);
+  return (
+    <CardRenderer
+      {...others}
+      isLoading={isLoading}
+      onCardAction={cachedOnCardAction}
+      card={card}
+      style={cachedStyle}
+    />
+  );
+};
+
 /**
  * This component decides which card component to render when passed a certain card type
  * It also caches some properties between renders to speed performance
  */
-const CardRenderer = ({
-  style, // eslint-disable-line
-  card, // eslint-disable-line
-  card: { availableActions, type, dataSource, isExpanded, ...others }, // eslint-disable-line
-  onCardAction, // eslint-disable-line
-  i18n, // eslint-disable-line
-  dashboardBreakpoints, // eslint-disable-line
-  cardDimensions, // eslint-disable-line
-  dashboardColumns, // eslint-disable-line
-  rowHeight, // eslint-disable-line
-  isLoading, // eslint-disable-line
-  isEditable, // eslint-disable-line
-  breakpoint, // eslint-disable-line
-  ...gridProps
-}) => {
-  // Speed up performance by caching
-  const cachedActions = useMemo(
-    () =>
-      merge(availableActions, {
-        range: !isEmpty(dataSource), // all cards should have the range picker
-        expand:
-          type === CARD_TYPES.IMAGE || type === CARD_TYPES.TIMESERIES || type === CARD_TYPES.TABLE, // image and line chart cards should have expand
-      }),
-    [availableActions, dataSource, type]
-  );
+const CardRenderer = React.memo(
+  ({
+    style, // eslint-disable-line
+    card, // eslint-disable-line
+    card: { availableActions, type, dataSource, isExpanded, ...others }, // eslint-disable-line
+    onCardAction, // eslint-disable-line
+    i18n, // eslint-disable-line
+    dashboardBreakpoints, // eslint-disable-line
+    cardDimensions, // eslint-disable-line
+    dashboardColumns, // eslint-disable-line
+    rowHeight, // eslint-disable-line
+    isLoading, // eslint-disable-line
+    isEditable, // eslint-disable-line
+    breakpoint, // eslint-disable-line
+    ...gridProps
+  }) => {
+    // Speed up performance by caching
+    const cachedActions = useMemo(
+      () =>
+        merge(availableActions, {
+          range: !isEmpty(dataSource), // all cards should have the range picker
+          expand:
+            type === CARD_TYPES.IMAGE ||
+            type === CARD_TYPES.TIMESERIES ||
+            type === CARD_TYPES.TABLE, // image and line chart cards should have expand
+        }),
+      [availableActions, dataSource, type]
+    );
 
-  const cachedExpandedStyle = useMemo(
-    () => (isExpanded ? merge({ height: '100%', width: '100%', padding: '50' }, style) : style),
-    [isExpanded, style]
-  );
+    const cachedExpandedStyle = useMemo(
+      () => (isExpanded ? merge({ height: '100%', width: '100%', padding: '50' }, style) : style),
+      [isExpanded, style]
+    );
 
-  return (
-    <div key={card.id} {...gridProps} style={cachedExpandedStyle}>
-      {type === CARD_TYPES.VALUE ? (
-        <ValueCard
-          {...others}
-          key={card.id}
-          availableActions={cachedActions}
-          dataSource={dataSource}
-          type={type}
-          i18n={i18n}
-          isLoading={card.isLoading || isLoading}
-          isEditable={isEditable}
-          onCardAction={onCardAction}
-          breakpoint={breakpoint}
-          dashboardBreakpoints={dashboardBreakpoints}
-          dashboardColumns={dashboardColumns}
-          cardDimensions={cardDimensions}
-          rowHeight={rowHeight}
-        />
-      ) : type === CARD_TYPES.IMAGE ? (
-        <ImageCard
-          {...others}
-          key={card.id}
-          availableActions={cachedActions}
-          dataSource={dataSource}
-          type={type}
-          i18n={i18n}
-          isLoading={card.isLoading || isLoading}
-          isEditable={isEditable}
-          onCardAction={onCardAction}
-          breakpoint={breakpoint}
-          dashboardBreakpoints={dashboardBreakpoints}
-          dashboardColumns={dashboardColumns}
-          cardDimensions={cardDimensions}
-          rowHeight={rowHeight}
-        />
-      ) : type === CARD_TYPES.TIMESERIES ? (
-        <TimeSeriesCard
-          {...others}
-          key={card.id}
-          availableActions={cachedActions}
-          dataSource={dataSource}
-          type={type}
-          i18n={i18n}
-          isLoading={card.isLoading || isLoading}
-          isEditable={isEditable}
-          onCardAction={onCardAction}
-          breakpoint={breakpoint}
-          dashboardBreakpoints={dashboardBreakpoints}
-          dashboardColumns={dashboardColumns}
-          cardDimensions={cardDimensions}
-          rowHeight={rowHeight}
-        />
-      ) : type === CARD_TYPES.TABLE ? (
-        <TableCard
-          {...others}
-          key={card.id}
-          availableActions={cachedActions}
-          dataSource={dataSource}
-          type={type}
-          i18n={i18n}
-          isLoading={card.isLoading || isLoading}
-          isEditable={isEditable}
-          onCardAction={onCardAction}
-          breakpoint={breakpoint}
-          dashboardBreakpoints={dashboardBreakpoints}
-          dashboardColumns={dashboardColumns}
-          cardDimensions={cardDimensions}
-          rowHeight={rowHeight}
-        />
-      ) : type === CARD_TYPES.DONUT ? (
-        <DonutCard
-          {...others}
-          key={card.id}
-          availableActions={cachedActions}
-          dataSource={dataSource}
-          type={type}
-          i18n={i18n}
-          isLoading={card.isLoading || isLoading}
-          isEditable={isEditable}
-          onCardAction={onCardAction}
-          breakpoint={breakpoint}
-          dashboardBreakpoints={dashboardBreakpoints}
-          dashboardColumns={dashboardColumns}
-          cardDimensions={cardDimensions}
-          rowHeight={rowHeight}
-        />
-      ) : type === CARD_TYPES.PIE ? (
-        <PieCard
-          {...others}
-          key={card.id}
-          availableActions={cachedActions}
-          dataSource={dataSource}
-          type={type}
-          i18n={i18n}
-          isLoading={card.isLoading || isLoading}
-          isEditable={isEditable}
-          onCardAction={onCardAction}
-          breakpoint={breakpoint}
-          dashboardBreakpoints={dashboardBreakpoints}
-          dashboardColumns={dashboardColumns}
-          cardDimensions={cardDimensions}
-          rowHeight={rowHeight}
-        />
-      ) : type === CARD_TYPES.BAR ? (
-        <BarChartCard
-          {...others}
-          key={card.id}
-          availableActions={cachedActions}
-          dataSource={dataSource}
-          type={type}
-          i18n={i18n}
-          isLoading={card.isLoading || isLoading}
-          isEditable={isEditable}
-          onCardAction={onCardAction}
-          breakpoint={breakpoint}
-          dashboardBreakpoints={dashboardBreakpoints}
-          dashboardColumns={dashboardColumns}
-          cardDimensions={cardDimensions}
-          rowHeight={rowHeight}
-        />
-      ) : null}
-    </div>
-  );
-};
-export default CardRenderer;
+    return (
+      <div key={card.id} {...gridProps} style={cachedExpandedStyle}>
+        {type === CARD_TYPES.VALUE ? (
+          <ValueCard
+            {...others}
+            key={card.id}
+            availableActions={cachedActions}
+            dataSource={dataSource}
+            type={type}
+            i18n={i18n}
+            isLoading={card.isLoading || isLoading}
+            isEditable={isEditable}
+            onCardAction={onCardAction}
+            breakpoint={breakpoint}
+            dashboardBreakpoints={dashboardBreakpoints}
+            dashboardColumns={dashboardColumns}
+            cardDimensions={cardDimensions}
+            rowHeight={rowHeight}
+          />
+        ) : type === CARD_TYPES.IMAGE ? (
+          <ImageCard
+            {...others}
+            key={card.id}
+            availableActions={cachedActions}
+            dataSource={dataSource}
+            type={type}
+            i18n={i18n}
+            isLoading={card.isLoading || isLoading}
+            isEditable={isEditable}
+            onCardAction={onCardAction}
+            breakpoint={breakpoint}
+            dashboardBreakpoints={dashboardBreakpoints}
+            dashboardColumns={dashboardColumns}
+            cardDimensions={cardDimensions}
+            rowHeight={rowHeight}
+          />
+        ) : type === CARD_TYPES.TIMESERIES ? (
+          <TimeSeriesCard
+            {...others}
+            key={card.id}
+            availableActions={cachedActions}
+            dataSource={dataSource}
+            type={type}
+            i18n={i18n}
+            isLoading={card.isLoading || isLoading}
+            isEditable={isEditable}
+            onCardAction={onCardAction}
+            breakpoint={breakpoint}
+            dashboardBreakpoints={dashboardBreakpoints}
+            dashboardColumns={dashboardColumns}
+            cardDimensions={cardDimensions}
+            rowHeight={rowHeight}
+          />
+        ) : type === CARD_TYPES.TABLE ? (
+          <TableCard
+            {...others}
+            key={card.id}
+            availableActions={cachedActions}
+            dataSource={dataSource}
+            type={type}
+            i18n={i18n}
+            isLoading={card.isLoading || isLoading}
+            isEditable={isEditable}
+            onCardAction={onCardAction}
+            breakpoint={breakpoint}
+            dashboardBreakpoints={dashboardBreakpoints}
+            dashboardColumns={dashboardColumns}
+            cardDimensions={cardDimensions}
+            rowHeight={rowHeight}
+          />
+        ) : type === CARD_TYPES.DONUT ? (
+          <DonutCard
+            {...others}
+            key={card.id}
+            availableActions={cachedActions}
+            dataSource={dataSource}
+            type={type}
+            i18n={i18n}
+            isLoading={card.isLoading || isLoading}
+            isEditable={isEditable}
+            onCardAction={onCardAction}
+            breakpoint={breakpoint}
+            dashboardBreakpoints={dashboardBreakpoints}
+            dashboardColumns={dashboardColumns}
+            cardDimensions={cardDimensions}
+            rowHeight={rowHeight}
+          />
+        ) : type === CARD_TYPES.PIE ? (
+          <PieCard
+            {...others}
+            key={card.id}
+            availableActions={cachedActions}
+            dataSource={dataSource}
+            type={type}
+            i18n={i18n}
+            isLoading={card.isLoading || isLoading}
+            isEditable={isEditable}
+            onCardAction={onCardAction}
+            breakpoint={breakpoint}
+            dashboardBreakpoints={dashboardBreakpoints}
+            dashboardColumns={dashboardColumns}
+            cardDimensions={cardDimensions}
+            rowHeight={rowHeight}
+          />
+        ) : type === CARD_TYPES.BAR ? (
+          <BarChartCard
+            {...others}
+            key={card.id}
+            availableActions={cachedActions}
+            dataSource={dataSource}
+            type={type}
+            i18n={i18n}
+            isLoading={card.isLoading || isLoading}
+            isEditable={isEditable}
+            onCardAction={onCardAction}
+            breakpoint={breakpoint}
+            dashboardBreakpoints={dashboardBreakpoints}
+            dashboardColumns={dashboardColumns}
+            cardDimensions={cardDimensions}
+            rowHeight={rowHeight}
+          />
+        ) : null}
+      </div>
+    );
+  }
+);
+export default CachedCardRenderer;

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -5,6 +5,7 @@ import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import styled from 'styled-components';
 import find from 'lodash/find';
+import some from 'lodash/some';
 
 import { getLayout } from '../../utils/componentUtilityFunctions';
 import {
@@ -81,8 +82,6 @@ const propTypes = {
   onDashboardAction: PropTypes.func,
   /** Is the dashboard in edit mode? */
   isEditable: PropTypes.bool,
-  /** Is the dashboard loading data */
-  isLoading: PropTypes.bool,
   /** array of configurable sizes to dimensions */
   cardDimensions: CardSizesToDimensionsPropTypes,
   /** Optional filter that should be rendered top right */
@@ -169,7 +168,6 @@ const propTypes = {
 
 const defaultProps = {
   isEditable: false,
-  isLoading: false,
   description: null,
   lastUpdated: null,
   onLayoutChange: null,
@@ -285,7 +283,6 @@ const Dashboard = ({
   rowHeight,
   layouts,
   isEditable,
-  isLoading,
   onLayoutChange,
   onBreakpointChange,
   className,
@@ -355,6 +352,9 @@ const Dashboard = ({
 
   const cachedOnLayoutChange = useCallback(handleLayoutChange, [onLayoutChange]);
   const cachedOnBreakpointChange = useCallback(handleBreakpointChange, [onBreakpointChange]);
+
+  // Is any card in the dashboard loading?
+  const isLoading = useMemo(() => some(cards, i => i.isLoading || i.isHotspotDataLoading), [cards]);
 
   const gridContents = useMemo(
     () =>

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -5,7 +5,6 @@ import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import styled from 'styled-components';
 import find from 'lodash/find';
-import merge from 'lodash/merge';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { getLayout } from '../../utils/componentUtilityFunctions';
@@ -331,16 +330,19 @@ const Dashboard = ({
           isExpanded: true,
         },
         isExpanded: true,
-        availableActions: merge(card.availableActions, {
-          // we will create a new card so we need to "enable" the expand so can close
-          expand: true,
-        }),
       });
     }
 
     // close expanded card
     if (type === 'CLOSE_EXPANDED_CARD') {
-      updateCardInDashboard({ ...card, isExpanded: false });
+      updateCardInDashboard({
+        ...card,
+        content: {
+          ...card.content,
+          isExpanded: false,
+        },
+        isExpanded: false,
+      });
     }
     return null;
   };
@@ -381,7 +383,6 @@ const Dashboard = ({
     }
   };
 
-  const cachedCardAction = useCallback(handleCardAction, [cardsState]); // cache the card action on the card state
   const cachedOnLayoutChange = useCallback(handleLayoutChange, [onLayoutChange]);
   const cachedOnBreakpointChange = useCallback(handleBreakpointChange, [onBreakpointChange]);
 
@@ -391,7 +392,7 @@ const Dashboard = ({
         <CardRenderer
           card={card}
           key={card.id}
-          onCardAction={cachedCardAction}
+          onCardAction={handleCardAction}
           i18n={cachedI18N}
           dashboardBreakpoints={dashboardBreakpoints}
           cardDimensions={cardDimensions}
@@ -401,10 +402,9 @@ const Dashboard = ({
           isEditable={isEditable}
           breakpoint={breakpoint}
         />
-      )),
+      )), // eslint-disable-next-line
     [
       breakpoint,
-      cachedCardAction,
       cachedI18N,
       cardDimensions,
       cards,
@@ -424,7 +424,7 @@ const Dashboard = ({
           <CardRenderer
             card={{ ...expandedCard }}
             key={expandedCard.id}
-            onCardAction={cachedCardAction}
+            onCardAction={handleCardAction}
             i18n={i18n}
             dashboardBreakpoints={dashboardBreakpoints}
             cardDimensions={cardDimensions}

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -540,7 +540,6 @@ storiesOf('Dashboard (Experimental)', module)
         cards={originalCards}
         lastUpdated={Date()}
         isEditable={boolean('isEditable', false)}
-        isLoading={boolean('isLoading', false)}
         onBreakpointChange={action('onBreakpointChange')}
         onLayoutChange={action('onLayoutChange')}
       />
@@ -552,7 +551,6 @@ storiesOf('Dashboard (Experimental)', module)
         title={text('title', 'Munich Building')}
         lastUpdated={Date()}
         isEditable={boolean('isEditable', false)}
-        isLoading={boolean('isLoading', false)}
         onBreakpointChange={action('onBreakpointChange')}
         onLayoutChange={action('onLayoutChange')}
       />
@@ -563,7 +561,6 @@ storiesOf('Dashboard (Experimental)', module)
       <StatefulDashboard
         title={text('title', 'Munich Building')}
         isEditable={boolean('isEditable', false)}
-        isLoading={boolean('isLoading', false)}
         onBreakpointChange={action('onBreakpointChange')}
         onLayoutChange={action('onLayoutChange')}
         hasLastUpdated={false}
@@ -575,7 +572,6 @@ storiesOf('Dashboard (Experimental)', module)
       <StatefulDashboard
         title={text('title', 'Munich Building')}
         isEditable={boolean('isEditable', false)}
-        isLoading={boolean('isLoading', false)}
         onBreakpointChange={action('onBreakpointChange')}
         onLayoutChange={action('onLayoutChange')}
         actions={[{ id: 'edit', label: 'Edit', icon: 'edit--glyph' }]}
@@ -590,7 +586,6 @@ storiesOf('Dashboard (Experimental)', module)
         title={text('title', 'Munich Building')}
         lastUpdated={Date()}
         isEditable={boolean('isEditable', false)}
-        isLoading={boolean('isLoading', false)}
         sidebar={
           <div style={{ width: 300 }}>
             <h1>Sidebar content</h1>
@@ -603,22 +598,12 @@ storiesOf('Dashboard (Experimental)', module)
       />
     );
   })
-  .add('loading', () => {
-    return (
-      <StatefulDashboard
-        title={text('title', 'Munich Building')}
-        isEditable={boolean('isEditable', false)}
-        isLoading={boolean('isLoading', true)}
-      />
-    );
-  })
   .add('i18n labels', () => {
     return (
       <StatefulDashboard
         title={text('title', 'Munich Building')}
         lastUpdated={Date()}
         isEditable={boolean('isEditable', false)}
-        isLoading={boolean('isLoading', false)}
         onBreakpointChange={action('onBreakpointChange')}
         onLayoutChange={action('onLayoutChange')}
         onDashboardAction={action('onDashboardAction')}


### PR DESCRIPTION
feat(cardrenderer): add caching layer on top of the memoized cardRenderer to cache old style and the old onCardAction methods
refactor(dashboard): remove the dashboard template from state and instead just use expandedId.  This will allow us to memoize callbacks depending on a much more granular state