### PR TITLE
fix(proptypes): warnings for minor invalid props

### DIFF
--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -8,7 +8,7 @@ import ImageControls from './ImageControls';
 
 const propTypes = {
   /** source of the local image file to display */
-  src: PropTypes.string.isRequired,
+  src: PropTypes.string,
   /** alt tag and shown on mouseover */
   alt: PropTypes.string,
   /** optional array of hotspots to render over the image */
@@ -23,6 +23,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  src: null,
   hotspots: [],
   alt: null,
   hideZoomControls: false,

--- a/src/components/ResourceList/ResourceList.story.jsx
+++ b/src/components/ResourceList/ResourceList.story.jsx
@@ -3,7 +3,7 @@ import { select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import Bee32 from '@carbon/icons-react/lib/bee/32';
-import Edit from '@carbon/icons-react/lib/edit/16';
+import Edit16 from '@carbon/icons-react/lib/edit/16';
 
 import ResourceList from './ResourceList';
 
@@ -71,7 +71,7 @@ storiesOf('Watson IoT|ResourceList', module)
       customAction={{
         onClick: action('customAction.onClick'),
         label: 'Configure',
-        icon: () => <Edit />,
+        icon: Edit16,
       }}
     />
   ));

--- a/src/components/ResourceList/ResourceList.test.jsx
+++ b/src/components/ResourceList/ResourceList.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import Edit16 from '@carbon/icons-react/lib/edit/16';
 
 import ResourceList from './ResourceList';
 
@@ -52,7 +53,7 @@ describe('Resource List', () => {
         customAction={{
           onClick: actionClick,
           label: 'Configure',
-          icon: 'edit',
+          icon: Edit16,
         }}
       />
     );


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Fixes a few lingering prop types issues from the v10 upgrade.

**Change List (commits, features, bugs, etc)**

- remove src as a required prop of ImageHotspots - it correctly handles not being provided a src
- fix ResourceList icon usage story and test - only need to pass the icon component, not an instance of it

**Acceptance Test (how to verify the PR)**

- You should see locally or in travis that we no longer have console warnings for these components when `yarn test` is ran.
