### PR TITLE
style/alignment updates: PageTitleBar, Table (pagination)

### DIFF
--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
-import { Information24, Edit24 } from '@carbon/icons-react';
+import { Information20, Edit20 } from '@carbon/icons-react';
 import { Breadcrumb, BreadcrumbItem, Tooltip, SkeletonText, Tabs } from 'carbon-components-react';
 
 import Button from '../Button';
@@ -11,8 +11,12 @@ const PageTitleBarPropTypes = {
   title: PropTypes.node.isRequired,
   /** Details about what the page shows */
   description: PropTypes.node,
-  /** Optional node to render in the right side of the PageTitleBar */
+  /** Optional node to render in the right side of the PageTitleBar
+   *  NOTE: Deprecated in favor of extraContent
+   */
   rightContent: PropTypes.node,
+  /** Optional node to render to the side of the PageTitleBar */
+  extraContent: PropTypes.node,
   /** Breadcrumbs to show */
   breadcrumb: PropTypes.arrayOf(PropTypes.node),
   /** Should page description be collapsed into tooltip. Should be `true` when using in conjunction with tabs. */
@@ -35,7 +39,8 @@ const PageTitleBarPropTypes = {
 const defaultProps = {
   description: null,
   className: null,
-  rightContent: null,
+  rightContent: null, // deprecated in favor of 'extraContent'
+  extraContent: null,
   breadcrumb: null,
   collapsed: false,
   editable: false,
@@ -49,7 +54,8 @@ const PageTitleBar = ({
   title,
   description,
   className,
-  rightContent,
+  rightContent, // deprecated in favor of 'extraContent'
+  extraContent,
   breadcrumb,
   collapsed,
   editable,
@@ -63,47 +69,57 @@ const PageTitleBar = ({
       <SkeletonText className="page-title-bar-loading" heading width="30%" />
     ) : (
       <Fragment>
-        {breadcrumb ? (
-          <div className="page-title-bar-breadcrumb">
-            <Breadcrumb>
-              {breadcrumb.map((crumb, index) => (
-                <BreadcrumbItem key={`breadcrumb-${index}`}>{crumb}</BreadcrumbItem>
-              ))}
-            </Breadcrumb>
-          </div>
-        ) : null}
-        <div className="page-title-bar-title">
-          <div className="page-title-bar-title--text">
-            <h2>{title}</h2>
-            {description && (collapsed || tabs) ? (
-              <Tooltip
-                tabIndex={0}
-                triggerText=""
-                triggerId="tooltip"
-                tooltipId="tooltip"
-                renderIcon={Information24}
-              >
-                <p>{description}</p>
-              </Tooltip>
+        <div className="page-title-bar-header">
+          <div>
+            {breadcrumb ? (
+              <div className="page-title-bar-breadcrumb">
+                <Breadcrumb>
+                  {breadcrumb.map((crumb, index) => (
+                    <BreadcrumbItem key={`breadcrumb-${index}`}>{crumb}</BreadcrumbItem>
+                  ))}
+                </Breadcrumb>
+              </div>
             ) : null}
-            {editable ? (
-              <Button
-                className="page-title-bar-title--edit"
-                kind="ghost"
-                hasIconOnly
-                renderIcon={Edit24}
-                iconDescription={editIconDescription}
-                tooltipAlignment="center"
-                tooltipPosition="bottom"
-                onClick={onEdit}
-              />
+            <div className="page-title-bar-title">
+              <div className="page-title-bar-title--text">
+                <h2>{title}</h2>
+                {description && (collapsed || tabs) ? (
+                  <Tooltip
+                    tabIndex={0}
+                    triggerText=""
+                    triggerId="tooltip"
+                    tooltipId="tooltip"
+                    renderIcon={Information20}
+                  >
+                    <p>{description}</p>
+                  </Tooltip>
+                ) : null}
+                {editable ? (
+                  <Button
+                    className="page-title-bar-title--edit"
+                    kind="ghost"
+                    size="small"
+                    hasIconOnly
+                    renderIcon={Edit20}
+                    iconDescription={editIconDescription}
+                    tooltipAlignment="center"
+                    tooltipPosition="bottom"
+                    onClick={onEdit}
+                  />
+                ) : null}
+              </div>
+            </div>
+            {description && !collapsed && !tabs ? (
+              <p className="page-title-bar-description">{description}</p>
             ) : null}
           </div>
-          {rightContent}
+          {extraContent || rightContent ? (
+            <Fragment>
+              <div style={{ flex: 1 }} />
+              <div>{extraContent || rightContent}</div>
+            </Fragment>
+          ) : null}
         </div>
-        {description && !collapsed && !tabs ? (
-          <p className="page-title-bar-description">{description}</p>
-        ) : null}
         {tabs ? <div className="page-title-bar-tabs">{tabs}</div> : null}
       </Fragment>
     )}

--- a/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -12,10 +12,15 @@ import PageTitleBar from './PageTitleBar';
 export const commonPageTitleBarProps = {
   title: 'Page title',
   description: 'Descriptive text about this page and what the user can or should do on it',
-  rightContent: (
-    <Button className="some-right-content" renderIcon={Add24} onClick={action('click')}>
-      Right Content
-    </Button>
+  extraContent: (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <span style={{ marginRight: '1rem' }}>
+        <b>Last updated:</b> yesterday
+      </span>
+      <Button className="some-right-content" renderIcon={Add24} onClick={action('click')}>
+        Take an action
+      </Button>
+    </div>
   ),
 };
 
@@ -74,4 +79,27 @@ storiesOf('Watson IoT|PageTitleBar', module)
     />
   ))
   .add('with rich content', () => <PageTitleBar {...commonPageTitleBarProps} collapsed />)
+  .add('with everything', () => (
+    <PageTitleBar
+      title={commonPageTitleBarProps.title}
+      description={commonPageTitleBarProps.description}
+      breadcrumb={pageTitleBarBreadcrumb}
+      extraContent={commonPageTitleBarProps.extraContent}
+      editable
+      tabs={
+        <Tabs>
+          <Tab label="Tab 1">
+            <div>Content for first tab.</div>
+          </Tab>
+          <Tab label="Tab 2">
+            <div>Content for second tab.</div>
+          </Tab>
+          <Tab label="Tab 3">
+            <div>Content for third tab.</div>
+          </Tab>
+        </Tabs>
+      }
+      onEdit={action('edit')}
+    />
+  ))
   .add('isLoading', () => <PageTitleBar title={commonPageTitleBarProps.title} isLoading />);

--- a/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -31,14 +31,20 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
         className="page-title-bar"
       >
         <div
-          className="page-title-bar-title"
+          className="page-title-bar-header"
         >
-          <div
-            className="page-title-bar-title--text"
-          >
-            <h2>
-              Page title
-            </h2>
+          <div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  Page title
+                </h2>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -168,51 +174,57 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
         className="page-title-bar"
       >
         <div
-          className="page-title-bar-breadcrumb"
+          className="page-title-bar-header"
         >
-          <nav
-            className="bx--breadcrumb"
-          >
+          <div>
             <div
-              className="bx--breadcrumb-item"
+              className="page-title-bar-breadcrumb"
             >
-              <a
-                className="bx--link"
-                href="/"
+              <nav
+                className="bx--breadcrumb"
               >
-                Home
-              </a>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Home
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Type
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <span
+                    className="bx--link"
+                  >
+                    Instance
+                  </span>
+                </div>
+              </nav>
             </div>
             <div
-              className="bx--breadcrumb-item"
+              className="page-title-bar-title"
             >
-              <a
-                className="bx--link"
-                href="/"
+              <div
+                className="page-title-bar-title--text"
               >
-                Type
-              </a>
+                <h2>
+                  Page title
+                </h2>
+              </div>
             </div>
-            <div
-              className="bx--breadcrumb-item"
-            >
-              <span
-                className="bx--link"
-              >
-                Instance
-              </span>
-            </div>
-          </nav>
-        </div>
-        <div
-          className="page-title-bar-title"
-        >
-          <div
-            className="page-title-bar-title--text"
-          >
-            <h2>
-              Page title
-            </h2>
           </div>
         </div>
       </div>
@@ -275,21 +287,27 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
         className="page-title-bar"
       >
         <div
-          className="page-title-bar-title"
+          className="page-title-bar-header"
         >
-          <div
-            className="page-title-bar-title--text"
-          >
-            <h2>
-              Page title
-            </h2>
+          <div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  Page title
+                </h2>
+              </div>
+            </div>
+            <p
+              className="page-title-bar-description"
+            >
+              Descriptive text about this page and what the user can or should do on it
+            </p>
           </div>
         </div>
-        <p
-          className="page-title-bar-description"
-        >
-          Descriptive text about this page and what the user can or should do on it
-        </p>
       </div>
     </div>
   </div>
@@ -350,55 +368,443 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
         className="page-title-bar"
       >
         <div
-          className="page-title-bar-title"
+          className="page-title-bar-header"
         >
+          <div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  Page title
+                </h2>
+                <button
+                  className="page-title-bar-title--edit Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Edit page title
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Edit page title"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M2 27h28v2H2zM25.41 9a2 2 0 0 0 0-2.83l-3.58-3.58a2 2 0 0 0-2.83 0l-15 15V24h6.41zm-5-5L24 7.59l-3 3L17.41 7zM6 22v-3.59l10-10L19.59 12l-10 10z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <p
+              className="page-title-bar-description"
+            >
+              Descriptive text about this page and what the user can or should do on it
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageTitleBar with everything 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-header"
+        >
+          <div>
+            <div
+              className="page-title-bar-breadcrumb"
+            >
+              <nav
+                className="bx--breadcrumb"
+              >
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Home
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Type
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <span
+                    className="bx--link"
+                  >
+                    Instance
+                  </span>
+                </div>
+              </nav>
+            </div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  Page title
+                </h2>
+                <div
+                  className="bx--tooltip__label"
+                  id="tooltip"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                      />
+                      <path
+                        d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <button
+                  className="page-title-bar-title--edit Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Edit page title
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Edit page title"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M2 27h28v2H2zM25.41 9a2 2 0 0 0 0-2.83l-3.58-3.58a2 2 0 0 0-2.83 0l-15 15V24h6.41zm-5-5L24 7.59l-3 3L17.41 7zM6 22v-3.59l10-10L19.59 12l-10 10z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
           <div
-            className="page-title-bar-title--text"
-          >
-            <h2>
-              Page title
-            </h2>
-            <button
-              className="page-title-bar-title--edit Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--bottom bx--tooltip--align-center"
-              disabled={false}
-              onClick={[Function]}
-              tabIndex={0}
-              type="button"
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          />
+          <div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
             >
               <span
-                className="bx--assistive-text"
+                style={
+                  Object {
+                    "marginRight": "1rem",
+                  }
+                }
               >
-                Edit page title
+                <b>
+                  Last updated:
+                </b>
+                 yesterday
               </span>
+              <button
+                className="some-right-content Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Take an action
+                <svg
+                  aria-hidden={true}
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={24}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={24}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="page-title-bar-tabs"
+        >
+          <div
+            className="bx--tabs"
+            role="navigation"
+            selected={0}
+          >
+            <div
+              aria-label="listbox"
+              className="bx--tabs-trigger"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="listbox"
+              tabIndex={0}
+            >
+              <a
+                className="bx--tabs-trigger-text"
+                href="#"
+                onClick={[Function]}
+                tabIndex={-1}
+              >
+                Tab 1
+              </a>
               <svg
-                aria-hidden="true"
-                aria-label="Edit page title"
-                className="bx--btn__icon"
+                aria-hidden={true}
                 focusable="false"
-                height={24}
+                height={6}
                 preserveAspectRatio="xMidYMid meet"
-                role="img"
                 style={
                   Object {
                     "willChange": "transform",
                   }
                 }
-                viewBox="0 0 32 32"
-                width={24}
+                viewBox="0 0 10 6"
+                width={10}
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M2 27h28v2H2zM25.41 9a2 2 0 0 0 0-2.83l-3.58-3.58a2 2 0 0 0-2.83 0l-15 15V24h6.41zm-5-5L24 7.59l-3 3L17.41 7zM6 22v-3.59l10-10L19.59 12l-10 10z"
+                  d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"
                 />
+                <title>
+                  show menu options
+                </title>
               </svg>
-            </button>
+            </div>
+            <ul
+              className="bx--tabs__nav bx--tabs__nav--hidden"
+              role="tablist"
+            >
+              <li
+                className="bx--tabs__nav-item bx--tabs__nav-item--selected"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="presentation"
+                selected={true}
+                tabIndex={-1}
+              >
+                <a
+                  aria-selected={true}
+                  className="bx--tabs__nav-link"
+                  href="#"
+                  role="tab"
+                  tabIndex={0}
+                >
+                  Tab 1
+                </a>
+              </li>
+              <li
+                className="bx--tabs__nav-item"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="presentation"
+                selected={false}
+                tabIndex={-1}
+              >
+                <a
+                  aria-selected={false}
+                  className="bx--tabs__nav-link"
+                  href="#"
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  Tab 2
+                </a>
+              </li>
+              <li
+                className="bx--tabs__nav-item"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="presentation"
+                selected={false}
+                tabIndex={-1}
+              >
+                <a
+                  aria-selected={false}
+                  className="bx--tabs__nav-link"
+                  href="#"
+                  role="tab"
+                  tabIndex={-1}
+                >
+                  Tab 3
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div
+            aria-hidden={false}
+            hidden={false}
+            selected={true}
+          >
+            <div>
+              Content for first tab.
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
+          >
+            <div>
+              Content for second tab.
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
+          >
+            <div>
+              Content for third tab.
+            </div>
           </div>
         </div>
-        <p
-          className="page-title-bar-description"
-        >
-          Descriptive text about this page and what the user can or should do on it
-        </p>
       </div>
     </div>
   </div>
@@ -459,39 +865,106 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
         className="page-title-bar"
       >
         <div
-          className="page-title-bar-title"
+          className="page-title-bar-header"
         >
-          <div
-            className="page-title-bar-title--text"
-          >
-            <h2>
-              Page title
-            </h2>
+          <div>
             <div
-              className="bx--tooltip__label"
-              id="tooltip"
+              className="page-title-bar-title"
             >
-              
               <div
-                aria-describedby={null}
-                aria-haspopup="true"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
+                className="page-title-bar-title--text"
               >
+                <h2>
+                  Page title
+                </h2>
+                <div
+                  className="bx--tooltip__label"
+                  id="tooltip"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                      />
+                      <path
+                        d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          />
+          <div>
+            <div
+              style={
+                Object {
+                  "alignItems": "center",
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                style={
+                  Object {
+                    "marginRight": "1rem",
+                  }
+                }
+              >
+                <b>
+                  Last updated:
+                </b>
+                 yesterday
+              </span>
+              <button
+                className="some-right-content Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Take an action
                 <svg
                   aria-hidden={true}
-                  description={null}
+                  className="bx--btn__icon"
                   focusable="false"
                   height={24}
                   preserveAspectRatio="xMidYMid meet"
-                  role={null}
                   style={
                     Object {
                       "willChange": "transform",
@@ -502,43 +975,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
-                  />
-                  <path
-                    d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
                   />
                 </svg>
-              </div>
+              </button>
             </div>
           </div>
-          <button
-            className="some-right-content Button__StyledButton-sc-19kycwu-0 gTXQZR bx--btn bx--btn--primary"
-            disabled={false}
-            onClick={[Function]}
-            tabIndex={0}
-            type="button"
-          >
-            Right Content
-            <svg
-              aria-hidden={true}
-              className="bx--btn__icon"
-              focusable="false"
-              height={24}
-              preserveAspectRatio="xMidYMid meet"
-              style={
-                Object {
-                  "willChange": "transform",
-                }
-              }
-              viewBox="0 0 32 32"
-              width={24}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
-              />
-            </svg>
-          </button>
         </div>
       </div>
     </div>
@@ -600,92 +1042,98 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
         className="page-title-bar"
       >
         <div
-          className="page-title-bar-breadcrumb"
+          className="page-title-bar-header"
         >
-          <nav
-            className="bx--breadcrumb"
-          >
+          <div>
             <div
-              className="bx--breadcrumb-item"
+              className="page-title-bar-breadcrumb"
             >
-              <a
-                className="bx--link"
-                href="/"
+              <nav
+                className="bx--breadcrumb"
               >
-                Home
-              </a>
-            </div>
-            <div
-              className="bx--breadcrumb-item"
-            >
-              <a
-                className="bx--link"
-                href="/"
-              >
-                Type
-              </a>
-            </div>
-            <div
-              className="bx--breadcrumb-item"
-            >
-              <span
-                className="bx--link"
-              >
-                Instance
-              </span>
-            </div>
-          </nav>
-        </div>
-        <div
-          className="page-title-bar-title"
-        >
-          <div
-            className="page-title-bar-title--text"
-          >
-            <h2>
-              Page title
-            </h2>
-            <div
-              className="bx--tooltip__label"
-              id="tooltip"
-            >
-              
-              <div
-                aria-describedby={null}
-                aria-haspopup="true"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  description={null}
-                  focusable="false"
-                  height={24}
-                  preserveAspectRatio="xMidYMid meet"
-                  role={null}
-                  style={
-                    Object {
-                      "willChange": "transform",
-                    }
-                  }
-                  viewBox="0 0 32 32"
-                  width={24}
-                  xmlns="http://www.w3.org/2000/svg"
+                <div
+                  className="bx--breadcrumb-item"
                 >
-                  <path
-                    d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
-                  />
-                  <path
-                    d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
-                  />
-                </svg>
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Home
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Type
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <span
+                    className="bx--link"
+                  >
+                    Instance
+                  </span>
+                </div>
+              </nav>
+            </div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  Page title
+                </h2>
+                <div
+                  className="bx--tooltip__label"
+                  id="tooltip"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                      />
+                      <path
+                        d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -884,92 +1332,98 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageT
         className="page-title-bar"
       >
         <div
-          className="page-title-bar-breadcrumb"
+          className="page-title-bar-header"
         >
-          <nav
-            className="bx--breadcrumb"
-          >
+          <div>
             <div
-              className="bx--breadcrumb-item"
+              className="page-title-bar-breadcrumb"
             >
-              <a
-                className="bx--link"
-                href="/"
+              <nav
+                className="bx--breadcrumb"
               >
-                Home
-              </a>
-            </div>
-            <div
-              className="bx--breadcrumb-item"
-            >
-              <a
-                className="bx--link"
-                href="/"
-              >
-                Type
-              </a>
-            </div>
-            <div
-              className="bx--breadcrumb-item"
-            >
-              <span
-                className="bx--link"
-              >
-                Instance
-              </span>
-            </div>
-          </nav>
-        </div>
-        <div
-          className="page-title-bar-title"
-        >
-          <div
-            className="page-title-bar-title--text"
-          >
-            <h2>
-              Page title
-            </h2>
-            <div
-              className="bx--tooltip__label"
-              id="tooltip"
-            >
-              
-              <div
-                aria-describedby={null}
-                aria-haspopup="true"
-                className="bx--tooltip__trigger"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                role="button"
-                tabIndex={0}
-              >
-                <svg
-                  aria-hidden={true}
-                  description={null}
-                  focusable="false"
-                  height={24}
-                  preserveAspectRatio="xMidYMid meet"
-                  role={null}
-                  style={
-                    Object {
-                      "willChange": "transform",
-                    }
-                  }
-                  viewBox="0 0 32 32"
-                  width={24}
-                  xmlns="http://www.w3.org/2000/svg"
+                <div
+                  className="bx--breadcrumb-item"
                 >
-                  <path
-                    d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
-                  />
-                  <path
-                    d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
-                  />
-                </svg>
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Home
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <a
+                    className="bx--link"
+                    href="/"
+                  >
+                    Type
+                  </a>
+                </div>
+                <div
+                  className="bx--breadcrumb-item"
+                >
+                  <span
+                    className="bx--link"
+                  >
+                    Instance
+                  </span>
+                </div>
+              </nav>
+            </div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  Page title
+                </h2>
+                <div
+                  className="bx--tooltip__label"
+                  id="tooltip"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                      />
+                      <path
+                        d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/PageTitleBar/_page-title-bar.scss
+++ b/src/components/PageTitleBar/_page-title-bar.scss
@@ -14,9 +14,14 @@
       display: flex;
 
       h2 {
-        @include type-style('productive-heading-04');
+        @include type-style('productive-heading-03');
       }
     }
+  }
+
+  &-header {
+    display: flex;
+    align-items: center;
   }
 
   &-description {
@@ -28,7 +33,6 @@
   &-breadcrumb {
     display: flex;
     justify-content: space-between;
-    margin-bottom: $spacing-03;
   }
 
   &-loading {

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -53,7 +53,6 @@ const StyledPagination = sizeMe({ noPlaceholder: true })(styled(
     }
     .bx--select .bx--select-input ~ .bx--select__arrow {
       align-self: center;
-      top: 0px;
     }
   }
 `);

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -1011,7 +1011,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -2635,7 +2635,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -5530,7 +5530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -6831,7 +6831,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -8133,7 +8133,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -8972,7 +8972,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -9811,7 +9811,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -11322,7 +11322,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -12834,7 +12834,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -14135,7 +14135,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -16033,7 +16033,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -17698,7 +17698,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -19316,7 +19316,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -21653,7 +21653,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -22952,7 +22952,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -25645,7 +25645,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {
@@ -27904,7 +27904,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               </tbody>
             </table>
             <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 dqBSMm"
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
               disabled={false}
               size={
                 Object {


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Fixes to alignment and styling for PageTitleBar and Table (pagination)
- Added `extraContent` prop in PageTitleBar, added deprecation comment for `rightContent`

**Change List (commits, features, bugs, etc)**

* PageTitleBar styling / `extraContent` alignment

![image](https://user-images.githubusercontent.com/2175647/67226798-719d8400-f3fb-11e9-8e3b-5742151f8e67.png)

* Fixed alignment issue in pagination select indicator

![image](https://user-images.githubusercontent.com/2175647/67226635-05bb1b80-f3fb-11e9-8436-1d08e00c4e84.png)

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes IBM/carbon-addons-iot-react#618

**Acceptance Test (how to verify the PR)**

- Verify all permutations of the PageTitleBar story
- Verify a Table story with pagination
