### PR TITLE
fix(imagecard): handle when imagecard setup throws error

### DIFF
--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -84,8 +84,11 @@ const CardRenderer = React.memo(
           // Image cards require extra setup before loading data
           if (onSetupCard && card.type === CARD_TYPES.IMAGE && !card.content.src) {
             updatedCard = await onSetupCard(card);
+            setCard(updatedCard);
           }
-          loadCardData(updatedCard, setCard, onFetchData, timeGrain);
+          if (!updatedCard.error) {
+            loadCardData(updatedCard, setCard, onFetchData, timeGrain);
+          }
         };
         if (isLoading) {
           setupAndLoadCard();

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -39,6 +39,7 @@ const ImageCard = ({
   onCardAction,
   isEditable,
   isExpanded,
+  error,
   isLoading,
   i18n: { loadingDataLabel, ...otherLabels },
   ...others
@@ -49,7 +50,7 @@ const ImageCard = ({
   const supportedSize = supportedSizes.includes(size);
   const availableActions = { expand: supportedSize };
 
-  const isCardLoading = isNil(src) && !isEditable;
+  const isCardLoading = isNil(src) && !isEditable && !error;
 
   return (
     <Card
@@ -60,6 +61,7 @@ const ImageCard = ({
       isLoading={isCardLoading} // only show the spinner if we don't have an image
       isExpanded={isExpanded}
       {...others}
+      error={error}
       i18n={otherLabels}
     >
       {!isCardLoading ? (

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -113,4 +113,22 @@ storiesOf('ImageCard (Experimental)', module)
         />
       </div>
     );
+  })
+  .add('error loading image', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <ImageCard
+          title={text('title', 'Image')}
+          isLoading={boolean('isLoading', true)}
+          id="image-hotspots"
+          content={object('content', omit(content, ['src']))}
+          values={object('values', values)}
+          breakpoint="lg"
+          size={size}
+          onCardAction={action('onCardAction')}
+          error={text('error', `Error no image found called ImageID`)}
+        />
+      </div>
+    );
   });


### PR DESCRIPTION
<!-- Please fill in areas below: -->

**Summary**

- Small bug where if the image card setup throws an error, it isn't shown to the user

**Change List (commits, features, bugs, etc)**

- correctly handle the error if the setupCard throws an error

**Acceptance Test (how to verify the PR)**

- Test the new imagecard error loading src story
