### PR TITLE
fix visual defect in ff for empty tables

### DIFF
--- a/src/components/Table/EmptyTable/EmptyTable.jsx
+++ b/src/components/Table/EmptyTable/EmptyTable.jsx
@@ -11,6 +11,7 @@ const { TableBody, TableCell, TableRow } = DataTable;
 
 const StyledEmptyTableRow = styled(TableRow)`
   &&& {
+    height: calc(100% - 3rem);
     &:hover td {
       border: 1px solid ${COLORS.lightGrey};
       background: inherit;


### PR DESCRIPTION
There is a [defect](https://github.com/carbon-design-system/carbon/issues/4339) in underlining Carbon component that causes table cells to grow to match  size of table with explicitly set height in Firefox browser. See our storybook for table card empty table story.

![image](https://user-images.githubusercontent.com/1590966/67329376-c0751780-f4e8-11e9-9645-42e46292c042.png)


**Change List (commits, features, bugs, etc)**

added styles to empty table component for now as it seems to only happen when there is no data for the table. May be worth applying these styles to tables as a whole. Will be pushing up to the carbon repo as well. 

**Related Issues**

<!-- replace NUMBER with issue number to auto-close on merge -->

- Closes https://github.ibm.com/wiotp/monitoring-dashboard/issues/422

**Acceptance Test (how to verify the PR)**

- tests here