### PR TITLE
fix(imagecard): expansion and collapse doesn't work on firefox

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -62,6 +62,7 @@ export const CardHeader = styled.div`
 export const CardContent = styled.div`
   flex: 1;
   position: relative;
+  overflow: hidden;
   height: ${props => props.dimensions.y - CARD_TITLE_HEIGHT}px;
 `;
 
@@ -186,7 +187,6 @@ const Card = ({
   availableActions,
   breakpoint,
   i18n,
-  i18n: { closeLabel },
   ...others
 }) => {
   const [tooltipId, setTooltipId] = useState(uuidv1());
@@ -319,7 +319,8 @@ const Card = ({
                 kind="ghost"
                 small
                 renderIcon={Close16}
-                iconDescription={closeLabel}
+                iconDescription={strings.closeLabel}
+                title={strings.closeLabel}
                 onClick={() => onCardAction(id, 'CLOSE_EXPANDED_CARD')}
               />
             ) : (

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -64,29 +64,36 @@ const ImageCard = ({
       error={error}
       i18n={otherLabels}
     >
-      {!isCardLoading ? (
-        <ContentWrapper>
-          {supportedSize ? (
-            isEditable ? (
-              <EmptyDiv>
-                <Image32 width={250} height={250} fill="gray" />
-              </EmptyDiv>
-            ) : content && src ? (
-              <ImageHotspots
-                {...content}
-                isExpanded={isExpanded}
-                hotspots={hotspots}
-                isHotspotDataLoading={isLoading}
-                loadingHotspotsLabel={loadingDataLabel}
-              />
-            ) : (
-              <p>Error retrieving image.</p>
-            )
-          ) : (
-            <p>Size not supported.</p>
-          )}
-        </ContentWrapper>
-      ) : null}
+      {!isCardLoading
+        ? (
+            // Get width and height from parent card
+            { width, height } // eslint-disable-line
+          ) => (
+            <ContentWrapper>
+              {supportedSize ? (
+                isEditable ? (
+                  <EmptyDiv>
+                    <Image32 width={250} height={250} fill="gray" />
+                  </EmptyDiv>
+                ) : content && src ? (
+                  <ImageHotspots
+                    {...content}
+                    width={width}
+                    height={height}
+                    isExpanded={isExpanded}
+                    hotspots={hotspots}
+                    isHotspotDataLoading={isLoading}
+                    loadingHotspotsLabel={loadingDataLabel}
+                  />
+                ) : (
+                  <p>Error retrieving image.</p>
+                )
+              ) : (
+                <p>Size not supported.</p>
+              )}
+            </ContentWrapper>
+          )
+        : null}
     </Card>
   );
 };

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -328,7 +328,7 @@ const ImageHotspots = ({
   background,
   src,
   height: heightProp,
-  width,
+  width: widthProp,
   alt,
   isHotspotDataLoading,
   zoomMax,
@@ -350,7 +350,8 @@ const ImageHotspots = ({
     hideMinimapProp,
   });
 
-  const height = heightProp - 80; // Need to adjust for card chrome
+  const height = heightProp - (48 + 16); // Need to adjust for card chrome
+  const width = widthProp - 16 * 2; // need to adjust for card chrome
   const orientation = width > height ? 'landscape' : 'portrait';
   const ratio = orientation === 'landscape' ? width / height : height / width;
 

--- a/src/components/ImageCard/ImageHotspots.test.jsx
+++ b/src/components/ImageCard/ImageHotspots.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { act, isDOMComponent } from 'react-dom/test-utils';
 
-import ImageHotspots from './ImageHotspots';
+import ImageHotspots, { calculateImageHeight, calculateImageWidth } from './ImageHotspots';
 
 describe('ImageHotspots', () => {
   let container;
@@ -23,5 +23,41 @@ describe('ImageHotspots', () => {
     });
     const image = container.querySelector('img');
     expect(isDOMComponent(image)).toBe(false);
+  });
+  test('calculateImageHeight', () => {
+    // landscape test where image is bigger picks container height
+    expect(
+      calculateImageHeight(
+        { orientation: 'landscape', ratio: 2, width: 300, height: 200 },
+        'landscape',
+        3
+      )
+    ).toEqual(100);
+    // landscape container is bigger
+    expect(
+      calculateImageHeight(
+        { orientation: 'landscape', ratio: 2, width: 300, height: 200 },
+        'landscape',
+        1
+      )
+    ).toEqual(200);
+  });
+  test('calculateImageWidth', () => {
+    // landscape test where image is bigger picks container height
+    expect(
+      calculateImageWidth(
+        { orientation: 'landscape', ratio: 2, width: 300, height: 200 },
+        'landscape',
+        3
+      )
+    ).toEqual(300);
+    // landscape container is bigger
+    expect(
+      calculateImageWidth(
+        { orientation: 'landscape', ratio: 2, width: 300, height: 200 },
+        'landscape',
+        1
+      )
+    ).toEqual(200);
   });
 });

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -140,7 +140,7 @@ const TimeSeriesCard = ({
     ? memoizedGenerateSampleValues(series, timeDataSourceId, interval)
     : valuesProp;
 
-  const isAllValuesEmpty = isValuesEmpty(valuesProp, timeDataSourceId);
+  const isAllValuesEmpty = isValuesEmpty(values, timeDataSourceId);
 
   const valueSort = useMemo(
     () =>


### PR DESCRIPTION
Closes #638

**Summary**

- Internal Bug reported where the Image Card didn't collapse from full screen correctly on firefox

**Change List (commits, features, bugs, etc)**

- refactor(ImageHotspots): pretty large refactor to remove the local container state from ImageHotspots and instead inherit the size from the Card content parent (which correctly handles Firefox)
- fix(TimeSeriesCard): isEditable is no longer showing fake data

**Acceptance Test (how to verify the PR)**

- Verify in Firefox the full screen image card dashboard story.  Expand and then collapse the image and ensure it is correctly positioned
