### PR TITLE
fix(multiselect): copy story and readme from carbon 10.6.4

### DIFF
--- a/src/components/MultiSelect/MultiSelect.story.jsx
+++ b/src/components/MultiSelect/MultiSelect.story.jsx
@@ -1,11 +1,150 @@
-// This story relies on the readme.md present in the carbon repo, which is not included in the distributed package.
-// Enabling the line below causes a build error:
-// ERROR in ./node_modules/carbon-components-react/lib/components/MultiSelect/MultiSelect-story.js
-// Module not found: Error: Can't resolve './README.md' in '/Users/taylorjones/dev/carbon-addons-iot-react/node_modules/carbon-components-react/lib/components/MultiSelect'
-//  @ ./node_modules/carbon-components-react/lib/components/MultiSelect/MultiSelect-story.js 13:37-59
-//  @ ./src/components/MultiSelect/MultiSelect.story.jsx
-//  @ ./src/components sync \.story\.jsx$
-//  @ ./.storybook/config.js
-//  @ multi ./node_modules/@storybook/core/dist/server/common/polyfills.js ./node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/config.js ./node_modules/webpack-hot-middleware/client.js?reload=true
+/**
+ * Copyright IBM Corp. 2016, 2018
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-// export default from 'carbon-components-react/lib/components/MultiSelect/MultiSelect-story'
+/**
+ * Note: The content below has been copied from v10.6.4:
+ * https://github.com/carbon-design-system/carbon/blob/81d69760a833e0159a820d00d3609ad013c1c8ec/packages/react/src/components/MultiSelect/MultiSelect-story.js
+ * in the base Carbon repository.
+ */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean, select, text, object } from '@storybook/addon-knobs';
+import { withReadme } from 'storybook-readme';
+import { MultiSelect } from 'carbon-components-react';
+
+import readme from './README.md';
+
+const items = [
+  {
+    id: 'downshift-1-item-0',
+    text: 'Option 1',
+  },
+  {
+    id: 'downshift-1-item-1',
+    text: 'Option 2',
+  },
+  {
+    id: 'downshift-1-item-2',
+    text: 'Option 3',
+  },
+  {
+    id: 'downshift-1-item-3',
+    text: 'Option 4',
+  },
+  {
+    id: 'downshift-1-item-4',
+    text: 'An example option that is really long to show what should be done to handle long text',
+  },
+];
+
+const defaultLabel = 'MultiSelect Label';
+const defaultPlaceholder = 'Filter';
+
+const types = {
+  'Default (default)': 'default',
+  'Inline (inline)': 'inline',
+};
+
+const props = () => ({
+  id: text('MultiSelect ID (id)', 'carbon-multiselect-example'),
+  titleText: text('Title (titleText)', 'Multiselect title'),
+  helperText: text('Helper text (helperText)', 'This is not helper text'),
+  filterable: boolean('Filterable (`<MultiSelect.Filterable>` instead of `<MultiSelect>`)', false),
+  disabled: boolean('Disabled (disabled)', false),
+  light: boolean('Light variant (light)', false),
+  useTitleInItem: boolean('Show tooltip on hover', false),
+  type: select('UI type (Only for `<MultiSelect>`) (type)', types, 'default'),
+  label: text('Label (label)', defaultLabel),
+  invalid: boolean('Show form validation UI (invalid)', false),
+  invalidText: text('Form validation UI content (invalidText)', 'Invalid Selection'),
+  onChange: action('onChange'),
+  listBoxMenuIconTranslationIds: object(
+    'Listbox menu icon translation IDs (for translateWithId callback)',
+    {
+      'close.menu': 'Close menu',
+      'open.menu': 'Open menu',
+      'clear.all': 'Clear all',
+      'clear.selection': 'Clear selection',
+    }
+  ),
+  selectionFeedback: select(
+    'Selection feedback',
+    ['top', 'fixed', 'top-after-reopen'],
+    'top-after-reopen'
+  ),
+});
+
+storiesOf('MultiSelect', module)
+  .addDecorator(withKnobs)
+  .add(
+    'default',
+    withReadme(readme, () => {
+      const {
+        filterable,
+        listBoxMenuIconTranslationIds,
+        selectionFeedback,
+        ...multiSelectProps
+      } = props();
+      const ComponentToUse = !filterable ? MultiSelect : MultiSelect.Filterable;
+      const placeholder = !filterable ? undefined : defaultPlaceholder;
+      return (
+        <div style={{ width: 300 }}>
+          <ComponentToUse
+            {...multiSelectProps}
+            items={items}
+            itemToString={item => (item ? item.text : '')}
+            placeholder={placeholder}
+            translateWithId={id => listBoxMenuIconTranslationIds[id]}
+            selectionFeedback={selectionFeedback}
+          />
+        </div>
+      );
+    }),
+    {
+      info: {
+        text: `
+            MultiSelect
+          `,
+      },
+    }
+  )
+  .add(
+    'with initial selected items',
+    withReadme(readme, () => {
+      const {
+        filterable,
+        listBoxMenuIconTranslationIds,
+        selectionFeedback,
+        ...multiSelectProps
+      } = props();
+      const ComponentToUse = !filterable ? MultiSelect : MultiSelect.Filterable;
+      const placeholder = !filterable ? undefined : defaultPlaceholder;
+
+      return (
+        <div style={{ width: 300 }}>
+          <ComponentToUse
+            {...multiSelectProps}
+            items={items}
+            itemToString={item => (item ? item.text : '')}
+            initialSelectedItems={[items[0], items[1]]}
+            placeholder={placeholder}
+            translateWithId={id => listBoxMenuIconTranslationIds[id]}
+            selectionFeedback={selectionFeedback}
+          />
+        </div>
+      );
+    }),
+    {
+      info: {
+        text: `
+            Provide a set of items to initially select in the control
+          `,
+      },
+    }
+  );

--- a/src/components/MultiSelect/README.md
+++ b/src/components/MultiSelect/README.md
@@ -1,0 +1,98 @@
+> Note: The content below has been _copied_ from [this specific point](https://github.com/carbon-design-system/carbon/blob/287e08992573bdbce41887d34be56181fba48d08/packages/react/src/components/MultiSelect/README.md) in the base Carbon repository.
+
+# `MultiSelect`
+
+> A Dropdown Menu from which you can select given items by clicking on a
+> checkbox. Given the right options/properties items can be already selected
+> initially.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+
+## Installation
+
+This component comes with any installation of the `carbon-components-react`
+package on npm. You can install this package by running the following command in
+your terminal with [npm](https://www.npmjs.com/):
+
+```bash
+npm i carbon-components carbon-components-react carbon-icons --save
+```
+
+If you prefer [Yarn](https://yarnpkg.com/en/), use the following command
+instead:
+
+```bash
+yarn add carbon-components-react carbon-components carbon-icons
+```
+
+## Usage
+
+You can use `MultiSelect` by doing the following in your project:
+
+```js
+import { MultiSelect } from 'carbon-components-react';
+```
+
+You can then create the `MultiSelect` by the following:
+
+```jsx
+<MultiSelect
+  useTitleInItem={false}
+  label="MultiSelect Label"
+  invalid={false}
+  invalidText="Invalid Selection"
+  onChange={onChange}
+  items={[{ id: 'item-1', text: 'Item 1' }, { id: 'item-2', text: 'Item 2' }]}
+  itemToString={itemToString}
+  initialSelectedItems={[{ id: 'item-1', text: 'Item 1' }, { id: 'item-2', text: 'Item 2' }]}
+  translateWithId={translateWithId}
+/>
+```
+
+## Use-cases
+
+If the variable array provided to the `items` attribute lacks a `label`
+property, the component will not render. Using the label prop to render items
+would look like the following:
+
+```jsx
+<MultiSelect
+  useTitleInItem={false}
+  label="MultiSelect Label"
+  invalid={false}
+  invalidText="Invalid Selection"
+  onChange={onChange}
+  items={[
+    { id: 'item-1', text: 'Item 1', label: 'Item 1' },
+    { id: 'item-2', text: 'Item 2', label: 'Item 2' },
+  ]}
+  itemToString={itemToString}
+  initialSelectedItems={[{ id: 'item-1', text: 'Item 1' }, { id: 'item-2', text: 'Item 2' }]}
+  translateWithId={translateWithId}
+/>
+```
+
+However, you can have items in your array without a `label` field, as long as
+you provide the `itemToString` method that properly maps them.
+
+What does the helper function itemToString do?<br/> The helper function
+`itemToString` allows you to render a given item to a string label. By default,
+it extracts the `label` field from a given item to serve as the item label in
+the list. For instance you can use:
+
+```jsx
+<MultiSelect
+  useTitleInItem={false}
+  label="MultiSelect Label"
+  invalid={false}
+  invalidText="Invalid Selection"
+  onChange={onChange}
+  items={[{ id: 'item-1', text: 'Item 1' }, { id: 'item-2', text: 'Item 2' }]}
+  initialSelectedItems={[{ id: 'item-1', text: 'Item 1' }, { id: 'item-2', text: 'Item 2' }]}
+  translateWithId={translateWithId}
+  itemToString={item => (item ? item.text : '')}
+/>
+```


### PR DESCRIPTION
Closes #649 

**Summary**

- Copied the story and readme over, included link to permalink of where it's copied from.

**Acceptance Test (how to verify the PR)**

- Deploy preview should show the MultiSelect story
