### PR TITLE
chore(tests): re-increase test coverage thresholds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,10 @@ module.exports = {
   coverageReporters: ['html', 'text-summary'],
   coverageThreshold: {
     global: {
-      statements: 75,
-      branches: 65,
-      functions: 65,
-      lines: 75,
+      statements: 80,
+      branches: 73,
+      functions: 80,
+      lines: 80,
     },
   },
   globals: {


### PR DESCRIPTION
Closes #621 

**Summary**

- Reimplements test coverage thresholds we had set before the dashboard component migration from 1.x to 2.x. `Branches` increases, but will remain below 80% until `PageWizard` stabilizes and is covered in tests.

**Acceptance Test (how to verify the PR)**

- Validate the Travis CI checks take into account the new thresholds. The current coverage amounts in `master` meet these thresholds.
