### PR TITLE
fix(tooltip): write our own parse since cheeriojs has issues with rollup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,8 @@
         "targets": {
           "browsers": ["last 1 version", "ie >= 11"]
         },
-        "useBuiltIns": "usage"
+        "useBuiltIns": "usage",
+        "corejs": 2
       }
     ],
     "@babel/preset-react",

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,17 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-flow"],
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "browsers": ["last 1 version", "ie >= 11"]
+        },
+        "useBuiltIns": "usage"
+      }
+    ],
+    "@babel/preset-react",
+    "@babel/preset-flow"
+  ],
   "ignore": ["__mocks__"],
   "plugins": [
     "babel-plugin-lodash",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@carbon/colors": "^10.1.0",
     "ajv": "^6.10.2",
     "c3": "^0.7.1",
-    "cheerio": "^1.0.0-rc.3",
     "classnames": "^2.2.5",
     "immutability-helper": "^2.9.0",
     "js-file-download": "^0.4.7",
@@ -189,8 +188,7 @@
     "concurrent": false
   },
   "resolutions": {
-    "@carbon/charts": "https://github.com/scottdickerson/carbon-charts#carbon-charts-v0.16.26-gitpkg",
-    "htmlparser2": "4.0.0"
+    "@carbon/charts": "https://github.com/scottdickerson/carbon-charts#carbon-charts-v0.16.26-gitpkg"
   },
   "version": "0.0.0-development"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,8 +6,6 @@ import { uglify } from 'rollup-plugin-uglify';
 import filesize from 'rollup-plugin-filesize';
 import postcss from 'rollup-plugin-postcss';
 import json from 'rollup-plugin-json';
-// import builtins from 'rollup-plugin-node-builtins';
-// import globals from 'rollup-plugin-node-globals';
 
 const env = process.env.NODE_ENV || 'development';
 const prodSettings = env === 'development' ? [] : [uglify(), filesize()];
@@ -46,11 +44,8 @@ export default {
   plugins: [
     resolve({
       browser: true,
-      // preferBuiltins: false,
       extensions: ['.mjs', '.js', '.jsx', '.json'],
     }),
-    // builtins(),
-    // globals(),
     postcss({
       plugins: [],
     }),

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -119,7 +119,9 @@ const formatChartData = (timeDataSourceId, series, values) => {
     datasets: series.map(({ dataSourceId, label, color }) => ({
       label,
       ...(color ? { fillColors: [color] } : {}),
-      data: values.map(i => ({ date: new Date(i[timeDataSourceId]), value: i[dataSourceId] })),
+      data:
+        values &&
+        values.map(i => ({ date: new Date(i[timeDataSourceId]), value: i[dataSourceId] })),
     })),
   };
 };

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -9,7 +9,6 @@ import isNil from 'lodash/isNil';
 import memoize from 'lodash/memoize';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import withSize from 'react-sizeme';
-// import cheerio from 'cheerio';
 
 import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
@@ -18,23 +17,21 @@ import Card from '../Card/Card';
 import { generateSampleValues, isValuesEmpty } from './timeSeriesUtils';
 
 /** Extends default tooltip with the additional date information */
-/*
 export const handleTooltip = (data, defaultTooltip) => {
-  const $ = cheerio.load(defaultTooltip);
+  console.log(`defaultTooltip: ${defaultTooltip}`);
   const dateLabel = `<li class='datapoint-tooltip'><p class='label'>${moment(
     Array.isArray(data) && data[0] ? data[0].date : data.date
   ).format('L HH:mm:ss')}</p></li>`;
+  let updatedTooltip = defaultTooltip;
   if (Array.isArray(data)) {
     // prepend the date inside the existing multi tooltip
-    $('.multi-tooltip > li:first-child').before(dateLabel);
+    updatedTooltip = defaultTooltip.replace('<li', `${dateLabel}<li`);
   } else {
     // wrap to make single a multi-tooltip
-    $('.datapoint-tooltip').wrap(`<ul class='multi-tooltip'><li></li></ul>`);
-    $('.multi-tooltip > li:first-child').before(dateLabel);
+    updatedTooltip = `<ul class='multi-tooltip'>${dateLabel}<li>${defaultTooltip}</li></ul>`;
   }
-  return $.html('body > *');
+  return updatedTooltip;
 };
-*/
 
 const LineChartWrapper = styled.div`
   padding-left: 16px;
@@ -335,7 +332,7 @@ const TimeSeriesCard = ({
                     containerResizable: true,
                     tooltip: {
                       formatter: tooltipValue => valueFormatter(tooltipValue, size, unit),
-                      // customHTML: handleTooltip,
+                      customHTML: handleTooltip,
                       gridline: {
                         enabled: false,
                       },


### PR DESCRIPTION
Unfortunately cheeriojs throws errors when we try and use it downstream with rollup (due to htmlparser2) so I had to remove it and implement our own html parser

For some bizarre reason, I also had to adjust our polyfills in babelrc because the library started throwing an error