### PR TITLE
fix(timeseries): bug where the x-axis isn't formatting correctly with the new graphs

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -3,7 +3,6 @@ import moment from 'moment/min/moment-with-locales.min';
 import { LineChart } from '@carbon/charts-react';
 // TODO: waiting for @carbon/charts support https://github.com/carbon-design-system/carbon-charts/pull/389
 import '@carbon/charts/dist/styles.css';
-import isEmpty from 'lodash/isEmpty';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
 import memoize from 'lodash/memoize';
@@ -14,7 +13,7 @@ import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropType
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
 
-import { generateSampleValues, isValuesEmpty } from './timeSeriesUtils';
+import { generateSampleValues, isValuesEmpty, formatGraphTick } from './timeSeriesUtils';
 
 /** Extends default tooltip with the additional date information */
 export const handleTooltip = (data, defaultTooltip) => {
@@ -165,30 +164,13 @@ const TimeSeriesCard = ({
   ...others
 }) => {
   let chartRef = useRef();
+  const previousTick = useRef();
 
   const values = isEditable
     ? memoizedGenerateSampleValues(series, timeDataSourceId, interval)
     : valuesProp;
 
   const isAllValuesEmpty = isValuesEmpty(values, timeDataSourceId);
-
-  const valueSort = useMemo(
-    () =>
-      values
-        ? values.sort((left, right) =>
-            moment.utc(left[timeDataSourceId]).diff(moment.utc(right[timeDataSourceId]))
-          )
-        : [],
-    [values, timeDataSourceId]
-  );
-
-  const sameYear =
-    !isEmpty(values) &&
-    moment(moment.unix(valueSort[0][timeDataSourceId] / 1000)).isSame(moment(), 'year') &&
-    moment(moment.unix(valueSort[valueSort.length - 1][timeDataSourceId] / 1000)).isSame(
-      moment(),
-      'year'
-    );
 
   const maxTicksPerSize = useMemo(
     () => {
@@ -209,12 +191,6 @@ const TimeSeriesCard = ({
     [size]
   );
 
-  /** Interval is the points between ticks */
-  const ticksInterval =
-    Math.round(valueSort.length / maxTicksPerSize) !== 0
-      ? Math.round(valueSort.length / maxTicksPerSize)
-      : 1;
-
   const formatTick = useCallback(
     /** *
      * timestamp of current value
@@ -222,42 +198,12 @@ const TimeSeriesCard = ({
      * ticks: array of current ticks
      */
     (timestamp, index, ticks) => {
-      // moment locale default to english
-      moment.locale('en');
-      if (locale) {
-        moment.locale(locale);
-      }
-      const m = moment.unix(timestamp / 1000);
-
-      return interval === 'hour' && index === 0
-        ? ticks.length > 1
-          ? m.format('DD MMM')
-          : m.format('DD MMM HH:mm')
-        : interval === 'hour' &&
-          index !== 0 &&
-          !moment(
-            moment.unix(valueSort[Math.max(index - ticksInterval, 0)].timestamp / 1000)
-          ).isSame(moment.unix(valueSort[index].timestamp / 1000), 'day')
-        ? m.format('DD MMM')
-        : interval === 'hour'
-        ? m.format('HH:mm')
-        : interval === 'day' && index === 0
-        ? m.format('DD MMM')
-        : interval === 'day' && index !== 0
-        ? m.format('DD MMM')
-        : interval === 'month' && !sameYear
-        ? m.format('MMM YYYY')
-        : interval === 'month' && sameYear && index === 0
-        ? m.format('MMM YYYY')
-        : interval === 'month' && sameYear
-        ? m.format('MMM')
-        : interval === 'year'
-        ? m.format('YYYY')
-        : interval === 'minute'
-        ? m.format('HH:mm')
-        : m.format('DD MMM YYYY');
+      const previousTimestamp = previousTick.current;
+      // store current in the previous tick
+      previousTick.current = timestamp;
+      return formatGraphTick(timestamp, index, ticks, interval, locale, previousTimestamp);
     },
-    [interval, locale, sameYear, ticksInterval, valueSort]
+    [interval, locale]
   );
 
   const lines = useMemo(

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -338,7 +338,7 @@ storiesOf('TimeSeriesCard (Experimental)', module)
             yLabel: text('yLabel', 'Temperature (˚F)'),
             timeDataSourceId: 'timestamp',
           })}
-          values={getIntervalChartData('month', 12, { min: 10, max: 100 }, 100)}
+          values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
           interval="month"
           breakpoint="lg"
           size={size}
@@ -640,7 +640,7 @@ storiesOf('TimeSeriesCard (Experimental)', module)
             yLabel: text('yLabel', 'Temperature (˚F)'),
             timeDataSourceId: 'timestamp',
           })}
-          values={getIntervalChartData('month', 12, { min: 10, max: 100 }, 100)}
+          values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
           interval="month"
           breakpoint="lg"
           size={size}

--- a/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -64,3 +64,52 @@ export const generateTableSampleValues = columns => {
     }, {}),
   }));
 };
+/** *
+ * timestamp of current value
+ * index of current value
+ * ticks: array of current ticks
+ */
+export const formatGraphTick = (
+  timestamp,
+  index,
+  ticks,
+  interval,
+  locale,
+  previousTickTimestamp
+) => {
+  // moment locale default to english
+  moment.locale('en');
+  if (locale) {
+    moment.locale(locale);
+  }
+  const currentTimestamp = moment.unix(timestamp / 1000);
+
+  const sameDay = moment(previousTickTimestamp).isSame(currentTimestamp, 'day');
+  const sameYear = moment(previousTickTimestamp).isSame(currentTimestamp, 'year');
+
+  return interval === 'hour' && index === 0
+    ? ticks.length > 1
+      ? currentTimestamp.format('DD MMM')
+      : currentTimestamp.format('DD MMM HH:mm')
+    : interval === 'hour' && index !== 0 && !sameDay
+    ? currentTimestamp.format('DD MMM')
+    : interval === 'hour'
+    ? currentTimestamp.format('HH:mm')
+    : interval === 'day' && index === 0
+    ? currentTimestamp.format('DD MMM')
+    : interval === 'day' && index !== 0
+    ? currentTimestamp.format('DD MMM')
+    : interval === 'month' && !sameYear
+    ? currentTimestamp.format('MMM YYYY')
+    : interval === 'month' && sameYear && index === 0
+    ? currentTimestamp.format('MMM YYYY')
+    : interval === 'month' && sameYear
+    ? currentTimestamp.format('MMM')
+    : interval === 'year' && sameYear && index !== 0
+    ? currentTimestamp.format('MMM') // if we're on the year boundary and the same year, then don't repeat
+    : interval === 'year' && (!sameYear || index === 0)
+    ? currentTimestamp.format('YYYY')
+    : interval === 'minute'
+    ? currentTimestamp.format('HH:mm')
+    : currentTimestamp.format('DD MMM YYYY');
+};

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -1,6 +1,11 @@
 import every from 'lodash/every';
 
-import { generateSampleValues, generateTableSampleValues, isValuesEmpty } from './timeSeriesUtils';
+import {
+  generateSampleValues,
+  generateTableSampleValues,
+  isValuesEmpty,
+  formatGraphTick,
+} from './timeSeriesUtils';
 
 describe('timeSeriesUtils', () => {
   test('isValuesEmpty', () => {
@@ -67,5 +72,23 @@ describe('timeSeriesUtils', () => {
     expect(tableSampleValues[0].values).toHaveProperty('column1');
     expect(tableSampleValues[0].values).toHaveProperty('column2');
     expect(tableSampleValues[0].values).toHaveProperty('column3');
+  });
+  test('formatGraphTick', () => {
+    // hour different day
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'hour', null, 1572912000000)
+    ).toContain('05 Nov');
+    // hour same day
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'hour', null, 1572933600000)
+    ).toContain('00:00');
+    // month different year
+    expect(
+      formatGraphTick(1546322400000, 1, [1, 2, 3, 4, 5, 6], 'month', null, 1522558800000)
+    ).toContain('Jan 2019');
+    // month same year
+    expect(
+      formatGraphTick(1561957200000, 1, [1, 2, 3, 4, 5, 6], 'month', null, 1572584400000)
+    ).toContain('Jul');
   });
 });


### PR DESCRIPTION
x-axis wasn't being formatted correctly with the new graphs, adds a testcase to validate and ensure this formatting.
refactor(TimeSeriesCard): split the formatting utility to be sharable between components