### PR TITLE
feat(table): 3287-Table-Header-Row-Count

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -948,59 +948,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -1014,15 +977,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -2797,59 +2797,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -2863,15 +2826,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -4678,59 +4678,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -4744,15 +4707,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -6071,59 +6071,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -6137,15 +6100,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -8712,59 +8712,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -8778,15 +8741,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -20987,59 +20987,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -21053,15 +21016,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}

--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -75,3 +75,7 @@ html[dir='rtl'] {
     padding-right: $spacing-04;
   }
 }
+
+.#{$prefix}--toolbar-search-container-active .#{$prefix}--search .#{$prefix}--search-input {
+  padding-right: $spacing-09;
+}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -84,6 +84,7 @@ const propTypes = {
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
     shouldLazyRender: PropTypes.bool,
+    hasRowCount: PropTypes.bool,
   }),
 
   /** Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux see StatefulTable component for an example */
@@ -346,6 +347,7 @@ const Table = props => {
           filterNone: i18n.filterNone,
           filterAscending: i18n.filterAscending,
           filterDescending: i18n.filterDescending,
+          rowCountLabel: i18n.rowCountLabel,
         }}
         actions={pick(
           actions.toolbar,
@@ -356,10 +358,18 @@ const Table = props => {
           'onToggleFilter',
           'onApplySearch'
         )}
-        options={pick(options, 'hasColumnSelection', 'hasFilter', 'hasSearch', 'hasRowSelection')}
+        options={pick(
+          options,
+          'hasColumnSelection',
+          'hasFilter',
+          'hasSearch',
+          'hasRowSelection',
+          'hasRowCount'
+        )}
         tableState={{
           totalSelected: view.table.selectedIds.length,
           totalFilters: view.filters ? view.filters.length : 0,
+          totalItemsCount: view.pagination.totalItems,
           ...pick(
             view.toolbar,
             'batchActions',

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -428,6 +428,27 @@ storiesOf('Watson IoT|Table', module)
       },
     }
   )
+  .add('Stateful Example with Row Count', () => (
+    <FullWidthWrapper>
+      <StatefulTable
+        {...initialState}
+        options={{
+          hasSearch: true,
+          hasPagination: true,
+          hasRowSelection: 'multi',
+          hasFilter: true,
+          hasRowActions: true,
+          hasRowCount: boolean('Show Row Count', true),
+        }}
+        view={{
+          toolbar: { activeBar: null },
+        }}
+        i18n={{
+          rowCountLabel: text('Row Count Label', 'Results'),
+        }}
+      />
+    </FullWidthWrapper>
+  ))
   .add(
     'Stateful Example with every third row unselectable',
     () => (

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -70,6 +70,14 @@ const StyledTableBatchActions = styled(TableBatchActions)`
   }
 `;
 
+const ToolBarResultLabel = styled.label`
+  &&& {
+    display: flex;
+    position: relative;
+    height: 3rem;
+    padding: 1rem;
+  }
+`;
 const propTypes = {
   /** id of table */
   tableId: PropTypes.string.isRequired,
@@ -78,6 +86,7 @@ const propTypes = {
     hasFilter: PropTypes.bool,
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
+    hasRowCount: PropTypes.bool,
   }).isRequired,
 
   /** internationalized labels */
@@ -93,6 +102,7 @@ const propTypes = {
     filterNone: PropTypes.string,
     filterAscending: PropTypes.string,
     filterDescending: PropTypes.string,
+    rowCountLabel: PropTypes.string,
   }),
   /**
    * Action callbacks to update tableState
@@ -144,6 +154,7 @@ const defaultProps = {
     filterNone: 'Unsort rows by this header',
     filterAscending: 'Sort rows by this header in ascending order',
     filterDescending: 'Sort rows by this header in descending order',
+    rowCountLabel: 'Results',
   },
 };
 
@@ -183,7 +194,7 @@ const TableToolbar = ({
   tableId,
   className,
   i18n,
-  options: { hasColumnSelection, hasFilter, hasSearch, hasRowSelection },
+  options: { hasColumnSelection, hasFilter, hasSearch, hasRowSelection, hasRowCount },
   actions: {
     onCancelBatchAction,
     onApplyBatchAction,
@@ -200,6 +211,7 @@ const TableToolbar = ({
     // activeBar,
     customToolbarContent,
     isDisabled,
+    totalItemsCount,
   },
 }) => (
   <StyledCarbonTableToolbar className={className}>
@@ -215,16 +227,22 @@ const TableToolbar = ({
         </TableBatchAction>
       ))}
     </StyledTableBatchActions>
-    {hasSearch ? (
-      <StyledToolbarSearch
-        {...search}
-        translateWithId={(...args) => translateWithId(i18n, ...args)}
-        id={`${tableId}-toolbar-search`}
-        onChange={event => onApplySearch(event.currentTarget ? event.currentTarget.value : '')}
-        disabled={isDisabled}
-      />
+    {hasRowCount ? (
+      <ToolBarResultLabel>
+        {i18n.rowCountLabel}: {totalItemsCount}
+      </ToolBarResultLabel>
     ) : null}
+
     <StyledTableToolbarContent>
+      {hasSearch ? (
+        <StyledToolbarSearch
+          {...search}
+          translateWithId={(...args) => translateWithId(i18n, ...args)}
+          id={`${tableId}-toolbar-search`}
+          onChange={event => onApplySearch(event.currentTarget ? event.currentTarget.value : '')}
+          disabled={isDisabled}
+        />
+      ) : null}
       {customToolbarContent || null}
       {totalFilters > 0 ? (
         <Button kind="secondary" onClick={onClearAllFilters}>

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -85,59 +85,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    disabled={true}
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -151,1308 +114,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
-                <button
-                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </section>
-            <table
-              className="bx--data-table bx--data-table--no-border"
-            >
-              <thead
-                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
-              >
-                <tr>
-                  <th
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
-                      data-column="alert"
-                      id="column-alert"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Alert"
-                        >
-                          Alert
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="hour"
-                      id="column-hour"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Hour"
-                        >
-                          Hour
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="pressure"
-                      id="column-pressure"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Pressure"
-                        >
-                          Pressure
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                aria-live="polite"
-              >
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-0-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-0-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-0-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-1-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-1-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-1-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-2-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-2-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-2-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-4-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-4-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-4-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-5-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-5-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-5-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-6-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-6-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-6-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-7-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-7-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-7-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-8-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-8-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-8-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-9-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-9-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-9-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
-              disabled={false}
-              size={
-                Object {
-                  "height": undefined,
-                  "position": undefined,
-                  "width": undefined,
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-30"
-                  id="bx-pagination-select-30-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-30"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={20}
-                          >
-                            20
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={30}
-                          >
-                            30
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 10 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
                     <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-32"
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
                     >
-                      Page number, of 1 pages
+                      Search
                     </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      disabled={true}
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-32"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
                           }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
                   </div>
                 </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 1 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23l-8-7 8-7v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9l8 7-8 7V9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard editable with expanded rows 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "flexDirection": "column",
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 kGdXdI"
-        id="table-list"
-      >
-        <div
-          className="card--header"
-        >
-          <span
-            className="card--title"
-            title="Open Alerts"
-          >
-            Open Alerts
-             
-          </span>
-          <div
-            className="bx--toolbar card--toolbar"
-          />
-        </div>
-        <div
-          className="Card__CardContent-v5r71h-1 fabdLf"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
-              >
-                <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    disabled={true}
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -1516,10 +223,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
               >
                 <tr>
-                  <th
-                    className="bx--table-expand"
-                    scope="col"
-                  />
                   <th
                     className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
                     scope="col"
@@ -1717,45 +420,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 aria-live="polite"
               >
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -1815,45 +482,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -1913,45 +544,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2011,45 +606,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2109,45 +668,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2207,45 +730,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2305,45 +792,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2403,45 +854,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2501,45 +916,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2599,45 +978,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2950,6 +1293,1663 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard editable with expanded rows 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 kGdXdI"
+        id="table-list"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Open Alerts"
+          >
+            Open Alerts
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          />
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 fabdLf"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
+                >
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      disabled={true}
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </section>
+            <table
+              className="bx--data-table bx--data-table--no-border"
+            >
+              <thead
+                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
+              >
+                <tr>
+                  <th
+                    className="bx--table-expand"
+                    scope="col"
+                  />
+                  <th
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
+                      data-column="alert"
+                      id="column-alert"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Alert"
+                        >
+                          Alert
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="hour"
+                      id="column-hour"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Hour"
+                        >
+                          Hour
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="pressure"
+                      id="column-pressure"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Pressure"
+                        >
+                          Pressure
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                aria-live="polite"
+              >
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-0-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-0-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-0-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-1-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-1-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-1-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-2-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-2-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-2-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-4-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-4-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-4-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-5-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-5-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-5-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-6-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-6-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-6-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-7-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-7-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-7-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-8-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-8-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-8-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-9-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-9-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-9-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
+              disabled={false}
+              size={
+                Object {
+                  "height": undefined,
+                  "position": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-32"
+                  id="bx-pagination-select-32-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-32"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={20}
+                          >
+                            20
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={30}
+                          >
+                            30
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 10 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-34"
+                    >
+                      Page number, of 1 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-34"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 1 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23l-8-7 8-7v14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9l8 7-8 7V9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard empty table 1`] = `
 <div
   className="storybook-container"
@@ -3117,58 +3117,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -3182,15 +3146,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -3651,58 +3651,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -3716,15 +3680,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -5676,8 +5676,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-33"
-                  id="bx-pagination-select-33-count-label"
+                  htmlFor="bx-pagination-select-34"
+                  id="bx-pagination-select-34-count-label"
                 >
                   Items per page:
                 </label>
@@ -5696,7 +5696,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33"
+                          id="bx-pagination-select-34"
                           onChange={[Function]}
                           value={10}
                         >
@@ -5769,7 +5769,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-35"
+                      htmlFor="bx-pagination-select-36"
                     >
                       Page number, of 2 pages
                     </label>
@@ -5782,7 +5782,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-35"
+                          id="bx-pagination-select-36"
                           onChange={[Function]}
                           value={1}
                         >
@@ -6087,58 +6087,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -6152,15 +6116,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -7010,8 +7010,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-29"
-                  id="bx-pagination-select-29-count-label"
+                  htmlFor="bx-pagination-select-30"
+                  id="bx-pagination-select-30-count-label"
                 >
                   Items per page:
                 </label>
@@ -7030,7 +7030,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29"
+                          id="bx-pagination-select-30"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7103,7 +7103,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-31"
+                      htmlFor="bx-pagination-select-32"
                     >
                       Page number, of 2 pages
                     </label>
@@ -7116,7 +7116,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
+                          id="bx-pagination-select-32"
                           onChange={[Function]}
                           value={1}
                         >
@@ -7421,58 +7421,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -7486,15 +7450,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -8345,8 +8345,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-17"
-                  id="bx-pagination-select-17-count-label"
+                  htmlFor="bx-pagination-select-18"
+                  id="bx-pagination-select-18-count-label"
                 >
                   Items per page:
                 </label>
@@ -8365,7 +8365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-17"
+                          id="bx-pagination-select-18"
                           onChange={[Function]}
                           value={10}
                         >
@@ -8438,7 +8438,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-19"
+                      htmlFor="bx-pagination-select-20"
                     >
                       Page number, of 2 pages
                     </label>
@@ -8451,7 +8451,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-19"
+                          id="bx-pagination-select-20"
                           onChange={[Function]}
                           value={1}
                         >
@@ -8756,58 +8756,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -8821,15 +8785,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -9195,8 +9195,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-18"
-                  id="bx-pagination-select-18-count-label"
+                  htmlFor="bx-pagination-select-19"
+                  id="bx-pagination-select-19-count-label"
                 >
                   Items per page:
                 </label>
@@ -9215,7 +9215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-18"
+                          id="bx-pagination-select-19"
                           onChange={[Function]}
                           value={10}
                         >
@@ -9288,7 +9288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-20"
+                      htmlFor="bx-pagination-select-21"
                     >
                       Page number, of 2 pages
                     </label>
@@ -9301,7 +9301,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-20"
+                          id="bx-pagination-select-21"
                           onChange={[Function]}
                           value={1}
                         >
@@ -9606,58 +9606,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -9671,15 +9635,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -10045,8 +10045,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-28"
-                  id="bx-pagination-select-28-count-label"
+                  htmlFor="bx-pagination-select-29"
+                  id="bx-pagination-select-29-count-label"
                 >
                   Items per page:
                 </label>
@@ -10065,7 +10065,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={10}
                         >
@@ -10138,7 +10138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-30"
+                      htmlFor="bx-pagination-select-31"
                     >
                       Page number, of 2 pages
                     </label>
@@ -10151,7 +10151,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30"
+                          id="bx-pagination-select-31"
                           onChange={[Function]}
                           value={1}
                         >
@@ -10423,58 +10423,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -10488,15 +10452,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -11600,8 +11600,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-19"
-                  id="bx-pagination-select-19-count-label"
+                  htmlFor="bx-pagination-select-20"
+                  id="bx-pagination-select-20-count-label"
                 >
                   Items per page:
                 </label>
@@ -11620,7 +11620,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-19"
+                          id="bx-pagination-select-20"
                           onChange={[Function]}
                           value={10}
                         >
@@ -11693,7 +11693,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-21"
+                      htmlFor="bx-pagination-select-22"
                     >
                       Page number, of 2 pages
                     </label>
@@ -11706,7 +11706,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-21"
+                          id="bx-pagination-select-22"
                           onChange={[Function]}
                           value={1}
                         >
@@ -11978,58 +11978,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -12043,15 +12007,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -13156,8 +13156,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-25"
-                  id="bx-pagination-select-25-count-label"
+                  htmlFor="bx-pagination-select-26"
+                  id="bx-pagination-select-26-count-label"
                 >
                   Items per page:
                 </label>
@@ -13176,7 +13176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13249,7 +13249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-27"
+                      htmlFor="bx-pagination-select-28"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13262,7 +13262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={1}
                         >
@@ -13567,58 +13567,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -13632,15 +13596,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -14490,8 +14490,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-26"
-                  id="bx-pagination-select-26-count-label"
+                  htmlFor="bx-pagination-select-27"
+                  id="bx-pagination-select-27-count-label"
                 >
                   Items per page:
                 </label>
@@ -14510,7 +14510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={10}
                         >
@@ -14583,7 +14583,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-28"
+                      htmlFor="bx-pagination-select-29"
                     >
                       Page number, of 2 pages
                     </label>
@@ -14596,7 +14596,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={1}
                         >
@@ -14901,58 +14901,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -14966,15 +14930,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -16432,8 +16432,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-20"
-                  id="bx-pagination-select-20-count-label"
+                  htmlFor="bx-pagination-select-21"
+                  id="bx-pagination-select-21-count-label"
                 >
                   Items per page:
                 </label>
@@ -16452,7 +16452,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-20"
+                          id="bx-pagination-select-21"
                           onChange={[Function]}
                           value={10}
                         >
@@ -16525,7 +16525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-22"
+                      htmlFor="bx-pagination-select-23"
                     >
                       Page number, of 2 pages
                     </label>
@@ -16538,7 +16538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-22"
+                          id="bx-pagination-select-23"
                           onChange={[Function]}
                           value={1}
                         >
@@ -16843,58 +16843,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -16908,15 +16872,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -18130,8 +18130,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-27"
-                  id="bx-pagination-select-27-count-label"
+                  htmlFor="bx-pagination-select-28"
+                  id="bx-pagination-select-28-count-label"
                 >
                   Items per page:
                 </label>
@@ -18150,7 +18150,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={10}
                         >
@@ -18223,7 +18223,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-29"
+                      htmlFor="bx-pagination-select-30"
                     >
                       Page number, of 2 pages
                     </label>
@@ -18236,7 +18236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29"
+                          id="bx-pagination-select-30"
                           onChange={[Function]}
                           value={1}
                         >
@@ -18541,58 +18541,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -18606,15 +18570,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -19792,8 +19792,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-21"
-                  id="bx-pagination-select-21-count-label"
+                  htmlFor="bx-pagination-select-22"
+                  id="bx-pagination-select-22-count-label"
                 >
                   Items per page:
                 </label>
@@ -19812,7 +19812,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-21"
+                          id="bx-pagination-select-22"
                           onChange={[Function]}
                           value={10}
                         >
@@ -19885,7 +19885,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-23"
+                      htmlFor="bx-pagination-select-24"
                     >
                       Page number, of 2 pages
                     </label>
@@ -19898,7 +19898,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23"
+                          id="bx-pagination-select-24"
                           onChange={[Function]}
                           value={1}
                         >
@@ -20170,58 +20170,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -20235,15 +20199,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -22195,8 +22195,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-23"
-                  id="bx-pagination-select-23-count-label"
+                  htmlFor="bx-pagination-select-24"
+                  id="bx-pagination-select-24-count-label"
                 >
                   Items per page:
                 </label>
@@ -22215,7 +22215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23"
+                          id="bx-pagination-select-24"
                           onChange={[Function]}
                           value={10}
                         >
@@ -22288,7 +22288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-25"
+                      htmlFor="bx-pagination-select-26"
                     >
                       Page number, of 2 pages
                     </label>
@@ -22301,7 +22301,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={1}
                         >
@@ -22573,58 +22573,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -22638,15 +22602,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -23512,8 +23512,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-24"
-                  id="bx-pagination-select-24-count-label"
+                  htmlFor="bx-pagination-select-25"
+                  id="bx-pagination-select-25-count-label"
                 >
                   Items per page:
                 </label>
@@ -23532,7 +23532,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={10}
                         >
@@ -23605,7 +23605,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-26"
+                      htmlFor="bx-pagination-select-27"
                     >
                       Page number, of 1 pages
                     </label>
@@ -23618,7 +23618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={1}
                         >
@@ -23882,58 +23882,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -23947,15 +23911,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -26271,8 +26271,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-22"
-                  id="bx-pagination-select-22-count-label"
+                  htmlFor="bx-pagination-select-23"
+                  id="bx-pagination-select-23-count-label"
                 >
                   Items per page:
                 </label>
@@ -26291,7 +26291,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-22"
+                          id="bx-pagination-select-23"
                           onChange={[Function]}
                           value={10}
                         >
@@ -26364,7 +26364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-24"
+                      htmlFor="bx-pagination-select-25"
                     >
                       Page number, of 2 pages
                     </label>
@@ -26377,7 +26377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={1}
                         >
@@ -26682,58 +26682,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -26747,15 +26711,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -28574,8 +28574,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-32"
-                  id="bx-pagination-select-32-count-label"
+                  htmlFor="bx-pagination-select-33"
+                  id="bx-pagination-select-33-count-label"
                 >
                   Items per page:
                 </label>
@@ -28594,7 +28594,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-33"
                           onChange={[Function]}
                           value={10}
                         >
@@ -28667,7 +28667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-34"
+                      htmlFor="bx-pagination-select-35"
                     >
                       Page number, of 2 pages
                     </label>
@@ -28680,7 +28680,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34"
+                          id="bx-pagination-select-35"
                           onChange={[Function]}
                           value={1}
                         >


### PR DESCRIPTION
#689

Closes #

**Summary**

1. Right align the search icon and toggle open when clicked to display a search component. 
2. Show table row count and should be appear on the left. i.e "Results: X", where X is equal to the number of rows in the table.
This field (Row count) should be configuration via boolean property and Result Label should allow to change. 

**Change List (commits, features, bugs, etc)**

src/components/DataTable/_data-table.scss
src/components/Table/Table.jsx
src/components/Table/Table.story.jsx
src/components/Table/TableToolbar/TableToolbar.jsx
src/components/Table/__snapshots__/Table.story.storyshot
src/components/TableCard/__snapshots__/TableCard.story.storyshot
src/components/Dashboard/__snapshots__/Dashboard.story.storyshot

**Acceptance Test (how to verify the PR)**

Two fields are provided in Know to test.
 Show row count checkbox use to display and hide Row count field
 Row count label input field will be using to change the row count label value.
![TableToolbar](https://user-images.githubusercontent.com/56038154/68304637-2c03db00-00cc-11ea-8968-945b11315974.png)

