### PR TITLE
feat(table): 3287-Table-SearhIcon-align-Row-Count

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -948,59 +948,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -1014,15 +977,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -1884,7 +1884,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
             >
               Last updated: 
                
-              Tue, 22 Oct 2019 05:00:00 GMT
+              Mon, 21 Oct 2019 18:30:00 GMT
             </div>
           </div>
           <div
@@ -2797,59 +2797,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -2863,15 +2826,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -3733,7 +3733,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
             >
               Last updated: 
                
-              Tue, 22 Oct 2019 05:00:00 GMT
+              Mon, 21 Oct 2019 18:30:00 GMT
             </div>
           </div>
           <div
@@ -4678,59 +4678,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -4744,15 +4707,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -6071,59 +6071,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -6137,15 +6100,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -7799,7 +7799,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
             >
               Last updated: 
                
-              Tue, 22 Oct 2019 05:00:00 GMT
+              Mon, 21 Oct 2019 18:30:00 GMT
             </div>
           </div>
           <div
@@ -8712,59 +8712,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -8778,15 +8741,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}
@@ -20049,7 +20049,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
             >
               Last updated: 
                
-              Tue, 22 Oct 2019 05:00:00 GMT
+              Mon, 21 Oct 2019 18:30:00 GMT
             </div>
           </div>
           <div
@@ -20987,59 +20987,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                         </div>
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          role="searchbox"
-                          tabIndex="0"
+                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
                         >
                           <div
-                            className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="searchbox"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -21053,15 +21016,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onChange={[Function]}
+                                placeholder="Search"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
-                        </div>
-                        <div
-                          className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-                        >
                           <button
                             className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                             disabled={false}

--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -78,3 +78,10 @@ html[dir='rtl'] {
 .#{$prefix}--toolbar-search-container-active .#{$prefix}--search .#{$prefix}--search-input {
   padding-right: $spacing-09;
 }
+
+.row-count-header {
+  display: flex;
+  position: relative;
+  height: $spacing-09;
+  padding: $spacing-05;
+}

--- a/src/components/DataTable/_data-table.scss
+++ b/src/components/DataTable/_data-table.scss
@@ -75,3 +75,6 @@ html[dir='rtl'] {
     padding-right: $spacing-04;
   }
 }
+.#{$prefix}--toolbar-search-container-active .#{$prefix}--search .#{$prefix}--search-input {
+  padding-right: $spacing-09;
+}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -269,8 +269,7 @@ export const defaultProps = baseProps => ({
     batchCancel: 'Cancel',
     itemsSelected: 'items selected',
     itemSelected: 'item selected',
-    rowCountLabel: 'Results',
-    rowCountInHeader: (totalRowCount, rowCountLabel) => `${rowCountLabel}: ${totalRowCount}`,
+    rowCountInHeader: totalRowCount => `Results: ${totalRowCount}`,
     /** empty state */
     emptyMessage: 'There is no data',
     emptyMessageWithFilters: 'No results match the current filters',

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -349,10 +349,8 @@ const Table = props => {
           filterNone: i18n.filterNone,
           filterAscending: i18n.filterAscending,
           filterDescending: i18n.filterDescending,
-          rowCountHeaderField: i18n.rowCountInHeader(
-            view.pagination.totalItems,
-            i18n.rowCountLabel
-          ),
+          rowCountLabel: i18n.rowCountLabel,
+          rowCountInHeader: i18n.rowCountInHeader,
         }}
         actions={pick(
           actions.toolbar,
@@ -374,6 +372,7 @@ const Table = props => {
         tableState={{
           totalSelected: view.table.selectedIds.length,
           totalFilters: view.filters ? view.filters.length : 0,
+          totalItemsCount: view.pagination.totalItems,
           ...pick(
             view.toolbar,
             'batchActions',

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -84,6 +84,7 @@ const propTypes = {
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
     shouldLazyRender: PropTypes.bool,
+    hasRowCount: PropTypes.bool,
   }),
 
   /** Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux see StatefulTable component for an example */
@@ -346,6 +347,7 @@ const Table = props => {
           filterNone: i18n.filterNone,
           filterAscending: i18n.filterAscending,
           filterDescending: i18n.filterDescending,
+          rowCountLabel: i18n.rowCountLabel,
         }}
         actions={pick(
           actions.toolbar,
@@ -356,10 +358,18 @@ const Table = props => {
           'onToggleFilter',
           'onApplySearch'
         )}
-        options={pick(options, 'hasColumnSelection', 'hasFilter', 'hasSearch', 'hasRowSelection')}
+        options={pick(
+          options,
+          'hasColumnSelection',
+          'hasFilter',
+          'hasSearch',
+          'hasRowSelection',
+          'hasRowCount'
+        )}
         tableState={{
           totalSelected: view.table.selectedIds.length,
           totalFilters: view.filters ? view.filters.length : 0,
+          totalItemsCount: view.pagination.totalItems,
           ...pick(
             view.toolbar,
             'batchActions',

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -84,7 +84,7 @@ const propTypes = {
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
     shouldLazyRender: PropTypes.bool,
-    hasRowCount: PropTypes.bool,
+    hasRowCountInHeader: PropTypes.bool,
   }),
 
   /** Initial state of the table, should be updated via a local state wrapper component implementation or via a central store/redux see StatefulTable component for an example */
@@ -269,6 +269,8 @@ export const defaultProps = baseProps => ({
     batchCancel: 'Cancel',
     itemsSelected: 'items selected',
     itemSelected: 'item selected',
+    rowCountLabel: 'Results',
+    rowCountInHeader: (totalRowCount, rowCountLabel) => `${rowCountLabel}: ${totalRowCount}`,
     /** empty state */
     emptyMessage: 'There is no data',
     emptyMessageWithFilters: 'No results match the current filters',
@@ -347,7 +349,10 @@ const Table = props => {
           filterNone: i18n.filterNone,
           filterAscending: i18n.filterAscending,
           filterDescending: i18n.filterDescending,
-          rowCountLabel: i18n.rowCountLabel,
+          rowCountHeaderField: i18n.rowCountInHeader(
+            view.pagination.totalItems,
+            i18n.rowCountLabel
+          ),
         }}
         actions={pick(
           actions.toolbar,
@@ -364,12 +369,11 @@ const Table = props => {
           'hasFilter',
           'hasSearch',
           'hasRowSelection',
-          'hasRowCount'
+          'hasRowCountInHeader'
         )}
         tableState={{
           totalSelected: view.table.selectedIds.length,
           totalFilters: view.filters ? view.filters.length : 0,
-          totalItemsCount: view.pagination.totalItems,
           ...pick(
             view.toolbar,
             'batchActions',

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -433,12 +433,12 @@ storiesOf('Watson IoT|Table', module)
       <StatefulTable
         {...initialState}
         options={{
-          hasSearch: true,
-          hasPagination: true,
+          hasSearch: boolean('Show Search', true),
+          hasPagination: boolean('Show Pagination', true),
           hasRowSelection: 'multi',
-          hasFilter: true,
-          hasRowActions: true,
-          hasRowCount: boolean('Show Row Count', true),
+          hasFilter: boolean('Show Filter', true),
+          hasRowActions: boolean('Show Row Action', true),
+          hasRowCountInHeader: boolean('Show Row Count', true),
         }}
         view={{
           toolbar: { activeBar: null },

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -444,7 +444,8 @@ storiesOf('Watson IoT|Table', module)
           toolbar: { activeBar: null },
         }}
         i18n={{
-          rowCountLabel: text('Row Count Label', 'Results'),
+          rowCountInHeader: totalRowCount =>
+            `${text('Row Count Label', 'Results')} : ${totalRowCount}`,
         }}
       />
     </FullWidthWrapper>

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -428,6 +428,27 @@ storiesOf('Watson IoT|Table', module)
       },
     }
   )
+  .add('Stateful Example with Row Count', () => (
+    <FullWidthWrapper>
+      <StatefulTable
+        {...initialState}
+        options={{
+          hasSearch: true,
+          hasPagination: true,
+          hasRowSelection: 'multi',
+          hasFilter: true,
+          hasRowActions: true,
+          hasRowCount: boolean('Show Row Count', true),
+        }}
+        view={{
+          toolbar: { activeBar: null },
+        }}
+        i18n={{
+          rowCountLabel: text('Row Count Label', 'Results'),
+        }}
+      />
+    </FullWidthWrapper>
+  ))
   .add(
     'Stateful Example with every third row unselectable',
     () => (

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -233,13 +233,12 @@ describe('Table', () => {
       />
     );
 
-    const resultLabel = 'Results';
     const rowCounts = view.pagination.totalItems;
     const renderRowCountField = wrapper
       .find('Table')
       .at(0)
       .props()
-      .i18n.rowCountInHeader(rowCounts, resultLabel);
+      .i18n.rowCountInHeader(rowCounts);
     expect(renderRowCountField).toContain('Results:');
 
     const min = 1;

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -116,6 +116,7 @@ describe('Table', () => {
 
   const options = {
     hasRowExpansion: true,
+    hasRowCountInHeader: true,
   };
 
   const view = {
@@ -219,5 +220,35 @@ describe('Table', () => {
     emptyTable.find('button').simulate('click');
     expect(mockActions.toolbar.onApplySearch).toHaveBeenCalled();
     expect(mockActions.toolbar.onClearAllFilters).toHaveBeenCalled();
+  });
+
+  test('validate row count function ', () => {
+    const wrapper = mount(
+      <Table
+        columns={tableColumns}
+        data={tableData}
+        actions={mockActions}
+        options={options}
+        view={view}
+      />
+    );
+
+    const resultLabel = 'Results';
+    const rowCounts = view.pagination.totalItems;
+    const renderRowCountField = wrapper
+      .find('Table')
+      .at(0)
+      .props()
+      .i18n.rowCountInHeader(rowCounts, resultLabel);
+    expect(renderRowCountField).toContain('Results:');
+
+    const min = 1;
+    const max = 10;
+    const renderItemRangeField = wrapper
+      .find('Table')
+      .at(0)
+      .props()
+      .i18n.itemsRange(min, max);
+    expect(renderItemRangeField).toContain('items');
   });
 });

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -158,6 +158,8 @@ export const I18NPropTypes = PropTypes.shape({
   filterNone: PropTypes.string,
   filterAscending: PropTypes.string,
   filterDescending: PropTypes.string,
+  rowCountLabel: PropTypes.string,
+  rowCountInHeader: PropTypes.func,
 });
 
 export const defaultI18NPropTypes = {
@@ -199,6 +201,7 @@ export const defaultI18NPropTypes = {
   filterAscending: 'Sort rows by this header in ascending order',
   filterDescending: 'Sort rows by this header in descending order',
   rowCountLabel: 'Results',
+  rowCountInHeader: (totalRowCount, rowCountLabel) => `${rowCountLabel}: ${totalRowCount}`,
 };
 
 export const TableSearchPropTypes = PropTypes.shape({

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -158,7 +158,6 @@ export const I18NPropTypes = PropTypes.shape({
   filterNone: PropTypes.string,
   filterAscending: PropTypes.string,
   filterDescending: PropTypes.string,
-  rowCountLabel: PropTypes.string,
   rowCountInHeader: PropTypes.func,
 });
 
@@ -200,7 +199,6 @@ export const defaultI18NPropTypes = {
   filterNone: 'Unsort rows by this header',
   filterAscending: 'Sort rows by this header in ascending order',
   filterDescending: 'Sort rows by this header in descending order',
-  rowCountLabel: 'Results',
   rowCountInHeader: (totalRowCount, rowCountLabel) => `${rowCountLabel}: ${totalRowCount}`,
 };
 

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -199,7 +199,7 @@ export const defaultI18NPropTypes = {
   filterNone: 'Unsort rows by this header',
   filterAscending: 'Sort rows by this header in ascending order',
   filterDescending: 'Sort rows by this header in descending order',
-  rowCountInHeader: (totalRowCount, rowCountLabel) => `${rowCountLabel}: ${totalRowCount}`,
+  rowCountInHeader: totalRowCount => `Results: ${totalRowCount}`,
 };
 
 export const TableSearchPropTypes = PropTypes.shape({

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -198,6 +198,7 @@ export const defaultI18NPropTypes = {
   filterNone: 'Unsort rows by this header',
   filterAscending: 'Sort rows by this header in ascending order',
   filterDescending: 'Sort rows by this header in descending order',
+  rowCountLabel: 'Results',
 };
 
 export const TableSearchPropTypes = PropTypes.shape({

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -70,6 +70,14 @@ const StyledTableBatchActions = styled(TableBatchActions)`
   }
 `;
 
+const ToolBarResultLabel = styled.label`
+  &&& {
+    display: flex;
+    position: relative;
+    height: 3rem;
+    padding: 1rem;
+  }
+`;
 const propTypes = {
   /** id of table */
   tableId: PropTypes.string.isRequired,
@@ -78,6 +86,7 @@ const propTypes = {
     hasFilter: PropTypes.bool,
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
+    hasRowCount: PropTypes.bool,
   }).isRequired,
 
   /** internationalized labels */
@@ -93,6 +102,7 @@ const propTypes = {
     filterNone: PropTypes.string,
     filterAscending: PropTypes.string,
     filterDescending: PropTypes.string,
+    rowCountLabel: PropTypes.string,
   }),
   /**
    * Action callbacks to update tableState
@@ -141,7 +151,7 @@ const TableToolbar = ({
   tableId,
   className,
   i18n,
-  options: { hasColumnSelection, hasFilter, hasSearch, hasRowSelection },
+  options: { hasColumnSelection, hasFilter, hasSearch, hasRowSelection, hasRowCount },
   actions: {
     onCancelBatchAction,
     onApplyBatchAction,
@@ -158,6 +168,7 @@ const TableToolbar = ({
     // activeBar,
     customToolbarContent,
     isDisabled,
+    totalItemsCount,
   },
 }) => (
   <StyledCarbonTableToolbar className={className}>
@@ -173,16 +184,21 @@ const TableToolbar = ({
         </TableBatchAction>
       ))}
     </StyledTableBatchActions>
-    {hasSearch ? (
-      <StyledToolbarSearch
-        {...search}
-        translateWithId={(...args) => tableTranslateWithId(i18n, ...args)}
-        id={`${tableId}-toolbar-search`}
-        onChange={event => onApplySearch(event.currentTarget ? event.currentTarget.value : '')}
-        disabled={isDisabled}
-      />
+    {hasRowCount ? (
+      <ToolBarResultLabel>
+        {i18n.rowCountLabel}: {totalItemsCount}
+      </ToolBarResultLabel>
     ) : null}
     <StyledTableToolbarContent>
+      {hasSearch ? (
+        <StyledToolbarSearch
+          {...search}
+          translateWithId={(...args) => tableTranslateWithId(i18n, ...args)}
+          id={`${tableId}-toolbar-search`}
+          onChange={event => onApplySearch(event.currentTarget ? event.currentTarget.value : '')}
+          disabled={isDisabled}
+        />
+      ) : null}
       {customToolbarContent || null}
       {totalFilters > 0 ? (
         <Button kind="secondary" onClick={onClearAllFilters}>

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -70,14 +70,6 @@ const StyledTableBatchActions = styled(TableBatchActions)`
   }
 `;
 
-const ToolBarResultLabel = styled.label`
-  &&& {
-    display: flex;
-    position: relative;
-    height: 3rem;
-    padding: 1rem;
-  }
-`;
 const propTypes = {
   /** id of table */
   tableId: PropTypes.string.isRequired,
@@ -86,7 +78,7 @@ const propTypes = {
     hasFilter: PropTypes.bool,
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
-    hasRowCount: PropTypes.bool,
+    hasRowCountInHeader: PropTypes.bool,
   }).isRequired,
 
   /** internationalized labels */
@@ -151,7 +143,7 @@ const TableToolbar = ({
   tableId,
   className,
   i18n,
-  options: { hasColumnSelection, hasFilter, hasSearch, hasRowSelection, hasRowCount },
+  options: { hasColumnSelection, hasFilter, hasSearch, hasRowSelection, hasRowCountInHeader },
   actions: {
     onCancelBatchAction,
     onApplyBatchAction,
@@ -168,7 +160,6 @@ const TableToolbar = ({
     // activeBar,
     customToolbarContent,
     isDisabled,
-    totalItemsCount,
   },
 }) => (
   <StyledCarbonTableToolbar className={className}>
@@ -184,10 +175,13 @@ const TableToolbar = ({
         </TableBatchAction>
       ))}
     </StyledTableBatchActions>
-    {hasRowCount ? (
-      <ToolBarResultLabel>
-        {i18n.rowCountLabel}: {totalItemsCount}
-      </ToolBarResultLabel>
+
+    {hasRowCountInHeader ? (
+      <label // eslint-disable-line
+        className="row-count-header"
+      >
+        {i18n.rowCountHeaderField}
+      </label>
     ) : null}
     <StyledTableToolbarContent>
       {hasSearch ? (

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -94,7 +94,6 @@ const propTypes = {
     filterNone: PropTypes.string,
     filterAscending: PropTypes.string,
     filterDescending: PropTypes.string,
-    rowCountLabel: PropTypes.string,
   }),
   /**
    * Action callbacks to update tableState
@@ -116,6 +115,7 @@ const propTypes = {
     activeBar: PropTypes.oneOf(['column', 'filter']),
     /** total number of selected rows */
     totalSelected: PropTypes.number,
+    totalItemsCount: PropTypes.number,
     /** row selection option */
     hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
     /** optional content to render inside the toolbar  */
@@ -160,6 +160,7 @@ const TableToolbar = ({
     // activeBar,
     customToolbarContent,
     isDisabled,
+    totalItemsCount,
   },
 }) => (
   <StyledCarbonTableToolbar className={className}>
@@ -180,7 +181,7 @@ const TableToolbar = ({
       <label // eslint-disable-line
         className="row-count-header"
       >
-        {i18n.rowCountHeaderField}
+        {i18n.rowCountInHeader(totalItemsCount, i18n.rowCountLabel)}
       </label>
     ) : null}
     <StyledTableToolbarContent>

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -181,7 +181,7 @@ const TableToolbar = ({
       <label // eslint-disable-line
         className="row-count-header"
       >
-        {i18n.rowCountInHeader(totalItemsCount, i18n.rowCountLabel)}
+        {i18n.rowCountInHeader(totalItemsCount)}
       </label>
     ) : null}
     <StyledTableToolbarContent>

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -85,59 +85,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    disabled={true}
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -151,1308 +114,52 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
-                <button
-                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </section>
-            <table
-              className="bx--data-table bx--data-table--no-border"
-            >
-              <thead
-                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
-              >
-                <tr>
-                  <th
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
-                      data-column="alert"
-                      id="column-alert"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Alert"
-                        >
-                          Alert
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="hour"
-                      id="column-hour"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Hour"
-                        >
-                          Hour
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="pressure"
-                      id="column-pressure"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Pressure"
-                        >
-                          Pressure
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                aria-live="polite"
-              >
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-0-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-0-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-0-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-1-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-1-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-1-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-2-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-2-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-2-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-4-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-4-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-4-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-5-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-5-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-5-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-6-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-6-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-6-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-7-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-7-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-7-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-8-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-8-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-8-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-9-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-9-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="hh:mm:ss"
-                      >
-                        hh:mm:ss
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-sample-values-table-list-9-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="--"
-                      >
-                        --
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
-              disabled={false}
-              size={
-                Object {
-                  "height": undefined,
-                  "position": undefined,
-                  "width": undefined,
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-30"
-                  id="bx-pagination-select-30-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-30"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={20}
-                          >
-                            20
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={30}
-                          >
-                            30
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 10 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
                     <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-32"
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
                     >
-                      Page number, of 1 pages
+                      Search
                     </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      disabled={true}
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-32"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
                           }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
                   </div>
                 </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 1 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23l-8-7 8-7v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9l8 7-8 7V9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard editable with expanded rows 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "flexDirection": "column",
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 kGdXdI"
-        id="table-list"
-      >
-        <div
-          className="card--header"
-        >
-          <span
-            className="card--title"
-            title="Open Alerts"
-          >
-            Open Alerts
-             
-          </span>
-          <div
-            className="bx--toolbar card--toolbar"
-          />
-        </div>
-        <div
-          className="Card__CardContent-v5r71h-1 fabdLf"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
-              >
-                <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    disabled={true}
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -1516,10 +223,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
               >
                 <tr>
-                  <th
-                    className="bx--table-expand"
-                    scope="col"
-                  />
                   <th
                     className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
                     scope="col"
@@ -1717,45 +420,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 aria-live="polite"
               >
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -1815,45 +482,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -1913,45 +544,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2011,45 +606,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2109,45 +668,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2207,45 +730,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2305,45 +792,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2403,45 +854,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2501,45 +916,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2599,45 +978,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   </td>
                 </tr>
                 <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 iSXVEC"
                   onClick={[Function]}
                 >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
                   <td
                     align="start"
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
@@ -2950,6 +1293,1663 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard editable with expanded rows 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 kGdXdI"
+        id="table-list"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Open Alerts"
+          >
+            Open Alerts
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          />
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 fabdLf"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
+                >
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      disabled={true}
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </section>
+            <table
+              className="bx--data-table bx--data-table--no-border"
+            >
+              <thead
+                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
+              >
+                <tr>
+                  <th
+                    className="bx--table-expand"
+                    scope="col"
+                  />
+                  <th
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
+                      data-column="alert"
+                      id="column-alert"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Alert"
+                        >
+                          Alert
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="hour"
+                      id="column-hour"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Hour"
+                        >
+                          Hour
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="pressure"
+                      id="column-pressure"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Pressure"
+                        >
+                          Pressure
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                aria-live="polite"
+              >
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-0-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-0-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-0-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-1-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-1-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-1-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-2-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-2-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-2-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-4-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-4-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-4-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-5-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-5-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-5-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-6-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-6-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-6-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-7-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-7-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-7-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-8-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-8-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-8-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-9-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-9-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="hh:mm:ss"
+                      >
+                        hh:mm:ss
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-sample-values-table-list-9-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="--"
+                      >
+                        --
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
+              disabled={false}
+              size={
+                Object {
+                  "height": undefined,
+                  "position": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-32"
+                  id="bx-pagination-select-32-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-32"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={20}
+                          >
+                            20
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={30}
+                          >
+                            30
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 10 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-34"
+                    >
+                      Page number, of 1 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-34"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 1 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23l-8-7 8-7v14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9l8 7-8 7V9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard empty table 1`] = `
 <div
   className="storybook-container"
@@ -3117,58 +3117,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -3182,15 +3146,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -3651,58 +3651,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -3716,15 +3680,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -4185,107 +4185,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-11-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-11-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={5}
-                      >
-                        5
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width=""
@@ -4417,6 +4316,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-11-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-11-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={5}
+                      >
+                        5
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -4876,6 +4876,205 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="count < 5"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <circle
+                                cx="8"
+                                cy="8"
+                                fill="#FDD13A"
+                                id="background-color"
+                                r="7"
+                              />
+                              <path
+                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                fill="#FFFFFF"
+                                id="symbol-color"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Low
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-3-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={3}
+                      >
+                        3
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="pressure >= 10"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -5271,205 +5470,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="count < 5"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <circle
-                                cx="8"
-                                cy="8"
-                                fill="#FDD13A"
-                                id="background-color"
-                                r="7"
-                              />
-                              <path
-                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                fill="#FFFFFF"
-                                id="symbol-color"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Low
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-3-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={3}
-                      >
-                        3
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="pressure >= 10"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -5676,8 +5676,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-33"
-                  id="bx-pagination-select-33-count-label"
+                  htmlFor="bx-pagination-select-34"
+                  id="bx-pagination-select-34-count-label"
                 >
                   Items per page:
                 </label>
@@ -5696,7 +5696,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33"
+                          id="bx-pagination-select-34"
                           onChange={[Function]}
                           value={10}
                         >
@@ -5769,7 +5769,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-35"
+                      htmlFor="bx-pagination-select-36"
                     >
                       Page number, of 2 pages
                     </label>
@@ -5782,7 +5782,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-35"
+                          id="bx-pagination-select-36"
                           onChange={[Function]}
                           value={1}
                         >
@@ -6087,58 +6087,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -6152,15 +6116,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -6429,62 +6429,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width=""
@@ -6524,6 +6468,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -6709,6 +6709,68 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -6877,68 +6939,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -7010,8 +7010,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-29"
-                  id="bx-pagination-select-29-count-label"
+                  htmlFor="bx-pagination-select-30"
+                  id="bx-pagination-select-30-count-label"
                 >
                   Items per page:
                 </label>
@@ -7030,7 +7030,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29"
+                          id="bx-pagination-select-30"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7103,7 +7103,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-31"
+                      htmlFor="bx-pagination-select-32"
                     >
                       Page number, of 2 pages
                     </label>
@@ -7116,7 +7116,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
+                          id="bx-pagination-select-32"
                           onChange={[Function]}
                           value={1}
                         >
@@ -7421,58 +7421,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -7486,15 +7450,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -7764,62 +7764,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width=""
@@ -7859,6 +7803,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -8044,6 +8044,68 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -8212,68 +8274,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -8345,8 +8345,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-17"
-                  id="bx-pagination-select-17-count-label"
+                  htmlFor="bx-pagination-select-18"
+                  id="bx-pagination-select-18-count-label"
                 >
                   Items per page:
                 </label>
@@ -8365,7 +8365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-17"
+                          id="bx-pagination-select-18"
                           onChange={[Function]}
                           value={10}
                         >
@@ -8438,7 +8438,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-19"
+                      htmlFor="bx-pagination-select-20"
                     >
                       Page number, of 2 pages
                     </label>
@@ -8451,7 +8451,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-19"
+                          id="bx-pagination-select-20"
                           onChange={[Function]}
                           value={1}
                         >
@@ -8756,58 +8756,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -8821,15 +8785,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -8946,7 +8946,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
+                    id="cell-Table-row-10-alert"
                     offset={0}
                     width="150px"
                   >
@@ -8970,7 +8970,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-10-alert"
+                    id="cell-Table-row-11-alert"
                     offset={0}
                     width="150px"
                   >
@@ -9066,6 +9066,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width="150px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width="150px"
@@ -9138,30 +9162,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width="150px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width="150px"
@@ -9195,8 +9195,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-18"
-                  id="bx-pagination-select-18-count-label"
+                  htmlFor="bx-pagination-select-19"
+                  id="bx-pagination-select-19-count-label"
                 >
                   Items per page:
                 </label>
@@ -9215,7 +9215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-18"
+                          id="bx-pagination-select-19"
                           onChange={[Function]}
                           value={10}
                         >
@@ -9288,7 +9288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-20"
+                      htmlFor="bx-pagination-select-21"
                     >
                       Page number, of 2 pages
                     </label>
@@ -9301,7 +9301,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-20"
+                          id="bx-pagination-select-21"
                           onChange={[Function]}
                           value={1}
                         >
@@ -9606,58 +9606,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -9671,15 +9635,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -9796,7 +9796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
+                    id="cell-Table-row-10-alert"
                     offset={0}
                     width="150px"
                   >
@@ -9820,7 +9820,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-10-alert"
+                    id="cell-Table-row-11-alert"
                     offset={0}
                     width="150px"
                   >
@@ -9916,6 +9916,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width="150px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width="150px"
@@ -9988,30 +10012,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width="150px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 hxltNH"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width="150px"
@@ -10045,8 +10045,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-28"
-                  id="bx-pagination-select-28-count-label"
+                  htmlFor="bx-pagination-select-29"
+                  id="bx-pagination-select-29-count-label"
                 >
                   Items per page:
                 </label>
@@ -10065,7 +10065,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={10}
                         >
@@ -10138,7 +10138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-30"
+                      htmlFor="bx-pagination-select-31"
                     >
                       Page number, of 2 pages
                     </label>
@@ -10151,7 +10151,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30"
+                          id="bx-pagination-select-31"
                           onChange={[Function]}
                           value={1}
                         >
@@ -10423,58 +10423,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -10488,15 +10452,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -10829,81 +10829,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-11-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={5}
-                      >
-                        5
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width=""
@@ -10962,6 +10887,81 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-11-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={5}
+                      >
+                        5
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -11204,6 +11204,87 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-3-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={3}
+                      >
+                        3
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -11429,87 +11510,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-3-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={3}
-                      >
-                        3
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -11600,8 +11600,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-19"
-                  id="bx-pagination-select-19-count-label"
+                  htmlFor="bx-pagination-select-20"
+                  id="bx-pagination-select-20-count-label"
                 >
                   Items per page:
                 </label>
@@ -11620,7 +11620,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-19"
+                          id="bx-pagination-select-20"
                           onChange={[Function]}
                           value={10}
                         >
@@ -11693,7 +11693,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-21"
+                      htmlFor="bx-pagination-select-22"
                     >
                       Page number, of 2 pages
                     </label>
@@ -11706,7 +11706,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-21"
+                          id="bx-pagination-select-22"
                           onChange={[Function]}
                           value={1}
                         >
@@ -11978,58 +11978,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -12043,15 +12007,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -12691,81 +12691,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-11-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={5}
-                      >
-                        5
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -12824,6 +12749,81 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-4-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-11-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={5}
+                      >
+                        5
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -13156,8 +13156,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-25"
-                  id="bx-pagination-select-25-count-label"
+                  htmlFor="bx-pagination-select-26"
+                  id="bx-pagination-select-26-count-label"
                 >
                   Items per page:
                 </label>
@@ -13176,7 +13176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13249,7 +13249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-27"
+                      htmlFor="bx-pagination-select-28"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13262,7 +13262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={1}
                         >
@@ -13567,58 +13567,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -13632,15 +13596,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -13909,62 +13909,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 feiOhV"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width="250px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 feiOhV"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width="250px"
@@ -14004,6 +13948,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 feiOhV"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width="250px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -14189,6 +14189,68 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 feiOhV"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width="250px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 feiOhV"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width="250px"
@@ -14357,3711 +14419,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 feiOhV"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width="250px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 feiOhV"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width="250px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize"
-                      >
-                        AHI001 proccess need to optimize
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-5-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-5-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
-              disabled={false}
-              size={
-                Object {
-                  "height": undefined,
-                  "position": undefined,
-                  "width": undefined,
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-26"
-                  id="bx-pagination-select-26-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-26"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={20}
-                          >
-                            20
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={30}
-                          >
-                            30
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-28"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-28"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23l-8-7 8-7v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9l8 7-8 7V9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with multiple actions 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "flexDirection": "column",
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 kGdXdI"
-        id="table-list"
-      >
-        <div
-          className="card--header"
-        >
-          <span
-            className="card--title"
-            title="Open Alerts"
-          >
-            Open Alerts
-             
-          </span>
-          <div
-            className="bx--toolbar card--toolbar"
-          >
-            <span
-              className="card--toolbar-timerange-lable Card__TimeRangeLabel-v5r71h-5 bSwbuP"
-              id="timeRange"
-            />
-            <div
-              aria-expanded={false}
-              aria-haspopup={true}
-              aria-label="Menu"
-              className="card--toolbar-action bx--overflow-menu"
-              onClick={[Function]}
-              onClose={[Function]}
-              onKeyDown={[Function]}
-              open={false}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="open and close list of options"
-                className="bx--overflow-menu__icon"
-                focusable="false"
-                height={20}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                />
-                <path
-                  d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                />
-                <path
-                  d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                />
-                <title>
-                  open and close list of options
-                </title>
-              </svg>
-            </div>
-            <button
-              className="card--toolbar-action Card__TinyButton-v5r71h-4 fggzfz bx--btn bx--btn--sm bx--btn--ghost"
-              disabled={false}
-              onClick={[Function]}
-              tabIndex={0}
-              title="Expand to fullscreen"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                aria-label="Expand to fullscreen"
-                className="bx--btn__icon"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
-                />
-                <path
-                  d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div
-          className="Card__CardContent-v5r71h-1 fabdLf"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
-              >
-                <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
-                <button
-                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </section>
-            <table
-              className="bx--data-table bx--data-table--no-border"
-            >
-              <thead
-                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
-              >
-                <tr>
-                  <th
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
-                      data-column="alert"
-                      id="column-alert"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Alert"
-                        >
-                          Alert
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="hour"
-                      id="column-hour"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Hour"
-                        >
-                          Hour
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="pressure"
-                      id="column-pressure"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Pressure"
-                        >
-                          Pressure
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    align="start"
-                    className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-2 bDukfp"
-                    data-column="actionColumn"
-                    id="column-actionColumn"
-                    scope="col"
-                    width="60px"
-                  >
-                    <span
-                      className="bx--table-header-label"
-                    >
-                      <span
-                        title=""
-                      >
-                        
-                      </span>
-                    </span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                aria-live="polite"
-              >
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-11-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-10-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-10-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-10-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-10-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-1-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI005 Asset failure"
-                      >
-                        AHI005 Asset failure
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-1-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-1-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-1-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-2-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI003 process need to optimize adjust X variables"
-                      >
-                        AHI003 process need to optimize adjust X variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-2-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-2-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-2-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-6-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize."
-                      >
-                        AHI001 proccess need to optimize.
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-6-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-6-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-6-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-4-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-4-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-4-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-4-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-8-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-8-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-8-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-8-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-9-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-9-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-9-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-9-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-3-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-5-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize"
-                      >
-                        AHI001 proccess need to optimize
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-5-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-5-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-5-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        aria-expanded={false}
-                        aria-haspopup={true}
-                        aria-label="Menu"
-                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                        floatingMenu={true}
-                        onClick={[Function]}
-                        onClose={[Function]}
-                        onKeyDown={[Function]}
-                        open={false}
-                        role="button"
-                        tabIndex={0}
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="#5a6872"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle
-                            cx="8"
-                            cy="3"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="8"
-                            r="1"
-                          />
-                          <circle
-                            cx="8"
-                            cy="13"
-                            r="1"
-                          />
-                        </svg>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
-              disabled={false}
-              size={
-                Object {
-                  "height": undefined,
-                  "position": undefined,
-                  "width": undefined,
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-20"
-                  id="bx-pagination-select-20-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-20"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={20}
-                          >
-                            20
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={30}
-                          >
-                            30
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-22"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-22"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23l-8-7 8-7v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9l8 7-8 7V9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with row expansion 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "flexDirection": "column",
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 kGdXdI"
-        id="table-list"
-      >
-        <div
-          className="card--header"
-        >
-          <span
-            className="card--title"
-            title="Open Alerts"
-          >
-            Open Alerts
-             
-          </span>
-          <div
-            className="bx--toolbar card--toolbar"
-          >
-            <span
-              className="card--toolbar-timerange-lable Card__TimeRangeLabel-v5r71h-5 bSwbuP"
-              id="timeRange"
-            />
-            <div
-              aria-expanded={false}
-              aria-haspopup={true}
-              aria-label="Menu"
-              className="card--toolbar-action bx--overflow-menu"
-              onClick={[Function]}
-              onClose={[Function]}
-              onKeyDown={[Function]}
-              open={false}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="open and close list of options"
-                className="bx--overflow-menu__icon"
-                focusable="false"
-                height={20}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                />
-                <path
-                  d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                />
-                <path
-                  d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                />
-                <title>
-                  open and close list of options
-                </title>
-              </svg>
-            </div>
-            <button
-              className="card--toolbar-action Card__TinyButton-v5r71h-4 fggzfz bx--btn bx--btn--sm bx--btn--ghost"
-              disabled={false}
-              onClick={[Function]}
-              tabIndex={0}
-              title="Expand to fullscreen"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                aria-label="Expand to fullscreen"
-                className="bx--btn__icon"
-                focusable="false"
-                height={20}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
-                />
-                <path
-                  d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div
-          className="Card__CardContent-v5r71h-1 fabdLf"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
-              >
-                <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
-                <button
-                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </section>
-            <table
-              className="bx--data-table bx--data-table--no-border"
-            >
-              <thead
-                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
-              >
-                <tr>
-                  <th
-                    className="bx--table-expand"
-                    scope="col"
-                  />
-                  <th
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
-                      data-column="alert"
-                      id="column-alert"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Alert"
-                        >
-                          Alert
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="hour"
-                      id="column-hour"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Hour"
-                        >
-                          Hour
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="pressure"
-                      id="column-pressure"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Pressure"
-                        >
-                          Pressure
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                aria-live="polite"
-              >
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-10-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-10-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-10-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-1-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI005 Asset failure"
-                      >
-                        AHI005 Asset failure
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-1-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-1-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-2-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI003 process need to optimize adjust X variables"
-                      >
-                        AHI003 process need to optimize adjust X variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-2-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-2-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-6-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize."
-                      >
-                        AHI001 proccess need to optimize.
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-6-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-6-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-4-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-4-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-4-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-8-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-8-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-8-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-9-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-9-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-9-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-5-alert"
-                    offset={0}
-                    width=""
                   >
                     <span
                       className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
@@ -18374,7 +14734,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with single actions 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with multiple actions 1`] = `
 <div
   className="storybook-container"
   style={
@@ -18541,58 +14901,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -18606,15 +14930,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -18901,6 +15261,121 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-10-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-10-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-10-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-11-alert"
                     offset={0}
                     width=""
@@ -18959,26 +15434,3464 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     <span
                       className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
                     >
-                      <svg
-                        aria-label="open"
-                        className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                        fillRule="evenodd"
-                        height="16"
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
                         onClick={[Function]}
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
                       >
-                        <title>
-                          open
-                        </title>
-                        <path
-                          d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
                     </span>
                   </td>
                 </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-1-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI005 Asset failure"
+                      >
+                        AHI005 Asset failure
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-1-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-1-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-1-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-2-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI003 process need to optimize adjust X variables"
+                      >
+                        AHI003 process need to optimize adjust X variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-2-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-2-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-2-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-6-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize."
+                      >
+                        AHI001 proccess need to optimize.
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-6-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-6-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-6-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-3-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-4-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-4-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-4-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-4-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-8-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-8-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-8-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-8-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-9-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-9-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-9-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-9-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-5-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize"
+                      >
+                        AHI001 proccess need to optimize
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-5-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-5-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-5-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                        floatingMenu={true}
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#5a6872"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="3"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="8"
+                            r="1"
+                          />
+                          <circle
+                            cx="8"
+                            cy="13"
+                            r="1"
+                          />
+                        </svg>
+                      </div>
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
+              disabled={false}
+              size={
+                Object {
+                  "height": undefined,
+                  "position": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-21"
+                  id="bx-pagination-select-21-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-21"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={20}
+                          >
+                            20
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={30}
+                          >
+                            30
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-23"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-23"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23l-8-7 8-7v14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9l8 7-8 7V9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with row expansion 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 kGdXdI"
+        id="table-list"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Open Alerts"
+          >
+            Open Alerts
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          >
+            <span
+              className="card--toolbar-timerange-lable Card__TimeRangeLabel-v5r71h-5 bSwbuP"
+              id="timeRange"
+            />
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="Menu"
+              className="card--toolbar-action bx--overflow-menu"
+              onClick={[Function]}
+              onClose={[Function]}
+              onKeyDown={[Function]}
+              open={false}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="open and close list of options"
+                className="bx--overflow-menu__icon"
+                focusable="false"
+                height={20}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                />
+                <path
+                  d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                />
+                <path
+                  d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                />
+                <title>
+                  open and close list of options
+                </title>
+              </svg>
+            </div>
+            <button
+              className="card--toolbar-action Card__TinyButton-v5r71h-4 fggzfz bx--btn bx--btn--sm bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              title="Expand to fullscreen"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                aria-label="Expand to fullscreen"
+                className="bx--btn__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                />
+                <path
+                  d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 fabdLf"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
+                >
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </section>
+            <table
+              className="bx--data-table bx--data-table--no-border"
+            >
+              <thead
+                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
+              >
+                <tr>
+                  <th
+                    className="bx--table-expand"
+                    scope="col"
+                  />
+                  <th
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
+                      data-column="alert"
+                      id="column-alert"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Alert"
+                        >
+                          Alert
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="hour"
+                      id="column-hour"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Hour"
+                        >
+                          Hour
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="pressure"
+                      id="column-pressure"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Pressure"
+                        >
+                          Pressure
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                aria-live="polite"
+              >
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-10-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-10-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-1-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI005 Asset failure"
+                      >
+                        AHI005 Asset failure
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-1-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-1-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-2-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI003 process need to optimize adjust X variables"
+                      >
+                        AHI003 process need to optimize adjust X variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-2-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-2-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-6-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize."
+                      >
+                        AHI001 proccess need to optimize.
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-6-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-6-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-4-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-4-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-4-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-8-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-8-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-8-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-9-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-9-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-9-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-5-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize"
+                      >
+                        AHI001 proccess need to optimize
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-5-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-5-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
+              disabled={false}
+              size={
+                Object {
+                  "height": undefined,
+                  "position": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-28"
+                  id="bx-pagination-select-28-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-28"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={20}
+                          >
+                            20
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={30}
+                          >
+                            30
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-30"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-30"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23l-8-7 8-7v14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9l8 7-8 7V9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with single actions 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 kGdXdI"
+        id="table-list"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Open Alerts"
+          >
+            Open Alerts
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          >
+            <span
+              className="card--toolbar-timerange-lable Card__TimeRangeLabel-v5r71h-5 bSwbuP"
+              id="timeRange"
+            />
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="Menu"
+              className="card--toolbar-action bx--overflow-menu"
+              onClick={[Function]}
+              onClose={[Function]}
+              onKeyDown={[Function]}
+              open={false}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="open and close list of options"
+                className="bx--overflow-menu__icon"
+                focusable="false"
+                height={20}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                />
+                <path
+                  d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                />
+                <path
+                  d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                />
+                <title>
+                  open and close list of options
+                </title>
+              </svg>
+            </div>
+            <button
+              className="card--toolbar-action Card__TinyButton-v5r71h-4 fggzfz bx--btn bx--btn--sm bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              title="Expand to fullscreen"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                aria-label="Expand to fullscreen"
+                className="bx--btn__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                />
+                <path
+                  d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 fabdLf"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
+                >
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </section>
+            <table
+              className="bx--data-table bx--data-table--no-border"
+            >
+              <thead
+                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
+              >
+                <tr>
+                  <th
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
+                      data-column="alert"
+                      id="column-alert"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Alert"
+                        >
+                          Alert
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="hour"
+                      id="column-hour"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Hour"
+                        >
+                          Hour
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="pressure"
+                      id="column-pressure"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Pressure"
+                        >
+                          Pressure
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    align="start"
+                    className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-2 bDukfp"
+                    data-column="actionColumn"
+                    id="column-actionColumn"
+                    scope="col"
+                    width="60px"
+                  >
+                    <span
+                      className="bx--table-header-label"
+                    >
+                      <span
+                        title=""
+                      >
+                        
+                      </span>
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                aria-live="polite"
+              >
                 <tr
                   className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
                   onClick={[Function]}
@@ -19040,6 +18953,93 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="actionColumn"
                     data-offset={0}
                     id="cell-Table-row-10-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <svg
+                        aria-label="open"
+                        className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                        fillRule="evenodd"
+                        height="16"
+                        onClick={[Function]}
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                      >
+                        <title>
+                          open
+                        </title>
+                        <path
+                          d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                        />
+                      </svg>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-11-actionColumn"
                     offset={0}
                     width="60px"
                   >
@@ -19336,6 +19336,99 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
+                    data-column="actionColumn"
+                    data-offset={0}
+                    id="cell-Table-row-3-actionColumn"
+                    offset={0}
+                    width="60px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <svg
+                        aria-label="open"
+                        className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                        fillRule="evenodd"
+                        height="16"
+                        onClick={[Function]}
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                      >
+                        <title>
+                          open
+                        </title>
+                        <path
+                          d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                        />
+                      </svg>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -19597,99 +19690,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 iUJbWV"
-                    data-column="actionColumn"
-                    data-offset={0}
-                    id="cell-Table-row-3-actionColumn"
-                    offset={0}
-                    width="60px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <svg
-                        aria-label="open"
-                        className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                        fillRule="evenodd"
-                        height="16"
-                        onClick={[Function]}
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                      >
-                        <title>
-                          open
-                        </title>
-                        <path
-                          d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                        />
-                      </svg>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -19792,8 +19792,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-21"
-                  id="bx-pagination-select-21-count-label"
+                  htmlFor="bx-pagination-select-22"
+                  id="bx-pagination-select-22-count-label"
                 >
                   Items per page:
                 </label>
@@ -19812,7 +19812,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-21"
+                          id="bx-pagination-select-22"
                           onChange={[Function]}
                           value={10}
                         >
@@ -19885,7 +19885,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-23"
+                      htmlFor="bx-pagination-select-24"
                     >
                       Page number, of 2 pages
                     </label>
@@ -19898,7 +19898,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23"
+                          id="bx-pagination-select-24"
                           onChange={[Function]}
                           value={1}
                         >
@@ -20170,58 +20170,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -20235,15 +20199,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -20704,107 +20704,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-11-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-11-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={5}
-                      >
-                        5
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width=""
@@ -20936,6 +20835,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-11-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-11-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={5}
+                      >
+                        5
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -21395,6 +21395,205 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="count < 5"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <circle
+                                cx="8"
+                                cy="8"
+                                fill="#FDD13A"
+                                id="background-color"
+                                r="7"
+                              />
+                              <path
+                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                fill="#FFFFFF"
+                                id="symbol-color"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Low
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-3-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={3}
+                      >
+                        3
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="pressure >= 10"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -21790,1522 +21989,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="count < 5"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <circle
-                                cx="8"
-                                cy="8"
-                                fill="#FDD13A"
-                                id="background-color"
-                                r="7"
-                              />
-                              <path
-                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                fill="#FFFFFF"
-                                id="symbol-color"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Low
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-3-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={3}
-                      >
-                        3
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="pressure >= 10"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-5-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize"
-                      >
-                        AHI001 proccess need to optimize
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-5-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="count >= 10"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-5-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-5-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-5-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="pressure >= 10"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-5-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <div
-              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
-              disabled={false}
-              size={
-                Object {
-                  "height": undefined,
-                  "position": undefined,
-                  "width": undefined,
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-23"
-                  id="bx-pagination-select-23-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-23"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={20}
-                          >
-                            20
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={30}
-                          >
-                            30
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-25"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-25"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-label="open list of options"
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
-                          />
-                          <title>
-                            open list of options
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23l-8-7 8-7v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9l8 7-8 7V9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with thresholds only with value 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "alignItems": "center",
-      "display": "flex",
-      "flexDirection": "column",
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "1056px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 kGdXdI"
-        id="table-list"
-      >
-        <div
-          className="card--header"
-        >
-          <span
-            className="card--title"
-            title="Open Alerts"
-          >
-            Open Alerts
-             
-          </span>
-          <div
-            className="bx--toolbar card--toolbar"
-          >
-            <span
-              className="card--toolbar-timerange-lable Card__TimeRangeLabel-v5r71h-5 bSwbuP"
-              id="timeRange"
-            />
-            <div
-              aria-expanded={false}
-              aria-haspopup={true}
-              aria-label="Menu"
-              className="card--toolbar-action bx--overflow-menu"
-              onClick={[Function]}
-              onClose={[Function]}
-              onKeyDown={[Function]}
-              open={false}
-              role="button"
-              tabIndex={0}
-            >
-              <svg
-                aria-label="open and close list of options"
-                className="bx--overflow-menu__icon"
-                focusable="false"
-                height={20}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                style={
-                  Object {
-                    "willChange": "transform",
-                  }
-                }
-                viewBox="0 0 32 32"
-                width={20}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                />
-                <path
-                  d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                />
-                <path
-                  d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                />
-                <title>
-                  open and close list of options
-                </title>
-              </svg>
-            </div>
-          </div>
-        </div>
-        <div
-          className="Card__CardContent-v5r71h-1 fabdLf"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
-              >
-                <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
-                <button
-                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex={0}
-                  title="Download table content"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    aria-label="Download table content"
-                    className="bx--btn__icon"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    role="img"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
-                  onClick={[Function]}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </section>
-            <table
-              className="bx--data-table bx--data-table--no-border"
-            >
-              <thead
-                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
-              >
-                <tr>
-                  <th
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
-                      data-column="alert"
-                      id="column-alert"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Alert"
-                        >
-                          Alert
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Unsort rows by this header"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN bx--table-sort"
-                      data-column="iconColumn-count"
-                      id="column-iconColumn-count"
-                      onClick={[Function]}
-                      width="140px"
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Count Severity"
-                        >
-                          Count Severity
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="count"
-                      id="column-count"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Count"
-                        >
-                          Count
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="hour"
-                      id="column-hour"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Hour"
-                        >
-                          Hour
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN bx--table-sort"
-                      data-column="iconColumn-pressure"
-                      id="column-iconColumn-pressure"
-                      onClick={[Function]}
-                      width="140px"
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Pressure Sev"
-                        >
-                          Pressure Sev
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="none"
-                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
-                    scope="col"
-                  >
-                    <button
-                      align="start"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
-                      data-column="pressure"
-                      id="column-pressure"
-                      onClick={[Function]}
-                      width=""
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title="Pressure"
-                        >
-                          Pressure
-                        </span>
-                      </span>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                        />
-                      </svg>
-                      <svg
-                        aria-label="Sort rows by this header in ascending order"
-                        className="bx--table-sort__icon-unsorted"
-                        focusable="false"
-                        height={20}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                aria-live="polite"
-              >
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="count < 5"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <circle
-                                cx="8"
-                                cy="8"
-                                fill="#FDD13A"
-                                id="background-color"
-                                r="7"
-                              />
-                              <path
-                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                fill="#FFFFFF"
-                                id="symbol-color"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Low
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-3-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={3}
-                      >
-                        3
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="pressure >= 10"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
-                  onClick={[Function]}
-                >
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -23591,7 +22274,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <span
                   className="bx--pagination__text"
                 >
-                  1–2 of 2 items
+                  1–10 of 11 items
                 </span>
               </div>
               <div
@@ -23607,7 +22290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       className="bx--label bx--visually-hidden"
                       htmlFor="bx-pagination-select-26"
                     >
-                      Page number, of 1 pages
+                      Page number, of 2 pages
                     </label>
                     <div
                       className="bx--select-input--inline__wrapper"
@@ -23619,6 +22302,1323 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         <select
                           className="bx--select-input"
                           id="bx-pagination-select-26"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23l-8-7 8-7v14z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9l8 7-8 7V9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with thresholds only with value 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "1056px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 kGdXdI"
+        id="table-list"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Open Alerts"
+          >
+            Open Alerts
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          >
+            <span
+              className="card--toolbar-timerange-lable Card__TimeRangeLabel-v5r71h-5 bSwbuP"
+              id="timeRange"
+            />
+            <div
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="Menu"
+              className="card--toolbar-action bx--overflow-menu"
+              onClick={[Function]}
+              onClose={[Function]}
+              onKeyDown={[Function]}
+              open={false}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="open and close list of options"
+                className="bx--overflow-menu__icon"
+                focusable="false"
+                height={20}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                />
+                <path
+                  d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                />
+                <path
+                  d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                />
+                <title>
+                  open and close list of options
+                </title>
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 fabdLf"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-4 jmgrzH"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
+              >
+                <div
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
+                >
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--search-magnifier"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
+                      />
+                    </svg>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <button
+                  className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex={0}
+                  title="Download table content"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Download table content"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 7l-.7-.7-3.8 3.8V1h-1v9.1L3.7 6.3 3 7l5 5zm0 5v2H3v-2H2v2c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-2h-1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="TableToolbar__ToolbarSVGWrapper-sc-17lb3av-0 dEzVra"
+                  onClick={[Function]}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </section>
+            <table
+              className="bx--data-table bx--data-table--no-border"
+            >
+              <thead
+                className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
+              >
+                <tr>
+                  <th
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort bx--table-sort--active"
+                      data-column="alert"
+                      id="column-alert"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Alert"
+                        >
+                          Alert
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Unsort rows by this header"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN bx--table-sort"
+                      data-column="iconColumn-count"
+                      id="column-iconColumn-count"
+                      onClick={[Function]}
+                      width="140px"
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Count Severity"
+                        >
+                          Count Severity
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="count"
+                      id="column-count"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Count"
+                        >
+                          Count
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="hour"
+                      id="column-hour"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Hour"
+                        >
+                          Hour
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 bolHgN bx--table-sort"
+                      data-column="iconColumn-pressure"
+                      id="column-iconColumn-pressure"
+                      onClick={[Function]}
+                      width="140px"
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Pressure Sev"
+                        >
+                          Pressure Sev
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                  <th
+                    aria-sort="none"
+                    className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg"
+                    scope="col"
+                  >
+                    <button
+                      align="start"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-2 cnPAGg bx--table-sort"
+                      data-column="pressure"
+                      id="column-pressure"
+                      onClick={[Function]}
+                      width=""
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title="Pressure"
+                        >
+                          Pressure
+                        </span>
+                      </span>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                        />
+                      </svg>
+                      <svg
+                        aria-label="Sort rows by this header in ascending order"
+                        className="bx--table-sort__icon-unsorted"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                        />
+                      </svg>
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                aria-live="polite"
+              >
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="count < 5"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <circle
+                                cx="8"
+                                cy="8"
+                                fill="#FDD13A"
+                                id="background-color"
+                                r="7"
+                              />
+                              <path
+                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                fill="#FFFFFF"
+                                id="symbol-color"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Low
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-3-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={3}
+                      >
+                        3
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="pressure >= 10"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="TableBodyRow__StyledTableRow-sc-103itxu-1 bhcNUt"
+                  onClick={[Function]}
+                >
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-5-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize"
+                      >
+                        AHI001 proccess need to optimize
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-5-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="count >= 10"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-5-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-5-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-5-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="pressure >= 10"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-5-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div
+              className="bx--pagination Table__StyledPagination-sc-1kalfns-1 iakRST"
+              disabled={false}
+              size={
+                Object {
+                  "height": undefined,
+                  "position": undefined,
+                  "width": undefined,
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-25"
+                  id="bx-pagination-select-25-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-25"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={20}
+                          >
+                            20
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={30}
+                          >
+                            30
+                          </option>
+                        </select>
+                        <svg
+                          aria-label="open list of options"
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"
+                          />
+                          <title>
+                            open list of options
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–2 of 2 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-27"
+                    >
+                      Page number, of 1 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={1}
                         >
@@ -23882,58 +23882,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -23947,15 +23911,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -24456,143 +24456,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-11-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-11-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="5"
-                      >
-                        5
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width=""
@@ -24724,6 +24587,143 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-11-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-11-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="5"
+                      >
+                        5
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -25327,6 +25327,241 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="count < 5"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <circle
+                                cx="8"
+                                cy="8"
+                                fill="#FDD13A"
+                                id="background-color"
+                                r="7"
+                              />
+                              <path
+                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                fill="#FFFFFF"
+                                id="symbol-color"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Low
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="count"
+                    data-offset={0}
+                    id="cell-Table-row-3-count"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="3"
+                      >
+                        3
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-pressure"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="pressure >= 10"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -25830,241 +26065,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="count < 5"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <circle
-                                cx="8"
-                                cy="8"
-                                fill="#FDD13A"
-                                id="background-color"
-                                r="7"
-                              />
-                              <path
-                                d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                fill="#FFFFFF"
-                                id="symbol-color"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Low
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="count"
-                    data-offset={0}
-                    id="cell-Table-row-3-count"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="3"
-                      >
-                        3
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-pressure"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="pressure >= 10"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -26271,8 +26271,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-22"
-                  id="bx-pagination-select-22-count-label"
+                  htmlFor="bx-pagination-select-23"
+                  id="bx-pagination-select-23-count-label"
                 >
                   Items per page:
                 </label>
@@ -26291,7 +26291,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-22"
+                          id="bx-pagination-select-23"
                           onChange={[Function]}
                           value={10}
                         >
@@ -26364,7 +26364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-24"
+                      htmlFor="bx-pagination-select-25"
                     >
                       Page number, of 2 pages
                     </label>
@@ -26377,7 +26377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={1}
                         >
@@ -26682,58 +26682,22 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 </div>
               </div>
               <div
-                className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                role="searchbox"
-                tabIndex="0"
+                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
               >
                 <div
-                  className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
+                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  role="searchbox"
+                  tabIndex="0"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="bx--search-magnifier"
-                    focusable="false"
-                    height={16}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
-                    />
-                  </svg>
-                  <label
-                    className="bx--label"
-                    htmlFor="Table-toolbar-search"
-                  >
-                    Search
-                  </label>
-                  <input
-                    aria-hidden={true}
-                    className="bx--search-input"
-                    id="Table-toolbar-search"
-                    onChange={[Function]}
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <button
-                    aria-label="Clear search input"
-                    className="bx--search-close bx--search-close--hidden"
-                    onClick={[Function]}
-                    type="button"
+                  <div
+                    className="bx--search bx--search--sm TableToolbar__StyledToolbarSearch-sc-17lb3av-1 jCiaXI"
                   >
                     <svg
                       aria-hidden={true}
+                      className="bx--search-magnifier"
                       focusable="false"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
@@ -26747,15 +26711,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       xmlns="http://www.w3.org/2000/svg"
                     >
                       <path
-                        d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        d="M15 14.3L10.7 10c1.9-2.3 1.6-5.8-.7-7.7S4.2.7 2.3 3 .7 8.8 3 10.7c2 1.7 5 1.7 7 0l4.3 4.3.7-.7zM2 6.5C2 4 4 2 6.5 2S11 4 11 6.5 9 11 6.5 11 2 9 2 6.5z"
                       />
                     </svg>
-                  </button>
+                    <label
+                      className="bx--label"
+                      htmlFor="Table-toolbar-search"
+                    >
+                      Search
+                    </label>
+                    <input
+                      aria-hidden={true}
+                      className="bx--search-input"
+                      id="Table-toolbar-search"
+                      onChange={[Function]}
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <button
+                      aria-label="Clear search input"
+                      className="bx--search-close bx--search-close--hidden"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 4.7l-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div
-                className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-3 jTKDEr"
-              >
                 <button
                   className="TableCard__ToolbarButton-q9l5bz-4 iFxaZU bx--btn bx--btn--sm bx--btn--ghost"
                   disabled={false}
@@ -27128,156 +27128,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-11-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI010 proccess need to optimize adjust Y variables"
-                      >
-                        AHI010 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-11-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="count > 2"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-11-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-11-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-10-alert"
                     offset={0}
                     width=""
@@ -27377,6 +27227,156 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     data-column="pressure"
                     data-offset={0}
                     id="cell-Table-row-10-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    />
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
+                    id="cell-Table-row-11-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI010 proccess need to optimize adjust Y variables"
+                      >
+                        AHI010 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-11-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="count > 2"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-11-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-11-pressure"
                     offset={0}
                     width=""
                   >
@@ -27884,6 +27884,162 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
+                    id="cell-Table-row-3-alert"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="AHI001 proccess need to optimize adjust Y variables"
+                      >
+                        AHI001 proccess need to optimize adjust Y variables
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
+                    data-column="iconColumn-count"
+                    data-offset={0}
+                    id="cell-Table-row-3-iconColumn-count"
+                    offset={0}
+                    width="140px"
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <div
+                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
+                        title="count > 2"
+                      >
+                        <svg
+                          height="16px"
+                          version="1.1"
+                          viewBox="0 0 16 16"
+                          width="16px"
+                        >
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                            id="Artboard-Copy-2"
+                            stroke="none"
+                            strokeWidth="1"
+                          >
+                            <g
+                              id="Group"
+                            >
+                              <path
+                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                fill="#FFFFFF"
+                                id="outline-color"
+                              />
+                              <path
+                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                fill="#DA1E28"
+                                id="background-color"
+                              />
+                              <polygon
+                                fill="#FFFFFF"
+                                id="icon-color"
+                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                        <span
+                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
+                        >
+                          Critical
+                        </span>
+                      </div>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="hour"
+                    data-offset={0}
+                    id="cell-Table-row-3-hour"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title="10/28/2018 07:34"
+                      >
+                        10/28/2018 07:34
+                      </span>
+                    </span>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="pressure"
+                    data-offset={0}
+                    id="cell-Table-row-3-pressure"
+                    offset={0}
+                    width=""
+                  >
+                    <span
+                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
+                    >
+                      <span
+                        title={10}
+                      >
+                        10
+                      </span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
+                  data-child-count={0}
+                  data-nesting-offset={0}
+                  data-parent-row={true}
+                  data-row-nesting={false}
+                  onClick={[Function]}
+                >
+                  <td
+                    className="bx--table-expand"
+                    headers="expand"
+                  >
+                    <button
+                      aria-label="Click to expand content"
+                      className="bx--table-expand__button"
+                      onClick={[Function]}
+                      title="Click to expand content"
+                    >
+                      <svg
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__svg"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
+                        />
+                      </svg>
+                    </button>
+                  </td>
+                  <td
+                    align="start"
+                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
+                    data-column="alert"
+                    data-offset={0}
                     id="cell-Table-row-4-alert"
                     offset={0}
                     width=""
@@ -28289,162 +28445,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
                     data-column="alert"
                     data-offset={0}
-                    id="cell-Table-row-3-alert"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="AHI001 proccess need to optimize adjust Y variables"
-                      >
-                        AHI001 proccess need to optimize adjust Y variables
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 gvSBzN"
-                    data-column="iconColumn-count"
-                    data-offset={0}
-                    id="cell-Table-row-3-iconColumn-count"
-                    offset={0}
-                    width="140px"
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <div
-                        className="TableCard__StyledIconDiv-q9l5bz-5 kQkprB"
-                        title="count > 2"
-                      >
-                        <svg
-                          height="16px"
-                          version="1.1"
-                          viewBox="0 0 16 16"
-                          width="16px"
-                        >
-                          <g
-                            fill="none"
-                            fillRule="evenodd"
-                            id="Artboard-Copy-2"
-                            stroke="none"
-                            strokeWidth="1"
-                          >
-                            <g
-                              id="Group"
-                            >
-                              <path
-                                d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                fill="#FFFFFF"
-                                id="outline-color"
-                              />
-                              <path
-                                d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                fill="#DA1E28"
-                                id="background-color"
-                              />
-                              <polygon
-                                fill="#FFFFFF"
-                                id="icon-color"
-                                points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                        <span
-                          className="TableCard__StyledSpan-q9l5bz-6 jbPfYa"
-                        >
-                          Critical
-                        </span>
-                      </div>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="hour"
-                    data-offset={0}
-                    id="cell-Table-row-3-hour"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title="10/28/2018 07:34"
-                      >
-                        10/28/2018 07:34
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="pressure"
-                    data-offset={0}
-                    id="cell-Table-row-3-pressure"
-                    offset={0}
-                    width=""
-                  >
-                    <span
-                      className="TableBodyRow__StyledNestedSpan-sc-103itxu-7 vTxhy"
-                    >
-                      <span
-                        title={10}
-                      >
-                        10
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-                <tr
-                  className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-3 hRplJq"
-                  data-child-count={0}
-                  data-nesting-offset={0}
-                  data-parent-row={true}
-                  data-row-nesting={false}
-                  onClick={[Function]}
-                >
-                  <td
-                    className="bx--table-expand"
-                    headers="expand"
-                  >
-                    <button
-                      aria-label="Click to expand content"
-                      className="bx--table-expand__button"
-                      onClick={[Function]}
-                      title="Click to expand content"
-                    >
-                      <svg
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__svg"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"
-                        />
-                      </svg>
-                    </button>
-                  </td>
-                  <td
-                    align="start"
-                    className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-6 jlcAKj"
-                    data-column="alert"
-                    data-offset={0}
                     id="cell-Table-row-5-alert"
                     offset={0}
                     width=""
@@ -28574,8 +28574,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-32"
-                  id="bx-pagination-select-32-count-label"
+                  htmlFor="bx-pagination-select-33"
+                  id="bx-pagination-select-33-count-label"
                 >
                   Items per page:
                 </label>
@@ -28594,7 +28594,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-33"
                           onChange={[Function]}
                           value={10}
                         >
@@ -28667,7 +28667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-34"
+                      htmlFor="bx-pagination-select-35"
                     >
                       Page number, of 2 pages
                     </label>
@@ -28680,7 +28680,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34"
+                          id="bx-pagination-select-35"
                           onChange={[Function]}
                           value={1}
                         >


### PR DESCRIPTION
#689

Closes #

**Summary**

Right align the search icon and toggle open when clicked to display a search component.
Show table row count and should be appear on the left. i.e "Results: X", where X is equal to the number of rows in the table.
This field (Row count) should be configuration via boolean property and Result Label should allow to change.

**Change List (commits, features, bugs, etc)**

src/components/DataTable/_data-table.scss
src/components/Table/Table.jsx
src/components/Table/Table.story.jsx
src/components/Table/TablePropTypes.js
src/components/Table/TableToolbar/TableToolbar.jsx
src/components/Table/snapshots/Table.story.storyshot
src/components/TableCard/snapshots/TableCard.story.storyshot
src/components/Dashboard/snapshots/Dashboard.story.storyshot

**Acceptance Test (how to verify the PR)**

Two fields are provided in Knob to test.
Search Icon should be display as right align in table toolbar and when clicked it should display a search component. 
Show total row count in table, 
Using knob, Row count label input field should allow to change row count label value, also show row count checkbox use to display and hide Row count field.
