### PR TITLE
feat(tablecard): add width to proptypes that can be passed in for columns

### DIFF
--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -103,12 +103,14 @@ const StyledCustomTableHeader = styled(TableHeader)`
       const { width } = props;
       return width !== undefined
         ? `
-        min-width: ${width};
-        max-width: ${width};
-        white-space: nowrap;
-        overflow-x: hidden;
-        overflow-y: hidden;
-        text-overflow: ellipsis;
+       .bx--table-header-label { 
+          min-width: ${width};
+          max-width: ${width};
+          white-space: nowrap;
+          overflow-x: hidden;
+          overflow-y: hidden;
+          text-overflow: ellipsis;
+        }
       `
         : '';
     }}

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -484,7 +484,7 @@ const TableCard = ({
           id: i.dataSourceId ? i.dataSourceId : i.id,
           name: i.label ? i.label : i.dataSourceId || '', // don't force label to be required
           isSortable: true,
-          width: i.width ? i.width : size === CARD_SIZES.TALL ? '150px' : '', // force the text wrap
+          width: i.width ? `${i.width}px` : size === CARD_SIZES.TALL ? '150px' : '', // force the text wrap
           filter: i.filter
             ? i.filter
             : { placeholderText: strings.defaultFilterStringPlaceholdText }, // if filter not send we send empty object

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -333,7 +333,7 @@ storiesOf('Table Card', module)
     );
 
     const tableCustomColumns = tableColumns.map((item, index) =>
-      index === 0 ? { ...item, width: '250px', name: 'Alert with long string name' } : item
+      index === 0 ? { ...item, width: 250, name: 'Alert with long string name' } : item
     );
 
     return (

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -83,8 +83,8 @@ export const TableCardPropTypes = {
     columns: PropTypes.arrayOf(
       PropTypes.shape({
         dataSourceId: PropTypes.string.isRequired,
-        /** optional width, default is no enforced max width.  for example 150px */
-        width: PropTypes.string,
+        /** optional width in pixels, default is no enforced max width */
+        width: PropTypes.number,
         label: PropTypes.string.isRequired,
         priority: PropTypes.number,
         renderer: PropTypes.func,

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -83,6 +83,8 @@ export const TableCardPropTypes = {
     columns: PropTypes.arrayOf(
       PropTypes.shape({
         dataSourceId: PropTypes.string.isRequired,
+        /** optional width, default is no enforced max width.  for example 150px */
+        width: PropTypes.string,
         label: PropTypes.string.isRequired,
         priority: PropTypes.number,
         renderer: PropTypes.func,

--- a/src/utils/schemas/tableCardContent.json
+++ b/src/utils/schemas/tableCardContent.json
@@ -64,7 +64,7 @@
       "properties": {
         "label": { "type": "string" },
         "dataSourceId": { "type": "string" },
-        "width": { "type": "string" },
+        "width": { "type": "number" },
         "priority": { "type": "number" },
         "filter": { "type": "object", "properties": { "placeholderText": { "type": "string" } } },
         "type": { "type": "string" }

--- a/src/utils/schemas/tableCardContent.json
+++ b/src/utils/schemas/tableCardContent.json
@@ -64,12 +64,13 @@
       "properties": {
         "label": { "type": "string" },
         "dataSourceId": { "type": "string" },
+        "width": { "type": "string" },
         "priority": { "type": "number" },
         "filter": { "type": "object", "properties": { "placeholderText": { "type": "string" } } },
         "type": { "type": "string" }
       },
       "required": ["dataSourceId"],
-      "propertyNames": { "enum": ["label", "dataSourceId", "priority", "filter", "type"] }
+      "propertyNames": { "enum": ["label", "dataSourceId", "priority", "filter", "type", "width"] }
     },
     "attribute": {
       "type": "object",


### PR DESCRIPTION
Supports new width string proptype and field that can be passed in to limit a column width
![image](https://user-images.githubusercontent.com/6663002/68403722-0239cb00-0143-11ea-8f0a-dc51b75295e5.png)
