### PR TITLE
test(headermenu): event handlers

### DIFF
--- a/src/components/Header/HeaderMenu.test.jsx
+++ b/src/components/Header/HeaderMenu.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { HeaderMenuItem } from 'carbon-components-react/lib/components/UIShell';
+import { render, fireEvent } from '@testing-library/react';
 
 import HeaderMenu, { matches, keys } from './HeaderMenu';
 
@@ -87,5 +88,64 @@ describe('HeaderMenu', () => {
 
   it('should match', () => {
     expect(matches(event, [keys.ENTER, keys.SPACE])).toEqual(true);
+  });
+
+  test('renders in action bar', () => {
+    const menuContent = () => <p>Some other text</p>;
+    const { getByText } = render(
+      <HeaderMenu renderMenuContent={menuContent} isMenu={false} {...mockProps}>
+        <HeaderMenuItem href="/a">A</HeaderMenuItem>
+        <HeaderMenuItem href="/b">B</HeaderMenuItem>
+        <HeaderMenuItem href="/c">C</HeaderMenuItem>
+      </HeaderMenu>
+    );
+    expect(getByText('Some other text')).toBeDefined();
+  });
+
+  test('onClick expands', () => {
+    const menuContent = () => <p>Some other text</p>;
+    const { getAllByRole } = render(
+      <HeaderMenu renderMenuContent={menuContent} {...mockProps}>
+        <HeaderMenuItem href="/a">A</HeaderMenuItem>
+        <HeaderMenuItem href="/b">B</HeaderMenuItem>
+        <HeaderMenuItem href="/c">C</HeaderMenuItem>
+      </HeaderMenu>
+    );
+    const menuTrigger = getAllByRole('menuitem')[0];
+    fireEvent.click(menuTrigger);
+    expect(menuTrigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  test('onKeyDown expands with enter or space', () => {
+    const menuContent = () => <p>Some other text</p>;
+    const { getAllByRole } = render(
+      <HeaderMenu renderMenuContent={menuContent} {...mockProps}>
+        <HeaderMenuItem href="/a">A</HeaderMenuItem>
+        <HeaderMenuItem href="/b">B</HeaderMenuItem>
+        <HeaderMenuItem href="/c">C</HeaderMenuItem>
+      </HeaderMenu>
+    );
+    const menuTrigger = getAllByRole('menuitem')[0];
+    fireEvent.keyDown(menuTrigger, { keyCode: keys.ENTER });
+    expect(menuTrigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.keyDown(menuTrigger, { keyCode: keys.SPACE });
+    expect(menuTrigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('onKeyDown esc on parent closes an open menu', () => {
+    const menuContent = () => <p>Some other text</p>;
+    const { getByRole, getAllByRole } = render(
+      <HeaderMenu renderMenuContent={menuContent} {...mockProps}>
+        <HeaderMenuItem href="/a">A</HeaderMenuItem>
+        <HeaderMenuItem href="/b">B</HeaderMenuItem>
+        <HeaderMenuItem href="/c">C</HeaderMenuItem>
+      </HeaderMenu>
+    );
+    const menuParent = getByRole('listitem');
+    const menuTrigger = getAllByRole('menuitem')[0];
+    fireEvent.keyDown(menuTrigger, { keyCode: keys.ENTER });
+    expect(menuTrigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.keyDown(menuParent, { keyCode: keys.ESC });
+    expect(menuTrigger.getAttribute('aria-expanded')).toBe('false');
   });
 });


### PR DESCRIPTION
**Summary**

- This PR contains tests that trigger and validate the expanded/unexpanded state of the `HeaderMenu` (icon triggering dropdown list for use in the `Header`).  You can see examples of using `@testing-library/react` to trigger keyboard and mouse events, validate based on aria properties, etc.

**Acceptance Test (how to verify the PR)**

- If the checks pass, it's good to go.
