### PR TITLE
Add render prop to dashboard/cards for icons

### DIFF
--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -70,6 +70,7 @@ const CardRenderer = React.memo(
     breakpoint, // eslint-disable-line
     onFetchData, // eslint-disable-line
     onSetupCard, // eslint-disable-line
+    renderIcon, // eslint-disable-line
     timeGrain, // eslint-disable-line
     ...gridProps
   }) => {
@@ -166,6 +167,7 @@ const CardRenderer = React.memo(
       i18n,
       isEditable,
       onCardAction: cachedOnCardAction,
+      renderIcon,
       breakpoint,
       dashboardBreakpoints,
       dashboardColumns,

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -70,7 +70,7 @@ const CardRenderer = React.memo(
     breakpoint, // eslint-disable-line
     onFetchData, // eslint-disable-line
     onSetupCard, // eslint-disable-line
-    renderIcon, // eslint-disable-line
+    renderIconByName, // eslint-disable-line
     timeGrain, // eslint-disable-line
     ...gridProps
   }) => {
@@ -167,7 +167,7 @@ const CardRenderer = React.memo(
       i18n,
       isEditable,
       onCardAction: cachedOnCardAction,
-      renderIcon,
+      renderIconByName,
       breakpoint,
       dashboardBreakpoints,
       dashboardColumns,

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -157,6 +157,22 @@ const CardRenderer = React.memo(
       [card, onFetchData, timeGrain]
     );
 
+    const commonCardProps = {
+      key: card.id,
+      availableActions: cachedActions,
+      dataSource,
+      isExpanded,
+      type,
+      i18n,
+      isEditable,
+      onCardAction: cachedOnCardAction,
+      breakpoint,
+      dashboardBreakpoints,
+      dashboardColumns,
+      cardDimensions,
+      rowHeight,
+    };
+
     return (
       <div
         key={card.id}
@@ -165,73 +181,13 @@ const CardRenderer = React.memo(
         style={cachedExpandedStyle}
       >
         {type === CARD_TYPES.VALUE ? (
-          <ValueCard
-            {...card}
-            key={card.id}
-            availableActions={cachedActions}
-            dataSource={dataSource}
-            isExpanded={isExpanded}
-            type={type}
-            i18n={i18n}
-            isEditable={isEditable}
-            onCardAction={cachedOnCardAction}
-            breakpoint={breakpoint}
-            dashboardBreakpoints={dashboardBreakpoints}
-            dashboardColumns={dashboardColumns}
-            cardDimensions={cardDimensions}
-            rowHeight={rowHeight}
-          />
+          <ValueCard {...card} {...commonCardProps} />
         ) : type === CARD_TYPES.IMAGE ? (
-          <ImageCard
-            {...card}
-            key={card.id}
-            availableActions={cachedActions}
-            dataSource={dataSource}
-            isExpanded={isExpanded}
-            type={type}
-            i18n={i18n}
-            isEditable={isEditable}
-            onCardAction={cachedOnCardAction}
-            breakpoint={breakpoint}
-            dashboardBreakpoints={dashboardBreakpoints}
-            dashboardColumns={dashboardColumns}
-            cardDimensions={cardDimensions}
-            rowHeight={rowHeight}
-          />
+          <ImageCard {...card} {...commonCardProps} />
         ) : type === CARD_TYPES.TIMESERIES ? (
-          <TimeSeriesCard
-            {...card}
-            key={card.id}
-            availableActions={cachedActions}
-            dataSource={dataSource}
-            isExpanded={isExpanded}
-            type={type}
-            i18n={i18n}
-            isEditable={isEditable}
-            onCardAction={cachedOnCardAction}
-            breakpoint={breakpoint}
-            dashboardBreakpoints={dashboardBreakpoints}
-            dashboardColumns={dashboardColumns}
-            cardDimensions={cardDimensions}
-            rowHeight={rowHeight}
-          />
+          <TimeSeriesCard {...card} {...commonCardProps} />
         ) : type === CARD_TYPES.TABLE ? (
-          <TableCard
-            {...card}
-            key={card.id}
-            availableActions={cachedActions}
-            dataSource={dataSource}
-            isExpanded={isExpanded}
-            type={type}
-            i18n={i18n}
-            isEditable={isEditable}
-            onCardAction={cachedOnCardAction}
-            breakpoint={breakpoint}
-            dashboardBreakpoints={dashboardBreakpoints}
-            dashboardColumns={dashboardColumns}
-            cardDimensions={cardDimensions}
-            rowHeight={rowHeight}
-          />
+          <TableCard {...card} {...commonCardProps} />
         ) : null}
       </div>
     );

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -90,7 +90,7 @@ const propTypes = {
   /** Callback called when an action is clicked.  The id of the action is passed to the callback */
   onDashboardAction: PropTypes.func,
   /** Callback called when a card determines what icon render based on a named string in card config */
-  renderIcon: PropTypes.func,
+  renderIconByName: PropTypes.func,
 
   // Data related properties
   /** If the overall dashboard should be using a timeGrain, we pass it here */
@@ -269,7 +269,7 @@ const defaultProps = {
   hasLastUpdated: true,
   onSetupCard: null,
   onFetchData: null,
-  renderIcon: null,
+  renderIconByName: null,
   timeGrain: null,
   isLoading: false,
   setIsLoading: null,
@@ -320,7 +320,7 @@ const Dashboard = ({
   onSetupCard,
   // TODO: fix the rendering of the lastUpdated bit, to migrate in the style from our ibm repo
   lastUpdated, // eslint-disable-line
-  renderIcon,
+  renderIconByName,
   onFetchData,
   timeGrain,
 }) => {
@@ -415,7 +415,7 @@ const Dashboard = ({
             breakpoint={breakpoint}
             onSetupCard={onSetupCard}
             onFetchData={handleOnFetchData}
-            renderIcon={renderIcon}
+            renderIconByName={renderIconByName}
             timeGrain={timeGrain}
           />
         ) : null

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -89,6 +89,8 @@ const propTypes = {
   onBreakpointChange: PropTypes.func,
   /** Callback called when an action is clicked.  The id of the action is passed to the callback */
   onDashboardAction: PropTypes.func,
+  /** Callback called when a card determines what icon render based on a named string in card config */
+  renderIcon: PropTypes.func,
 
   // Data related properties
   /** If the overall dashboard should be using a timeGrain, we pass it here */
@@ -267,6 +269,7 @@ const defaultProps = {
   hasLastUpdated: true,
   onSetupCard: null,
   onFetchData: null,
+  renderIcon: null,
   timeGrain: null,
   isLoading: false,
   setIsLoading: null,
@@ -317,6 +320,7 @@ const Dashboard = ({
   onSetupCard,
   // TODO: fix the rendering of the lastUpdated bit, to migrate in the style from our ibm repo
   lastUpdated, // eslint-disable-line
+  renderIcon,
   onFetchData,
   timeGrain,
 }) => {
@@ -411,6 +415,7 @@ const Dashboard = ({
             breakpoint={breakpoint}
             onSetupCard={onSetupCard}
             onFetchData={handleOnFetchData}
+            renderIcon={renderIcon}
             timeGrain={timeGrain}
           />
         ) : null

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -89,7 +89,9 @@ const propTypes = {
   onBreakpointChange: PropTypes.func,
   /** Callback called when an action is clicked.  The id of the action is passed to the callback */
   onDashboardAction: PropTypes.func,
-  /** Callback called when a card determines what icon render based on a named string in card config */
+  /** Callback called when a card determines what icon render based on a named string in card config
+   *    example usage: renderIconByName(name = 'my--checkmark--icon', props = { title: 'A checkmark', etc. })
+   */
   renderIconByName: PropTypes.func,
 
   // Data related properties

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { text, boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { FavoriteFilled16, ErrorFilled16, CopyFile16 } from '@carbon/icons-react';
 
 import FullWidthWrapper from '../../internal/FullWidthWrapper';
 import { getIntervalChartData, tableColumns, tableData } from '../../utils/sample';
@@ -972,6 +973,37 @@ storiesOf('Watson IoT|Dashboard', module)
             {dashboard}
           </div>,
         ])}
+      </FullWidthWrapper>
+    );
+  })
+  .add('custom renderIcon', () => {
+    return (
+      <FullWidthWrapper>
+        <Dashboard
+          {...commonDashboardProps}
+          cards={originalCards.filter(
+            i => i.id === 'floor map picture' || i.id === 'facilitycard-comfort-level'
+          )}
+          renderIcon={(name, props = {}) =>
+            name === 'arrowUp' ? (
+              <FavoriteFilled16 {...props}>
+                {props.title && <title>{props.title}</title>}
+              </FavoriteFilled16>
+            ) : name === 'arrowDown' ? (
+              <ErrorFilled16 {...props}>
+                {props.title && <title>{props.title}</title>}
+              </ErrorFilled16>
+            ) : name === 'close' ? (
+              <CopyFile16 {...props}>{props.title && <title>{props.title}</title>}</CopyFile16>
+            ) : name === 'checkmark' ? (
+              <FavoriteFilled16 {...props}>
+                {props.title && <title>{props.title}</title>}
+              </FavoriteFilled16>
+            ) : (
+              <span>Unknown</span>
+            )
+          }
+        />
       </FullWidthWrapper>
     );
   });

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -976,7 +976,7 @@ storiesOf('Watson IoT|Dashboard', module)
       </FullWidthWrapper>
     );
   })
-  .add('custom renderIcon', () => {
+  .add('custom renderIconByName', () => {
     return (
       <FullWidthWrapper>
         <Dashboard
@@ -984,7 +984,7 @@ storiesOf('Watson IoT|Dashboard', module)
           cards={originalCards.filter(
             i => i.id === 'floor map picture' || i.id === 'facilitycard-comfort-level'
           )}
-          renderIcon={(name, props = {}) =>
+          renderIconByName={(name, props = {}) =>
             name === 'arrowUp' ? (
               <FavoriteFilled16 {...props}>
                 {props.title && <title>{props.title}</title>}

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -5578,6 +5578,592 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashboard custom renderIcon 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div>
+        <div
+          className="dashboard--header"
+        >
+          <div
+            className="dashboard--header-left"
+          >
+            <h2>
+              Munich Building
+            </h2>
+            <div
+              className="dashboard--lastupdated"
+            >
+              Last updated: 
+               
+              Tue, 22 Oct 2019 05:00:00 GMT
+            </div>
+          </div>
+          <div
+            className="dashboard--header-right"
+          >
+            <div
+              className="dashboard--header-actions"
+            />
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <div
+              className="react-grid-layout Dashboard__StyledGridLayout-up3zyz-0 leaKVS"
+              style={
+                Object {
+                  "height": "304px",
+                }
+              }
+            >
+              <div
+                className="react-grid-item cssTransforms"
+                style={
+                  Object {
+                    "MozTransform": "translate(16px,16px)",
+                    "OTransform": "translate(16px,16px)",
+                    "WebkitTransform": "translate(16px,16px)",
+                    "height": "128px",
+                    "msTransform": "translate(16px,16px)",
+                    "position": "absolute",
+                    "transform": "translate(16px,16px)",
+                    "width": "142px",
+                  }
+                }
+              >
+                <div
+                  className="Card__CardWrapper-v5r71h-0 fbzdtE"
+                  id="facilitycard-comfort-level"
+                  type="VALUE"
+                >
+                  <div
+                    className="card--header"
+                  >
+                    <span
+                      className="card--title"
+                      title="Comfort Level"
+                    >
+                      Comfort Level
+                       
+                    </span>
+                    <div
+                      className="bx--toolbar card--toolbar"
+                    />
+                  </div>
+                  <div
+                    className="Card__CardContent-v5r71h-1 hoCWQe"
+                  >
+                    <div
+                      className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+                    >
+                      <div
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        size="XSMALL"
+                      >
+                        <div
+                          className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                          label={null}
+                          size="XSMALL"
+                        >
+                          <div
+                            className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                            color={null}
+                          >
+                            <span
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                              size="XSMALL"
+                              title="Bad "
+                              value="Bad"
+                            >
+                              Bad
+                            </span>
+                          </div>
+                          <div
+                            className="Attribute__StyledIcon-dhraql-5 gssLPC"
+                          >
+                            <div
+                              className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
+                            >
+                              <svg
+                                description="= Bad"
+                                fill="red"
+                                focusable="false"
+                                height={16}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                style={
+                                  Object {
+                                    "willChange": "transform",
+                                  }
+                                }
+                                title="= Bad"
+                                viewBox="0 0 16 16"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M14.72 7.35l-3-3.06A1 1 0 0 0 11 4H5a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V8a1 1 0 0 0-.28-.65zM11 5l3 3h-3zm-6 9V5h5v3a1 1 0 0 0 1 1h3v5z"
+                                />
+                                <path
+                                  d="M2 9H1V2a1 1 0 0 1 1-1h7v1H2z"
+                                />
+                                <title>
+                                  = Bad
+                                </title>
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          size="XSMALL"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="react-grid-item cssTransforms"
+                style={
+                  Object {
+                    "MozTransform": "translate(174px,16px)",
+                    "OTransform": "translate(174px,16px)",
+                    "WebkitTransform": "translate(174px,16px)",
+                    "height": "272px",
+                    "msTransform": "translate(174px,16px)",
+                    "position": "absolute",
+                    "transform": "translate(174px,16px)",
+                    "width": "616px",
+                  }
+                }
+              >
+                <div
+                  className="Card__CardWrapper-v5r71h-0 cynIXT"
+                  id="floor map picture"
+                  type="IMAGE"
+                >
+                  <div
+                    className="card--header"
+                  >
+                    <span
+                      className="card--title"
+                      title="Floor Map"
+                    >
+                      Floor Map
+                       
+                    </span>
+                    <div
+                      className="bx--toolbar card--toolbar"
+                    >
+                      <button
+                        className="card--toolbar-action Card__TinyButton-v5r71h-4 fggzfz bx--btn bx--btn--sm bx--btn--ghost"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        title="Expand to fullscreen"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          aria-label="Expand to fullscreen"
+                          className="bx--btn__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                          />
+                          <path
+                            d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    className="Card__CardContent-v5r71h-1 hDVRgE"
+                  >
+                    <div
+                      className="ImageCard__ContentWrapper-sc-1p2j9dm-0 jJnAwR"
+                    >
+                      <div
+                        onBlur={[Function]}
+                        onMouseOut={[Function]}
+                        style={
+                          Object {
+                            "background": "#eee",
+                            "height": "100%",
+                            "overflow": "hidden",
+                            "position": "relative",
+                            "textAlign": "center",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <img
+                          alt="Floor Map"
+                          onLoad={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseMove={[Function]}
+                          onMouseUp={[Function]}
+                          src="landscape.jpg"
+                          style={
+                            Object {
+                              "left": undefined,
+                              "position": "relative",
+                              "top": undefined,
+                            }
+                          }
+                        />
+                        <div
+                          style={
+                            Object {
+                              "left": undefined,
+                              "margin": "auto",
+                              "pointerEvents": "none",
+                              "position": "absolute",
+                              "right": "auto",
+                              "top": undefined,
+                            }
+                          }
+                        >
+                          <div
+                            className="Hotspot__StyledHotspot-nlpwmi-0 fvESgj"
+                          >
+                            <div
+                              aria-describedby={null}
+                              aria-haspopup="true"
+                              aria-labelledby="hotspot-35-65"
+                              className="bx--tooltip__label"
+                              id="hotspot-35-65"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                              role="button"
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="blue"
+                                focusable="false"
+                                height={25}
+                                preserveAspectRatio="xMidYMid meet"
+                                style={
+                                  Object {
+                                    "willChange": "transform",
+                                  }
+                                }
+                                title=""
+                                viewBox="0 0 16 16"
+                                width={25}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm2.7 10.5L4.5 5.3l.8-.8 6.2 6.2-.8.8z"
+                                />
+                                <path
+                                  d="M10.7 11.5L4.5 5.3l.8-.8 6.2 6.2-.8.8z"
+                                  data-icon-path="inner-path"
+                                  fill="none"
+                                  opacity="0"
+                                />
+                                
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                          >
+                            <div
+                              aria-describedby={null}
+                              aria-haspopup="true"
+                              aria-labelledby="hotspot-45-25"
+                              className="bx--tooltip__label"
+                              id="hotspot-45-25"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                              role="button"
+                              tabIndex={0}
+                            >
+                              <svg
+                                height={25}
+                                width={25}
+                              >
+                                <circle
+                                  cx={12.5}
+                                  cy={12.5}
+                                  fill="none"
+                                  opacity="1"
+                                  r={11.5}
+                                  stroke="white"
+                                  strokeWidth="2"
+                                />
+                                <circle
+                                  cx={12.5}
+                                  cy={12.5}
+                                  fill="#0f0"
+                                  opacity="0.7"
+                                  r={11.5}
+                                  stroke="none"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                          >
+                            <div
+                              aria-describedby={null}
+                              aria-haspopup="true"
+                              aria-labelledby="hotspot-45-50"
+                              className="bx--tooltip__label"
+                              id="hotspot-45-50"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                              role="button"
+                              tabIndex={0}
+                            >
+                              <svg
+                                height={25}
+                                width={25}
+                              >
+                                <circle
+                                  cx={12.5}
+                                  cy={12.5}
+                                  fill="none"
+                                  opacity="1"
+                                  r={11.5}
+                                  stroke="white"
+                                  strokeWidth="2"
+                                />
+                                <circle
+                                  cx={12.5}
+                                  cy={12.5}
+                                  fill="#00f"
+                                  opacity="0.7"
+                                  r={11.5}
+                                  stroke="none"
+                                />
+                              </svg>
+                            </div>
+                          </div>
+                          <div
+                            className="Hotspot__StyledHotspot-nlpwmi-0 ezcTmr"
+                          >
+                            <div
+                              aria-describedby={null}
+                              aria-haspopup="true"
+                              aria-labelledby="hotspot-45-75"
+                              className="bx--tooltip__label"
+                              id="hotspot-45-75"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                              role="button"
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="blue"
+                                focusable="false"
+                                height={25}
+                                preserveAspectRatio="xMidYMid meet"
+                                style={
+                                  Object {
+                                    "willChange": "transform",
+                                  }
+                                }
+                                title=""
+                                viewBox="0 0 16 16"
+                                width={25}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M11.2 2c-1 0-2 .4-2.7 1.1l-.5.6-.6-.6C6 1.6 3.6 1.6 2.1 3.1S.6 7 2.1 8.5l5.9 6 5.9-6c1.5-1.5 1.5-3.9 0-5.4-.7-.7-1.7-1.1-2.7-1.1z"
+                                />
+                                
+                              </svg>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "bottom": 10,
+                              "pointerEvents": "auto",
+                              "position": "absolute",
+                              "right": 10,
+                            }
+                          }
+                        >
+                          <button
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "background": "#fff",
+                                "border": "none",
+                                "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                                "height": "25px",
+                                "width": "25px",
+                              }
+                            }
+                            type="button"
+                          >
+                            +
+                          </button>
+                          <br />
+                          <button
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "background": "#fff",
+                                "border": "none",
+                                "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                                "height": "25px",
+                                "width": "25px",
+                              }
+                            }
+                            type="button"
+                          >
+                            -
+                          </button>
+                        </div>
+                        <div
+                          style={
+                            Object {
+                              "background": "#fff",
+                              "bottom": 10,
+                              "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                              "display": "block",
+                              "height": null,
+                              "left": 10,
+                              "pointerEvents": "none",
+                              "position": "absolute",
+                              "width": null,
+                            }
+                          }
+                        >
+                          <img
+                            alt="Minimap"
+                            height={null}
+                            src="landscape.jpg"
+                            width={null}
+                          />
+                          <div
+                            style={
+                              Object {
+                                "background": "rgba(64, 139, 252, 0.1)",
+                                "border": "1px solid rgba(64, 139, 252, 0.8)",
+                                "display": "block",
+                                "height": null,
+                                "left": 0,
+                                "pointerEvents": "none",
+                                "position": "absolute",
+                                "top": 0,
+                                "width": null,
+                              }
+                            }
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashboard full screen image card 1`] = `
 <div
   className="storybook-container"

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -5578,7 +5578,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashboard custom renderIcon 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashboard custom renderIconByName 1`] = `
 <div
   className="storybook-container"
   style={

--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -24,7 +24,7 @@ export const propTypes = {
   /** height of the hotspot */
   height: PropTypes.number,
   /** optional function to provide icon based on name */
-  renderIcon: PropTypes.func,
+  renderIconByName: PropTypes.func,
 };
 
 const defaultProps = {
@@ -33,7 +33,7 @@ const defaultProps = {
   color: 'blue',
   width: 25,
   height: 25,
-  renderIcon: null,
+  renderIconByName: null,
 };
 
 const StyledHotspot = styled(({ className, children }) => (
@@ -80,7 +80,7 @@ const Hotspot = ({
   color,
   width,
   height,
-  renderIcon,
+  renderIconByName,
   ...others
 }) => {
   const defaultIcon = (
@@ -106,8 +106,8 @@ const Hotspot = ({
   );
 
   const iconToRender = icon ? (
-    renderIcon ? (
-      renderIcon(icon, {
+    renderIconByName ? (
+      renderIconByName(icon, {
         title: iconDescription,
         fill: color,
         width,

--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Icon, Tooltip } from 'carbon-components-react';
 
-import icons, { bundledIconNames } from '../../utils/bundledIcons';
+import icons from '../../utils/bundledIcons';
 
 export const propTypes = {
   /** percentage from the left of the image to show this hotspot */
@@ -15,16 +15,7 @@ export const propTypes = {
   /** points to one of our enumerated icon names (ex. caretUp, edit, close)
    * TODO: add support for the carbon icon object (svgData, viewBox, width, height)
    */
-  icon: PropTypes.oneOfType([
-    PropTypes.oneOf(bundledIconNames),
-    PropTypes.shape({
-      width: PropTypes.string,
-      height: PropTypes.string,
-      viewBox: PropTypes.string.isRequired,
-      svgData: PropTypes.object.isRequired,
-    }),
-  ]),
-
+  icon: PropTypes.string,
   iconDescription: PropTypes.string,
   /** color of the hotspot */
   color: PropTypes.string,
@@ -32,6 +23,8 @@ export const propTypes = {
   width: PropTypes.number,
   /** height of the hotspot */
   height: PropTypes.number,
+  /** optional function to provide icon based on name */
+  renderIcon: PropTypes.func,
 };
 
 const defaultProps = {
@@ -40,6 +33,7 @@ const defaultProps = {
   color: 'blue',
   width: 25,
   height: 25,
+  renderIcon: null,
 };
 
 const StyledHotspot = styled(({ className, children }) => (
@@ -77,7 +71,18 @@ const StyledHotspot = styled(({ className, children }) => (
 /**
  * This component renders a hotspot with content over an image
  */
-const Hotspot = ({ x, y, content, icon, iconDescription, color, width, height, ...others }) => {
+const Hotspot = ({
+  x,
+  y,
+  content,
+  icon,
+  iconDescription,
+  color,
+  width,
+  height,
+  renderIcon,
+  ...others
+}) => {
   const defaultIcon = (
     <svg width={width} height={height}>
       <circle
@@ -100,23 +105,32 @@ const Hotspot = ({ x, y, content, icon, iconDescription, color, width, height, .
     </svg>
   );
 
+  const iconToRender = icon ? (
+    renderIcon ? (
+      renderIcon(icon, {
+        title: iconDescription,
+        fill: color,
+        width,
+        height,
+      })
+    ) : (
+      <Icon
+        icon={icons[icon] || icons.help}
+        fill={color}
+        width={parseInt(width, 10).toString()}
+        height={parseInt(height, 10).toString()}
+        description={iconDescription}
+      />
+    )
+  ) : (
+    defaultIcon
+  );
+
   return (
     <StyledHotspot x={x} y={y} width={width} height={height} icon={icon}>
       <Tooltip
         {...others}
-        triggerText={
-          icon ? (
-            <Icon
-              icon={icons[icon]}
-              fill={color}
-              width={parseInt(width, 10).toString()}
-              height={parseInt(height, 10).toString()}
-              description={iconDescription}
-            />
-          ) : (
-            defaultIcon
-          )
-        }
+        triggerText={iconToRender}
         showIcon={false}
         clickToOpen
         triggerId={`hotspot-${x}-${y}`}

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -42,7 +42,7 @@ const ImageCard = ({
   error,
   isLoading,
   i18n: { loadingDataLabel, ...otherLabels },
-  renderIcon,
+  renderIconByName,
   ...others
 }) => {
   const { src } = content;
@@ -85,7 +85,7 @@ const ImageCard = ({
                     hotspots={hotspots}
                     isHotspotDataLoading={isLoading}
                     loadingHotspotsLabel={loadingDataLabel}
-                    renderIcon={renderIcon}
+                    renderIconByName={renderIconByName}
                   />
                 ) : (
                   <p>Error retrieving image.</p>

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -42,6 +42,7 @@ const ImageCard = ({
   error,
   isLoading,
   i18n: { loadingDataLabel, ...otherLabels },
+  renderIcon,
   ...others
 }) => {
   const { src } = content;
@@ -84,6 +85,7 @@ const ImageCard = ({
                     hotspots={hotspots}
                     isHotspotDataLoading={isLoading}
                     loadingHotspotsLabel={loadingDataLabel}
+                    renderIcon={renderIcon}
                   />
                 ) : (
                   <p>Error retrieving image.</p>

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { text, select, object, boolean } from '@storybook/addon-knobs';
 import omit from 'lodash/omit';
+import { Bee16, Checkmark16 } from '@carbon/icons-react';
 
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
@@ -22,6 +23,7 @@ const values = {
       x: 35,
       y: 65,
       icon: 'arrowDown',
+      color: 'purple',
       content: <span style={{ padding: '10px' }}>Elevators</span>,
     },
     {
@@ -57,6 +59,36 @@ storiesOf('Watson IoT|ImageCard', module)
           values={object('values', values)}
           breakpoint="lg"
           size={size}
+          onCardAction={action('onCardAction')}
+        />
+      </div>
+    );
+  })
+  .add('custom renderIcon', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <ImageCard
+          title={text('title', 'Image')}
+          id="image-hotspots"
+          content={object('content', content)}
+          values={object('values', values)}
+          breakpoint="lg"
+          size={size}
+          renderIcon={(name, props = {}) => {
+            console.log('renderIcon', name, props);
+            return name === 'arrowDown' ? (
+              <Bee16 {...props}>
+                <title>{props.title}</title>
+              </Bee16>
+            ) : name === 'arrowUp' ? (
+              <Checkmark16 {...props}>
+                <title>{props.title}</title>
+              </Checkmark16>
+            ) : (
+              <span>Unknown</span>
+            );
+          }}
           onCardAction={action('onCardAction')}
         />
       </div>

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -75,9 +75,8 @@ storiesOf('Watson IoT|ImageCard', module)
           values={object('values', values)}
           breakpoint="lg"
           size={size}
-          renderIcon={(name, props = {}) => {
-            console.log('renderIcon', name, props);
-            return name === 'arrowDown' ? (
+          renderIcon={(name, props = {}) =>
+            name === 'arrowDown' ? (
               <Bee16 {...props}>
                 <title>{props.title}</title>
               </Bee16>
@@ -87,8 +86,8 @@ storiesOf('Watson IoT|ImageCard', module)
               </Checkmark16>
             ) : (
               <span>Unknown</span>
-            );
-          }}
+            )
+          }
           onCardAction={action('onCardAction')}
         />
       </div>

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -64,7 +64,7 @@ storiesOf('Watson IoT|ImageCard', module)
       </div>
     );
   })
-  .add('custom renderIcon', () => {
+  .add('custom renderIconByName', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -75,7 +75,7 @@ storiesOf('Watson IoT|ImageCard', module)
           values={object('values', values)}
           breakpoint="lg"
           size={size}
-          renderIcon={(name, props = {}) =>
+          renderIconByName={(name, props = {}) =>
             name === 'arrowDown' ? (
               <Bee16 {...props}>
                 <title>{props.title}</title>

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -25,7 +25,7 @@ const propTypes = {
   /** Current width in pixels */
   width: PropTypes.number.isRequired,
   zoomMax: PropTypes.number,
-  renderIcon: PropTypes.func,
+  renderIconByName: PropTypes.func,
 };
 
 const defaultProps = {
@@ -38,7 +38,7 @@ const defaultProps = {
   isHotspotDataLoading: false,
   background: '#eee',
   zoomMax: undefined,
-  renderIcon: null,
+  renderIconByName: null,
 };
 
 export const startDrag = (event, element, cursor, setCursor) => {
@@ -317,7 +317,7 @@ const ImageHotspots = ({
   alt,
   isHotspotDataLoading,
   zoomMax,
-  renderIcon,
+  renderIconByName,
 }) => {
   // Image needs to be stored in state because we're dragging it around when zoomed in, and we need to keep track of when it loads
   const [image, setImage] = useState({});
@@ -399,11 +399,11 @@ const ImageHotspots = ({
             style={hotspotsStyle}
             offsetX={image.offsetX}
             offsetY={image.offsetY}
-            renderIcon={renderIcon}
+            renderIconByName={renderIconByName}
           />
         );
       }),
-    [hotspots, hotspotsStyle, image.offsetX, image.offsetY, renderIcon]
+    [hotspots, hotspotsStyle, image.offsetX, image.offsetY, renderIconByName]
   );
 
   if (imageLoaded) {

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -25,6 +25,7 @@ const propTypes = {
   /** Current width in pixels */
   width: PropTypes.number.isRequired,
   zoomMax: PropTypes.number,
+  renderIcon: PropTypes.func,
 };
 
 const defaultProps = {
@@ -37,6 +38,7 @@ const defaultProps = {
   isHotspotDataLoading: false,
   background: '#eee',
   zoomMax: undefined,
+  renderIcon: null,
 };
 
 export const startDrag = (event, element, cursor, setCursor) => {
@@ -315,6 +317,7 @@ const ImageHotspots = ({
   alt,
   isHotspotDataLoading,
   zoomMax,
+  renderIcon,
 }) => {
   // Image needs to be stored in state because we're dragging it around when zoomed in, and we need to keep track of when it loads
   const [image, setImage] = useState({});
@@ -396,10 +399,11 @@ const ImageHotspots = ({
             style={hotspotsStyle}
             offsetX={image.offsetX}
             offsetY={image.offsetY}
+            renderIcon={renderIcon}
           />
         );
       }),
-    [hotspots, hotspotsStyle, image.offsetX, image.offsetY]
+    [hotspots, hotspotsStyle, image.offsetX, image.offsetY, renderIcon]
   );
 
   if (imageLoaded) {

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -147,7 +147,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
                   >
                     <svg
                       aria-label=""
-                      fill="blue"
+                      fill="purple"
                       fillRule="evenodd"
                       height="25"
                       role="img"
@@ -280,6 +280,415 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
                       <path
                         d="M5.993 4.047l-3.905 4.09L.635 6.763 6.992 0l6.366 6.762-1.452 1.376-3.913-4.092V16h-2V4.047z"
                       />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "bottom": 10,
+                    "pointerEvents": "auto",
+                    "position": "absolute",
+                    "right": 10,
+                  }
+                }
+              >
+                <button
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "background": "#fff",
+                      "border": "none",
+                      "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                      "height": "25px",
+                      "width": "25px",
+                    }
+                  }
+                  type="button"
+                >
+                  +
+                </button>
+                <br />
+                <button
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "background": "#fff",
+                      "border": "none",
+                      "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                      "height": "25px",
+                      "width": "25px",
+                    }
+                  }
+                  type="button"
+                >
+                  -
+                </button>
+              </div>
+              <div
+                style={
+                  Object {
+                    "background": "#fff",
+                    "bottom": 10,
+                    "boxShadow": "0px 0px 2px 0px rgba(0,0,0,0.5)",
+                    "display": "block",
+                    "height": null,
+                    "left": 10,
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "width": null,
+                  }
+                }
+              >
+                <img
+                  alt="Minimap"
+                  height={null}
+                  src="landscape.jpg"
+                  width={null}
+                />
+                <div
+                  style={
+                    Object {
+                      "background": "rgba(64, 139, 252, 0.1)",
+                      "border": "1px solid rgba(64, 139, 252, 0.8)",
+                      "display": "block",
+                      "height": null,
+                      "left": 0,
+                      "pointerEvents": "none",
+                      "position": "absolute",
+                      "top": 0,
+                      "width": null,
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ImageCard custom renderIcon 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "1056px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 kGdXdI"
+        id="image-hotspots"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Image"
+          >
+            Image
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          >
+            <button
+              className="card--toolbar-action Card__TinyButton-v5r71h-4 fggzfz bx--btn bx--btn--sm bx--btn--ghost"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex={0}
+              title="Expand to fullscreen"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                aria-label="Expand to fullscreen"
+                className="bx--btn__icon"
+                focusable="false"
+                height={20}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                style={
+                  Object {
+                    "willChange": "transform",
+                  }
+                }
+                viewBox="0 0 32 32"
+                width={20}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                />
+                <path
+                  d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 jAGfWa"
+        >
+          <div
+            className="ImageCard__ContentWrapper-sc-1p2j9dm-0 jJnAwR"
+          >
+            <div
+              onBlur={[Function]}
+              onMouseOut={[Function]}
+              style={
+                Object {
+                  "background": "#eee",
+                  "height": "100%",
+                  "overflow": "hidden",
+                  "position": "relative",
+                  "textAlign": "center",
+                  "width": "100%",
+                }
+              }
+            >
+              <img
+                alt="Sample image"
+                onLoad={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                onMouseUp={[Function]}
+                src="landscape.jpg"
+                style={
+                  Object {
+                    "left": undefined,
+                    "position": "relative",
+                    "top": undefined,
+                  }
+                }
+              />
+              <div
+                style={
+                  Object {
+                    "left": undefined,
+                    "margin": "auto",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": "auto",
+                    "top": undefined,
+                  }
+                }
+              >
+                <div
+                  className="Hotspot__StyledHotspot-nlpwmi-0 fvESgj"
+                >
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    aria-labelledby="hotspot-35-65"
+                    className="bx--tooltip__label"
+                    id="hotspot-35-65"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="purple"
+                      focusable="false"
+                      height={25}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      title=""
+                      viewBox="0 0 32 32"
+                      width={25}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                      />
+                      <title>
+                        
+                      </title>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="Hotspot__StyledHotspot-nlpwmi-0 kwumIH"
+                >
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    aria-labelledby="hotspot-45-25"
+                    className="bx--tooltip__label"
+                    id="hotspot-45-25"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      height={25}
+                      width={25}
+                    >
+                      <circle
+                        cx={12.5}
+                        cy={12.5}
+                        fill="none"
+                        opacity="1"
+                        r={11.5}
+                        stroke="white"
+                        strokeWidth="2"
+                      />
+                      <circle
+                        cx={12.5}
+                        cy={12.5}
+                        fill="#0f0"
+                        opacity="0.7"
+                        r={11.5}
+                        stroke="none"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="Hotspot__StyledHotspot-nlpwmi-0 eqtfro"
+                >
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    aria-labelledby="hotspot-45-50"
+                    className="bx--tooltip__label"
+                    id="hotspot-45-50"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      height={25}
+                      width={25}
+                    >
+                      <circle
+                        cx={12.5}
+                        cy={12.5}
+                        fill="none"
+                        opacity="1"
+                        r={11.5}
+                        stroke="white"
+                        strokeWidth="2"
+                      />
+                      <circle
+                        cx={12.5}
+                        cy={12.5}
+                        fill="#00f"
+                        opacity="0.7"
+                        r={11.5}
+                        stroke="none"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="Hotspot__StyledHotspot-nlpwmi-0 ezcTmr"
+                >
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    aria-labelledby="hotspot-45-75"
+                    className="bx--tooltip__label"
+                    id="hotspot-45-75"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="blue"
+                      focusable="false"
+                      height={25}
+                      preserveAspectRatio="xMidYMid meet"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      title=""
+                      viewBox="0 0 16 16"
+                      width={25}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M6 10.6L2.5 7.1l-.7.7 3.5 3.5.7.7 7.1-7.1-.7-.7z"
+                      />
+                      <title>
+                        
+                      </title>
                     </svg>
                   </div>
                 </div>

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -395,7 +395,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ImageCard custom renderIcon 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ImageCard custom renderIconByName 1`] = `
 <div
   className="storybook-container"
   style={

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -81,7 +81,7 @@ const propTypes = {
       icon: PropTypes.string,
     })
   ),
-  renderIcon: PropTypes.func,
+  renderIconByName: PropTypes.func,
   precision: PropTypes.number,
 };
 
@@ -94,7 +94,7 @@ const defaultProps = {
   isSmall: false,
   isMini: false,
   label: null,
-  renderIcon: null,
+  renderIconByName: null,
   secondaryValue: null,
 };
 
@@ -113,7 +113,7 @@ const Attribute = ({
   isSmall,
   isMini,
   label,
-  renderIcon,
+  renderIconByName,
   size, // eslint-disable-line
 }) => {
   // matching threshold will be the first match in the list, or a value of null
@@ -148,8 +148,8 @@ const Attribute = ({
   const thresholdIcon =
     matchingThreshold && matchingThreshold.icon ? (
       <ThresholdIconWrapper isMini={isMini}>
-        {renderIcon ? (
-          renderIcon(matchingThreshold.icon, thresholdIconProps)
+        {renderIconByName ? (
+          renderIconByName(matchingThreshold.icon, thresholdIconProps)
         ) : (
           <ThresholdIcon
             icon={icons[matchingThreshold.icon] || icons.help}

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -81,6 +81,7 @@ const propTypes = {
       icon: PropTypes.string,
     })
   ),
+  renderIcon: PropTypes.func,
   precision: PropTypes.number,
 };
 
@@ -93,6 +94,7 @@ const defaultProps = {
   isSmall: false,
   isMini: false,
   label: null,
+  renderIcon: null,
   secondaryValue: null,
 };
 
@@ -111,6 +113,7 @@ const Attribute = ({
   isSmall,
   isMini,
   label,
+  renderIcon,
   size, // eslint-disable-line
 }) => {
   // matching threshold will be the first match in the list, or a value of null
@@ -134,15 +137,27 @@ const Attribute = ({
     .concat([null])[0];
   const valueColor =
     matchingThreshold && matchingThreshold.icon === undefined ? matchingThreshold.color : null;
+  const thresholdIconProps = matchingThreshold
+    ? {
+        title: `${matchingThreshold.comparison} ${matchingThreshold.value}`,
+        fill: matchingThreshold.color,
+        tabindex: 0,
+        description: `${matchingThreshold.comparison} ${matchingThreshold.value}`,
+      }
+    : {};
   const thresholdIcon =
     matchingThreshold && matchingThreshold.icon ? (
       <ThresholdIconWrapper isMini={isMini}>
-        <ThresholdIcon
-          iconTitle={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
-          icon={icons[matchingThreshold.icon]}
-          fill={matchingThreshold.color}
-          description={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
-        />
+        {renderIcon ? (
+          renderIcon(matchingThreshold.icon, thresholdIconProps)
+        ) : (
+          <ThresholdIcon
+            icon={icons[matchingThreshold.icon] || icons.help}
+            iconTitle={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
+            fill={matchingThreshold.color}
+            description={`${matchingThreshold.comparison} ${matchingThreshold.value}`}
+          />
+        )}
       </ThresholdIconWrapper>
     ) : null;
 

--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -259,6 +259,7 @@ const ValueCard = ({ title, content, size, values, isEditable, ...others }) => {
                         size === CARD_SIZES.SMALL && attributes.length === 1 ? 'center' : undefined
                       }
                       {...attribute}
+                      renderIcon={others.renderIcon}
                       size={size} // When the card is in the editable state, we will show a preview
                       value={isEditable ? '--' : determineValue(attribute.dataSourceId, values)}
                       secondaryValue={

--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -259,7 +259,7 @@ const ValueCard = ({ title, content, size, values, isEditable, ...others }) => {
                         size === CARD_SIZES.SMALL && attributes.length === 1 ? 'center' : undefined
                       }
                       {...attribute}
-                      renderIcon={others.renderIcon}
+                      renderIconByName={others.renderIconByName}
                       size={size} // When the card is in the editable state, we will show a preview
                       value={isEditable ? '--' : determineValue(attribute.dataSourceId, values)}
                       secondaryValue={

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -215,9 +215,8 @@ storiesOf('Watson IoT|ValueCard', module)
         <ValueCard
           title={text('title', 'Alert Count')}
           id="facilitycard"
-          renderIcon={(name, props = {}) => {
-            console.log('renderIcon', name, props);
-            return name === 'bee' ? (
+          renderIcon={(name, props = {}) =>
+            name === 'bee' ? (
               <Bee16 {...props}>
                 <title>{props.title}</title>
               </Bee16>
@@ -227,8 +226,8 @@ storiesOf('Watson IoT|ValueCard', module)
               </Checkmark16>
             ) : (
               <span>Unknown</span>
-            );
-          }}
+            )
+          }
           content={{
             attributes: [
               {

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { text, select, object, boolean, number } from '@storybook/addon-knobs';
+import { Bee16, Checkmark16 } from '@carbon/icons-react';
 
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
@@ -194,6 +195,49 @@ storiesOf('Watson IoT|ValueCard', module)
                     comparison: '<',
                     value: 5,
                     icon: 'checkmark',
+                    color: 'green',
+                  },
+                ],
+              },
+            ],
+          }}
+          breakpoint="lg"
+          size={size}
+          values={{ alertCount: number('alertCount', 4) }}
+        />
+      </div>
+    );
+  })
+  .add('xsmall / thresholds (number, custom icon)', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <ValueCard
+          title={text('title', 'Alert Count')}
+          id="facilitycard"
+          renderIcon={(name, props = {}) => {
+            console.log('renderIcon', name, props);
+            return name === 'bee' ? (
+              <Bee16 {...props}>
+                <title>{props.title}</title>
+              </Bee16>
+            ) : name === 'checkmark' ? (
+              <Checkmark16 {...props}>
+                <title>{props.title}</title>
+              </Checkmark16>
+            ) : (
+              <span>Unknown</span>
+            );
+          }}
+          content={{
+            attributes: [
+              {
+                dataSourceId: 'alertCount',
+                thresholds: [
+                  {
+                    comparison: '<',
+                    value: 5,
+                    icon: 'bee',
                     color: 'green',
                   },
                 ],

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -208,14 +208,14 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / thresholds (number, custom icon)', () => {
+  .add('xsmall / thresholds (number, custom renderIconByName)', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ValueCard
           title={text('title', 'Alert Count')}
           id="facilitycard"
-          renderIcon={(name, props = {}) =>
+          renderIconByName={(name, props = {}) =>
             name === 'bee' ? (
               <Bee16 {...props}>
                 <title>{props.title}</title>

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -2700,7 +2700,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / thresholds (number, custom icon) 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / thresholds (number, custom renderIconByName) 1`] = `
 <div
   className="storybook-container"
   style={

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -2700,6 +2700,149 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / thresholds (number, custom icon) 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "118px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 fbzdtE"
+        id="facilitycard"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Alert Count"
+          >
+            Alert Count
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          />
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 hoCWQe"
+        >
+          <div
+            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+          >
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="XSMALL"
+            >
+              <div
+                className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                label={null}
+                size="XSMALL"
+              >
+                <div
+                  className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                  color={null}
+                >
+                  <span
+                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    size="XSMALL"
+                    title="4 "
+                    value={4}
+                  >
+                    4
+                  </span>
+                </div>
+                <div
+                  className="Attribute__StyledIcon-dhraql-5 gssLPC"
+                >
+                  <div
+                    className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
+                  >
+                    <svg
+                      description="< 5"
+                      fill="green"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      title="< 5"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                      />
+                      <title>
+                        &lt; 5
+                      </title>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                size="XSMALL"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / thresholds (number, icon) 1`] = `
 <div
   className="storybook-container"

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -19,15 +19,7 @@ export const AttributePropTypes = PropTypes.shape({
       comparison: PropTypes.oneOf(['<', '>', '=', '<=', '>=']).isRequired,
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
       color: PropTypes.string,
-      icon: PropTypes.oneOfType([
-        PropTypes.oneOf(bundledIconNames),
-        PropTypes.shape({
-          width: PropTypes.string,
-          height: PropTypes.string,
-          viewBox: PropTypes.string.isRequired,
-          svgData: PropTypes.object.isRequired,
-        }),
-      ]),
+      icon: PropTypes.string,
     })
   ),
   unit: PropTypes.string,

--- a/src/utils/bundledIcons.js
+++ b/src/utils/bundledIcons.js
@@ -7,6 +7,9 @@ import {
   iconWarningSolid,
   iconArrowDown,
   iconArrowUp,
+  iconHeaderUser,
+  iconInfo,
+  iconHelp,
 } from 'carbon-icons';
 
 export const bundledIconNames = [
@@ -18,6 +21,9 @@ export const bundledIconNames = [
   'warning',
   'arrowUp',
   'arrowDown',
+  'user',
+  'info',
+  'help',
 ];
 
 export default {
@@ -29,4 +35,7 @@ export default {
   warning: iconWarningSolid,
   arrowUp: iconArrowUp,
   arrowDown: iconArrowDown,
+  user: iconHeaderUser,
+  info: iconInfo,
+  help: iconHelp,
 };


### PR DESCRIPTION
**Summary**

`<Dashboard>` now accepts a render prop for icons `renderIcon` that can be used to allow the parent component to override the default icon rendering logic (i.e. matching to one of the "bundled" icons).  This is available at the card level as well, to `ValueCard` and `ImageCard` (which render dynamic icons for thresholds).

Example:

```
<ValueCard
  title={text('title', 'Alert Count')}
  id="facilitycard"
  renderIcon={(name, props = {}) => name === 'bee' ? (
    <Bee16 {...props}>
      <title>{props.title}</title>
    </Bee16>
  ) : null}
 />
```

**Acceptance Test (how to verify the PR)**

- Verify the added stories under Dashboard, ValueCard, and ImageCard for custom renderIcon

![image](https://user-images.githubusercontent.com/2175647/68900282-1fe5d200-06f9-11ea-8394-0cbb48f93125.png)
