### PR TITLE
fix(attribute): camelCase tabIndex to fix warning

### DIFF
--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -141,7 +141,7 @@ const Attribute = ({
     ? {
         title: `${matchingThreshold.comparison} ${matchingThreshold.value}`,
         fill: matchingThreshold.color,
-        tabindex: 0,
+        tabIndex: '0',
         description: `${matchingThreshold.comparison} ${matchingThreshold.value}`,
       }
     : {};

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -2783,7 +2783,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     <svg
                       description="< 5"
                       fill="green"
-                      focusable="false"
+                      focusable="true"
                       height={16}
                       preserveAspectRatio="xMidYMid meet"
                       role="img"
@@ -2792,6 +2792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                           "willChange": "transform",
                         }
                       }
+                      tabIndex="0"
                       title="< 5"
                       viewBox="0 0 32 32"
                       width={16}


### PR DESCRIPTION
**Summary**

- small fix from renderIcon work, pass `tabIndex` in attribute as camelcase to fix warning

**Acceptance Test (how to verify the PR)**

- tests pass
