### PR TITLE
feat(range): support minute and quarter ranges for data

### DIFF
--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -232,7 +232,7 @@ export const CardPropTypes = {
     '',
   ]),
   /** Interval for time series configuration */
-  interval: PropTypes.oneOf(['hour', 'day', 'week', 'month', 'year']),
+  interval: PropTypes.oneOf(['minute', 'hour', 'day', 'week', 'quarter', 'month', 'year']),
   availableActions: PropTypes.shape({
     edit: PropTypes.bool,
     clone: PropTypes.bool,

--- a/src/utils/schemas/dashboardContent.json
+++ b/src/utils/schemas/dashboardContent.json
@@ -64,7 +64,7 @@
       "properties": {
         "type": { "enum": ["periodToDate", "rolling"] },
         "count": { "type": "number" },
-        "interval": { "enum": ["month", "day", "year", "hour", "week"] }
+        "interval": { "enum": ["minute", "hour", "day", "week", "month", "quarter", "year"] }
       },
       "required": ["count", "interval"],
       "propertyNames": { "enum": ["type", "count", "interval"] }

--- a/src/utils/schemas/imageCardContent.json
+++ b/src/utils/schemas/imageCardContent.json
@@ -131,15 +131,6 @@
         "color": { "type": "string" },
         "icon": { "type": "string" }
       }
-    },
-    "range": {
-      "type": "object",
-      "properties": {
-        "count": { "type": "number" },
-        "interval": { "enum": ["hour", "day", "week", "month"] }
-      },
-      "propertyNames": { "enum": ["count", "interval"] },
-      "required": ["count", "interval"]
     }
   }
 }

--- a/src/utils/schemas/valueCardContent.json
+++ b/src/utils/schemas/valueCardContent.json
@@ -61,15 +61,6 @@
         "color": { "type": "string" },
         "icon": { "type": "string" }
       }
-    },
-    "range": {
-      "type": "object",
-      "properties": {
-        "count": { "type": "number" },
-        "interval": { "enum": ["hour", "day", "week", "month"] }
-      },
-      "propertyNames": { "enum": ["count", "interval"] },
-      "required": ["count", "interval"]
     }
   }
 }


### PR DESCRIPTION
Add additional minute and quarter support for data ranges

remove redundant validation rules from the image and value card so there's only one place