### PR TITLE
feat(cardrange): simplify range picker UX

### DIFF
--- a/src/components/Card/CardRangePicker.jsx
+++ b/src/components/Card/CardRangePicker.jsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import ChevronDown16 from '@carbon/icons-react/lib/chevron--down/16';
+import { ToolbarItem, OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
+
+const StyledOverflowMenu = styled(OverflowMenu)`
+  & svg.bx--overflow-menu__icon {
+    padding: 0;
+  }
+`;
+
+const TimeRangeLabel = styled.span`
+  font-size: 0.875rem;
+  font-weight: normal;
+`;
+
+export const CardRangePickerPropTypes = {
+  /** width of the card in pixels */
+  width: PropTypes.number,
+  /** Optional range to pass at the card level */
+  timeRange: PropTypes.oneOf([
+    'last24Hours',
+    'last7Days',
+    'lastMonth',
+    'lastQuarter',
+    'lastYear',
+    'thisWeek',
+    'thisMonth',
+    'thisQuarter',
+    'thisYear',
+    '',
+  ]),
+  /** callback to handle interactions with the range picker */
+  onCardAction: PropTypes.func.isRequired,
+  /** callback to close the overflow menu */
+  onClose: PropTypes.func.isRequired,
+  /** set of internationalized labels */
+  i18n: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.func])).isRequired,
+};
+
+const defaultProps = {
+  timeRange: null,
+  width: 0,
+};
+
+const CardRangePicker = ({ i18n, width, timeRange: timeRangeProp, onCardAction, onClose }) => {
+  const [timeRange, setTimeRange] = useState(timeRangeProp);
+  // maps the timebox internal label to a translated string
+  const timeBoxLabels = {
+    last24Hours: i18n.last24HoursLabel,
+    last7Days: i18n.last7DaysLabel,
+    lastMonth: i18n.lastMonthLabel,
+    lastQuarter: i18n.lastQuarterLabel,
+    lastYear: i18n.lastYearLabel,
+    thisWeek: i18n.thisWeekLabel,
+    thisMonth: i18n.thisMonthLabel,
+    thisQuarter: i18n.thisQuarterLabel,
+    thisYear: i18n.thisYearLabel,
+  };
+
+  return (
+    <ToolbarItem>
+      <TimeRangeLabel id="timeRange">{timeBoxLabels[timeRange]}</TimeRangeLabel>
+      <StyledOverflowMenu
+        floatingMenu
+        renderIcon={ChevronDown16}
+        iconDescription={width < 230 ? timeBoxLabels[timeRange] : i18n.overflowMenuDescription}
+      >
+        <OverflowMenuItem
+          key="default"
+          onClick={() => {
+            onClose();
+            onCardAction('CHANGE_TIME_RANGE', { range: 'default' });
+            setTimeRange('default');
+          }}
+          itemText={i18n.defaultLabel}
+        />
+        {Object.keys(timeBoxLabels)
+          .filter(i => i.includes('last'))
+          .map(i => (
+            <OverflowMenuItem
+              key={i}
+              onClick={() => {
+                onClose();
+                onCardAction('CHANGE_TIME_RANGE', { range: i });
+                setTimeRange(i);
+              }}
+              itemText={timeBoxLabels[i]}
+            />
+          ))}
+        {Object.keys(timeBoxLabels)
+          .filter(i => i.includes('this'))
+          .map(i => (
+            <OverflowMenuItem
+              key={i}
+              onClick={() => {
+                onClose();
+                onCardAction('CHANGE_TIME_RANGE', { range: i });
+                setTimeRange(i);
+              }}
+              itemText={timeBoxLabels[i]}
+            />
+          ))}
+      </StyledOverflowMenu>
+    </ToolbarItem>
+  );
+};
+
+CardRangePicker.propTypes = CardRangePickerPropTypes;
+CardRangePicker.defaultProps = defaultProps;
+export default CardRangePicker;

--- a/src/components/Card/CardRangePicker.jsx
+++ b/src/components/Card/CardRangePicker.jsx
@@ -78,9 +78,10 @@ const CardRangePicker = ({ i18n, width, timeRange: timeRangeProp, onCardAction, 
         />
         {Object.keys(timeBoxLabels)
           .filter(i => i.includes('last'))
-          .map(i => (
+          .map((i, index) => (
             <OverflowMenuItem
               key={i}
+              hasDivider={index === 0}
               onClick={() => {
                 onClose();
                 onCardAction('CHANGE_TIME_RANGE', { range: i });
@@ -91,9 +92,10 @@ const CardRangePicker = ({ i18n, width, timeRange: timeRangeProp, onCardAction, 
           ))}
         {Object.keys(timeBoxLabels)
           .filter(i => i.includes('this'))
-          .map(i => (
+          .map((i, index) => (
             <OverflowMenuItem
               key={i}
+              hasDivider={index === 0}
               onClick={() => {
                 onClose();
                 onCardAction('CHANGE_TIME_RANGE', { range: i });

--- a/src/components/Card/CardToolbar.jsx
+++ b/src/components/Card/CardToolbar.jsx
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import uuidv1 from 'uuid/v1';
+import omit from 'lodash/omit';
+import styled from 'styled-components';
+import Close16 from '@carbon/icons-react/lib/close/16';
+import Popup20 from '@carbon/icons-react/lib/popup/20';
+import {
+  Toolbar,
+  ToolbarItem,
+  OverflowMenu,
+  OverflowMenuItem,
+  Button,
+} from 'carbon-components-react';
+
+import CardRangePicker, { CardRangePickerPropTypes } from './CardRangePicker';
+
+const StyledToolbar = styled(Toolbar)`
+  &.bx--toolbar {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  div.bx--overflow-menu {
+    height: 30px;
+  }
+`;
+const TinyButton = styled(Button)`
+  &.bx--btn > svg {
+    margin: 0;
+  }
+`;
+const propTypes = {
+  /** set of available actions for the card */
+  availableActions: PropTypes.objectOf(PropTypes.bool).isRequired,
+  /** is the card editable */
+  isEditable: PropTypes.bool,
+  /** is the card expanded */
+  isExpanded: PropTypes.bool,
+  ...omit(CardRangePickerPropTypes, 'onClose'),
+};
+const defaultProps = {
+  isEditable: false,
+  isExpanded: false,
+};
+const CardToolbar = ({
+  i18n,
+  width,
+  isEditable,
+  isExpanded,
+  availableActions,
+  timeRange,
+  onCardAction,
+}) => {
+  const [tooltipId, setTooltipId] = useState(uuidv1());
+
+  return isEditable ? (
+    <StyledToolbar key={tooltipId}>
+      {(availableActions.edit || availableActions.clone || availableActions.delete) && (
+        <ToolbarItem>
+          <OverflowMenu floatingMenu>
+            {availableActions.edit && (
+              <OverflowMenuItem
+                onClick={() => {
+                  setTooltipId(uuidv1());
+                  onCardAction('EDIT_CARD');
+                }}
+                itemText={i18n.editCardLabel}
+              />
+            )}
+            {availableActions.clone && (
+              <OverflowMenuItem
+                onClick={() => {
+                  setTooltipId(uuidv1());
+                  onCardAction('CLONE_CARD');
+                }}
+                itemText={i18n.cloneCardLabel}
+              />
+            )}
+            {availableActions.delete && (
+              <OverflowMenuItem
+                isDelete
+                onClick={() => {
+                  setTooltipId(uuidv1());
+                  onCardAction('DELETE_CARD');
+                }}
+                itemText={i18n.deleteCardLabel}
+              />
+            )}
+          </OverflowMenu>
+        </ToolbarItem>
+      )}
+    </StyledToolbar>
+  ) : (
+    <StyledToolbar key={tooltipId}>
+      {availableActions.range ? (
+        <CardRangePicker
+          width={width}
+          i18n={i18n}
+          timeRange={timeRange}
+          onCardAction={onCardAction}
+          onClose={() => setTooltipId(uuidv1())}
+        />
+      ) : null}
+      {availableActions.expand ? (
+        <ToolbarItem>
+          {isExpanded ? (
+            <TinyButton
+              kind="ghost"
+              small
+              renderIcon={Close16}
+              iconDescription={i18n.closeLabel}
+              title={i18n.closeLabel}
+              onClick={() => onCardAction('CLOSE_EXPANDED_CARD')}
+            />
+          ) : (
+            <TinyButton
+              kind="ghost"
+              small
+              renderIcon={Popup20}
+              iconDescription={i18n.expandLabel}
+              title={i18n.expandLabel}
+              onClick={() => {
+                onCardAction('OPEN_EXPANDED_CARD');
+              }}
+            />
+          )}
+        </ToolbarItem>
+      ) : null}
+    </StyledToolbar>
+  );
+};
+
+CardToolbar.propTypes = propTypes;
+CardToolbar.defaultProps = defaultProps;
+export default CardToolbar;


### PR DESCRIPTION
Makes the card range picker better match the PAL library version of the range picker:

![image](https://user-images.githubusercontent.com/6663002/70092214-65543b80-15e3-11ea-87b9-609a0d00bf24.png)

It's not a one to one match, but it's close.