### PR TITLE
fix(cardrenderer): don't prevent loading when a card is in error

### DIFF
--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -88,7 +88,8 @@ const CardRenderer = React.memo(
             updatedCard = await onSetupCard(card);
             setCard(updatedCard);
           }
-          if (!updatedCard.error) {
+          if (!updatedCard.setupError) {
+            // don't load the card data if the setup failed
             loadCardData(updatedCard, setCard, onFetchData, timeGrain);
           }
         };
@@ -184,6 +185,7 @@ const CardRenderer = React.memo(
         ) : type === CARD_TYPES.IMAGE ? (
           <ImageCard
             {...card}
+            error={card.setupError || card.error}
             key={card.id}
             availableActions={cachedActions}
             dataSource={dataSource}

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -88,10 +88,7 @@ const CardRenderer = React.memo(
             updatedCard = await onSetupCard(card);
             setCard(updatedCard);
           }
-          if (!updatedCard.setupError) {
-            // don't load the card data if the setup failed
-            loadCardData(updatedCard, setCard, onFetchData, timeGrain);
-          }
+          loadCardData(updatedCard, setCard, onFetchData, timeGrain);
         };
         if (isLoading) {
           setupAndLoadCard();


### PR DESCRIPTION
small fix, we should allow cards to reload when they're in error and show if there's a setupError passed to a card.