### PR TITLE
fix(tablereducer): preserve the pagesize even if the data changes

### DIFF
--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -226,10 +226,11 @@ export const tableReducer = (state = {}, action) => {
       const updatedData = action.payload.data || state.data;
       const { view, totalItems } = action.payload;
       const { pageSize, pageSizes } = get(view, 'pagination') || {};
+      const paginationFromState = get(state, 'view.pagination');
       const pagination = get(state, 'view.pagination')
         ? {
             totalItems: { $set: totalItems || updatedData.length },
-            pageSize: { $set: pageSize },
+            pageSize: { $set: paginationFromState.pageSize || pageSize },
             pageSizes: { $set: pageSizes },
           }
         : {};


### PR DESCRIPTION
Closes Internal bug
[Internal tracking issue #158](https://github.ibm.com/Watson-IoT/pal-tracking/issues/158)

**Summary**

- Page size is being reset to the default anytime the data within the table changes

**Change List (commits, features, bugs, etc)**

- Small change to preserve the existing pagesize when the data changes.

**Acceptance Test (how to verify the PR)**

- Set the pagesize in a table, then change it's data
