### PR TITLE
feat(tablehead): add column selection config button

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -83,6 +83,7 @@ const propTypes = {
     /** has simple search capability */
     hasSearch: PropTypes.bool,
     hasColumnSelection: PropTypes.bool,
+    hasColumnSelectionConfig: PropTypes.bool,
     shouldLazyRender: PropTypes.bool,
     hasRowCountInHeader: PropTypes.bool,
   }),
@@ -178,6 +179,7 @@ const propTypes = {
       onClearRowError: PropTypes.func,
       onEmptyStateAction: PropTypes.func,
       onChangeOrdering: PropTypes.func,
+      onColumnSelectionConfig: PropTypes.func,
     }).isRequired,
   }),
   i18n: I18NPropTypes,
@@ -197,6 +199,7 @@ export const defaultProps = baseProps => ({
     hasOnlyPageData: false,
     hasSearch: false,
     hasColumnSelection: false,
+    hasColumnSelectionConfig: false,
     shouldLazyRender: false,
   },
   view: {
@@ -239,6 +242,7 @@ export const defaultProps = baseProps => ({
       onApplyRowAction: defaultFunction('actions.table.onApplyRowAction'),
       onEmptyStateAction: defaultFunction('actions.table.onEmptyStateAction'),
       onChangeOrdering: defaultFunction('actions.table.onChangeOrdering'),
+      onColumnSelectionConfig: defaultFunction('actions.table.onColumnSelectionConfig'),
     },
   },
   i18n: {
@@ -260,6 +264,7 @@ export const defaultProps = baseProps => ({
     /** toolbar */
     clearAllFilters: 'Clear all filters',
     columnSelectionButtonAria: 'Column Selection',
+    columnSelectionConfig: 'Manage Columns',
     filterButtonAria: 'Filters',
     searchLabel: 'Search',
     searchPlaceholder: 'Search',
@@ -391,12 +396,24 @@ const Table = props => {
           {...others}
           i18n={i18n}
           lightweight={lightweight}
-          options={pick(options, 'hasRowSelection', 'hasRowExpansion', 'hasRowActions')}
+          options={pick(
+            options,
+            'hasRowSelection',
+            'hasRowExpansion',
+            'hasRowActions',
+            'hasColumnSelectionConfig'
+          )}
           columns={columns}
           filters={view.filters}
           actions={{
             ...pick(actions.toolbar, 'onApplyFilter'),
-            ...pick(actions.table, 'onSelectAll', 'onChangeSort', 'onChangeOrdering'),
+            ...pick(
+              actions.table,
+              'onSelectAll',
+              'onChangeSort',
+              'onChangeOrdering',
+              'onColumnSelectionConfig'
+            ),
           }}
           selectAllText={i18n.selectAllAria}
           clearFilterText={i18n.clearFilterAria}

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -290,6 +290,7 @@ const actions = {
     onApplyRowAction: action('onApplyRowAction'),
     onRowExpanded: action('onRowExpanded'),
     onChangeOrdering: action('onChangeOrdering'),
+    onColumnSelectionConfig: action('onColumnSelectionConfig'),
     onChangeSort: action('onChangeSort'),
   },
 };
@@ -1109,7 +1110,7 @@ storiesOf('Watson IoT|Table', module)
       />
     );
   })
-  .add('with customized columns', () => (
+  .add('with column selection', () => (
     <Table
       columns={tableColumns}
       data={tableData}
@@ -1118,6 +1119,7 @@ storiesOf('Watson IoT|Table', module)
         hasPagination: true,
         hasRowSelection: 'multi',
         hasColumnSelection: true,
+        hasColumnSelectionConfig: boolean('hasColumnSelectionConfig', true),
       }}
       view={{
         toolbar: {
@@ -1127,6 +1129,7 @@ storiesOf('Watson IoT|Table', module)
           ordering: defaultOrdering,
         },
       }}
+      i18n={{ columnSelectionConfig: text('i18n.columnSelectionConfig', '__Manage columns__') }}
     />
   ))
   .add('with no results', () => (

--- a/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.jsx
@@ -2,9 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { DataTable } from 'carbon-components-react';
+import { DataTable, Button } from 'carbon-components-react';
 import styled from 'styled-components';
+import { Settings16 } from '@carbon/icons-react';
 
+import { defaultFunction } from '../../../../utils/componentUtilityFunctions';
+import { defaultI18NPropTypes } from '../../TablePropTypes';
 import ColumnHeaderSelect from '../ColumnHeaderSelect/ColumnHeaderSelect';
 
 const { TableHeader, TableRow } = DataTable;
@@ -68,11 +71,19 @@ class ColumnHeaderRow extends Component {
         isHidden: PropTypes.bool,
       })
     ).isRequired,
-    tableOptions: PropTypes.shape({
+    options: PropTypes.shape({
       hasRowSelection: PropTypes.oneOf(['multi', 'single', false]),
       hasRowExpansion: PropTypes.bool,
+      hasColumnSelectionConfig: PropTypes.bool,
     }).isRequired,
     onChangeOrdering: PropTypes.func.isRequired,
+    onColumnSelectionConfig: PropTypes.func,
+    columnSelectionConfigText: PropTypes.string,
+  };
+
+  static defaultProps = {
+    onColumnSelectionConfig: defaultFunction('actions.table.onColumnSelectionConfig'),
+    columnSelectionConfigText: defaultI18NPropTypes.columnSelectionConfig,
   };
 
   reorderColumn = (srcIndex, destIndex) => {
@@ -97,7 +108,9 @@ class ColumnHeaderRow extends Component {
     const {
       columns,
       ordering,
-      tableOptions: { hasRowSelection, hasRowExpansion, hasRowActions },
+      options: { hasRowSelection, hasRowExpansion, hasRowActions, hasColumnSelectionConfig },
+      onColumnSelectionConfig,
+      columnSelectionConfigText,
     } = this.props;
 
     const visibleColumns = columns.filter(
@@ -122,6 +135,17 @@ class ColumnHeaderRow extends Component {
               </ColumnHeaderSelect>
             ))}
           </StyledColumnSelectWrapper>
+          {hasColumnSelectionConfig ? (
+            <Button
+              className="column-header__btn"
+              kind="ghost"
+              size="small"
+              renderIcon={Settings16}
+              onClick={() => onColumnSelectionConfig()}
+            >
+              {columnSelectionConfigText}
+            </Button>
+          ) : null}
         </StyledTableHeader>
       </StyledColumnSelectTableRow>
     );

--- a/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
@@ -1,17 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DragSource, DropTarget } from 'react-dnd';
-import styled from 'styled-components';
 import { Button } from 'carbon-components-react';
 import Draggable from '@carbon/icons-react/lib/draggable/16';
-
-const StyledColumnSelectContainer = styled(Button)`
-  & {
-    margin: 0 1rem 1rem 0;
-    cursor: pointer;
-    opacity: ${props => (props['data-ishidden'] ? 0.5 : 1)};
-  }
-`;
+import classNames from 'classnames';
 
 const ColumnHeaderSelect = ({
   connectDragSource,
@@ -20,29 +12,28 @@ const ColumnHeaderSelect = ({
   isHidden,
   children,
   onClick,
-}) => (
-  <StyledColumnSelectContainer
-    kind="secondary"
-    key={columnId}
-    onClick={() => onClick()}
-    role="presentation"
-    data-ishidden={isHidden}
-    renderIcon={Draggable}
-    size="small"
-    ref={instance => {
-      connectDragSource(instance);
-      connectDropTarget(instance);
-    }}
-  >
-    {children}
-    {/* <IconStyled
-      style={{ cursor: 'move' }}
-      icon={iconDraggable}
-      description="Dragable column"
-      focusable="false"
-    /> */}
-  </StyledColumnSelectContainer>
-);
+}) => {
+  return (
+    <Button
+      className={classNames('column-header__btn', 'column-header__select', {
+        'column-header__select--hidden': isHidden,
+      })}
+      kind="secondary"
+      key={columnId}
+      onClick={() => onClick()}
+      role="presentation"
+      data-ishidden={isHidden}
+      renderIcon={Draggable}
+      size="small"
+      ref={instance => {
+        connectDragSource(instance);
+        connectDropTarget(instance);
+      }}
+    >
+      {children}
+    </Button>
+  );
+};
 
 ColumnHeaderSelect.propTypes = {
   columnId: PropTypes.string.isRequired,

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -63,6 +63,7 @@ const propTypes = {
     onSelectAll: PropTypes.func,
     onChangeSort: PropTypes.func,
     onChangeOrdering: PropTypes.func,
+    onColumnSelectionConfig: PropTypes.func,
     onApplyFilter: PropTypes.func,
   }).isRequired,
   /** lightweight  */
@@ -138,7 +139,7 @@ const TableHead = ({
     ordering,
     filters,
   },
-  actions: { onSelectAll, onChangeSort, onApplyFilter, onChangeOrdering },
+  actions: { onSelectAll, onChangeSort, onApplyFilter, onChangeOrdering, onColumnSelectionConfig },
   selectAllText,
   clearFilterText,
   filterText,
@@ -228,9 +229,11 @@ const TableHead = ({
             name: column.name,
           }))}
           ordering={ordering}
-          tableOptions={options}
+          options={options}
           onChangeOrdering={onChangeOrdering}
           lightweight={lightweight}
+          onColumnSelectionConfig={onColumnSelectionConfig}
+          columnSelectionConfigText={i18n.columnSelectionConfig}
         />
       )}
     </StyledCarbonTableHead>

--- a/src/components/Table/TableHead/_table-head.scss
+++ b/src/components/Table/TableHead/_table-head.scss
@@ -1,0 +1,21 @@
+@import '~carbon-components/scss/globals/scss/vars';
+@import '~carbon-components/scss/globals/scss/layout';
+
+.#{$prefix}--data-table {
+  .#{$prefix}--table-header-label {
+    display: flex;
+  }
+
+  .column-header__btn {
+    margin: 0 $spacing-05 $spacing-05 0;
+    max-height: $spacing-07;
+  }
+
+  .column-header__select {
+    opacity: 1;
+  }
+
+  .column-header__select--hidden {
+    opacity: 0.5;
+  }
+}

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -137,6 +137,7 @@ export const I18NPropTypes = PropTypes.shape({
   searchPlaceholder: PropTypes.string,
   clearAllFilters: PropTypes.string,
   columnSelectionButtonAria: PropTypes.string,
+  columnSelectionConfig: PropTypes.string,
   filterButtonAria: PropTypes.string,
   clearFilterAria: PropTypes.string,
   filterAria: PropTypes.string,
@@ -181,6 +182,7 @@ export const defaultI18NPropTypes = {
   /** toolbar */
   clearAllFilters: 'Clear all filters',
   columnSelectionButtonAria: 'Column Selection',
+  columnSelectionConfig: 'Manage columns',
   filterButtonAria: 'Filters',
   searchLabel: 'Search',
   searchPlaceholder: 'Search',

--- a/src/components/Table/_table.scss
+++ b/src/components/Table/_table.scss
@@ -1,0 +1,1 @@
+@import 'TableHead/table-head';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -149,6 +149,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/Skeleton/skeleton';
 @import 'components/InlineLoading/inline-loading';
 @import 'components/PaginationNav/pagination-nav';
+@import 'components/Table/table';
 
 //-------------------------------------
 // 🔬 Experimental


### PR DESCRIPTION
Closes #786, Internal tracking [issue #16](https://github.ibm.com/Watson-IoT/pal-tracking/issues/16) 

**Summary**

- Add a columnSelectionConfig button option to support advanced configuration of columns

**Change List (commits, features, bugs, etc)**

- Add button, associated sass partials/styles
- refactor ColumnHeaderSelect from styled-components to sass (also now we'll have a table partial!)
- add tests, improve coverage
- Modify and rename the story, add a knob to enable the button

**Acceptance Test (how to verify the PR)**

- View the `with column selection` story
