### PR TITLE
fix(table-head): sass build paths

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -79,7 +79,11 @@ export default {
 
         // Sass components
         {
-          src: ['src/components/**/*.scss', '!src/components/Notification/*.scss'],
+          src: [
+            'src/components/**/*.scss',
+            '!src/components/Notification/*.scss',
+            '!src/components/Table/TableHead/*.scss',
+          ],
           dest: 'lib/scss/components',
           rename: (name, extension) => sanitizeAndCamelCase(name, extension),
         },
@@ -88,6 +92,10 @@ export default {
         {
           src: 'src/components/Notification/*.scss',
           dest: 'lib/scss/components/Notification',
+        },
+        {
+          src: 'src/components/Table/TableHead/*.scss',
+          dest: 'lib/scss/components/Table/TableHead',
         },
       ],
       verbose: env !== 'development', // logs the file copy list on production builds for easier debugging


### PR DESCRIPTION
**Summary**

- Fixes an error in the build where sass paths were not correct.

**Acceptance Test (how to verify the PR)**

- run `yarn`. in your `lib/scss` folder, you should now see that the TableHead folder is nested within the Table folder, instead of beside it.



Error reported from consuming product (thanks @dennynguyen!):
```
ERROR in ./src/sass/main.scss (./node_modules/css-loader??ref--8-1!./node_modules/sass-loader/lib/loader.js??ref--8-2!./src/sass/main.scss)
Module build failed (from ./node_modules/sass-loader/lib/loader.js):
@import 'TableHead/table-head';
^
      File to import not found or unreadable: TableHead/table-head.
      in /Users/denny/workspace-git/common-core-external-dashboard/node_modules/carbon-addons-iot-react/lib/scss/components/Table/_table.scss (line 1, column 1)
 @ ./src/sass/main.scss 4:14-142 13:2-17:4 14:20-148
 @ ./src/Common/containers/HomeApp.jsx
 @ ./src/index.jsx
 @ multi react-hot-loader/patch webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000 ./src/index.jsx
```
