### PR TITLE
feat(tilecatalog): isSelectedByDefault prop that determines whether to force a selection or not

### DIFF
--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -1,4 +1,5 @@
 import React, { useReducer, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import omit from 'lodash/omit';
 
@@ -10,6 +11,7 @@ import TileCatalog, { propTypes } from './TileCatalog';
  */
 
 const StatefulTileCatalog = ({
+  isSelectedByDefault,
   onSelection,
   pagination,
   search,
@@ -43,7 +45,7 @@ const StatefulTileCatalog = ({
         },
       });
       // If we totally change the tiles data, we should generate a selection event for the initial default selection
-      if (onSelection && tilesProp.length > 0 && !selectedTileIdProp) {
+      if (isSelectedByDefault && onSelection && tilesProp.length > 0 && !selectedTileIdProp) {
         onSelection(tilesProp[0].id);
       }
     },
@@ -115,6 +117,14 @@ const StatefulTileCatalog = ({
   );
 };
 
-StatefulTileCatalog.propTypes = propTypes;
+StatefulTileCatalog.defaultProps = {
+  isSelectedByDefault: true,
+};
+
+StatefulTileCatalog.propTypes = {
+  ...propTypes,
+  /** Will always select the first entry if set true */
+  isSelectedByDefault: PropTypes.bool,
+};
 
 export default StatefulTileCatalog;

--- a/src/components/TileCatalog/StatefulTileCatalog.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.jsx
@@ -22,6 +22,7 @@ const StatefulTileCatalog = ({
   const initialState = determineInitialState({
     ...props,
     selectedTileId: selectedTileIdProp,
+    isSelectedByDefault,
     tiles: tilesProp,
     search,
     pagination,
@@ -39,6 +40,7 @@ const StatefulTileCatalog = ({
         payload: {
           ...props,
           selectedTileId: selectedTileIdProp,
+          isSelectedByDefault,
           tiles: tilesProp,
           search,
           pagination,

--- a/src/components/TileCatalog/StatefulTileCatalog.test.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.test.jsx
@@ -83,6 +83,15 @@ describe('StatefulTileCatalog', () => {
     const wrapper = mount(
       <StatefulTileCatalog {...commonTileProps} pagination={{ pageSize: 5 }} />
     );
+
+    // The new first tile should be selected
+    expect(
+      wrapper
+        .find('RadioTile')
+        .at(0)
+        .prop('checked')
+    ).toEqual(true);
+
     // On page 1
     expect(
       wrapper
@@ -132,6 +141,13 @@ describe('StatefulTileCatalog', () => {
         isSelectedByDefault={false}
       />
     );
+    // The new first tile should not be selected
+    expect(
+      wrapper
+        .find('RadioTile')
+        .at(0)
+        .prop('checked')
+    ).toEqual(false);
     const newTiles = commonTileProps.tiles.slice(1, 5);
     // Back to Page 1
     mockOnSelection.mockClear();

--- a/src/components/TileCatalog/StatefulTileCatalog.test.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.test.jsx
@@ -123,4 +123,20 @@ describe('StatefulTileCatalog', () => {
         .prop('checked')
     ).toEqual(true);
   });
+
+  test('tiles prop change should not select if isSelectedByDefault false', () => {
+    const wrapper = mount(
+      <StatefulTileCatalog
+        {...commonTileProps}
+        pagination={{ pageSize: 5 }}
+        isSelectedByDefault={false}
+      />
+    );
+    const newTiles = commonTileProps.tiles.slice(1, 5);
+    // Back to Page 1
+    mockOnSelection.mockClear();
+    wrapper.setProps({ tiles: newTiles });
+    // Needs to have called the selection callback for the newly default selected row
+    expect(mockOnSelection).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/components/TileCatalog/TileCatalog.story.jsx
+++ b/src/components/TileCatalog/TileCatalog.story.jsx
@@ -114,4 +114,7 @@ storiesOf('Watson IoT|TileCatalog', module)
       );
     };
     return <Container />;
-  });
+  })
+  .add('isSelectedByDefault false', () => (
+    <StatefulTileCatalog {...commonTileCatalogProps} isSelectedByDefault={false} />
+  ));

--- a/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
+++ b/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
@@ -990,6 +990,748 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileC
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog isSelectedByDefault false 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+    >
+      <div
+        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+      />
+      <div
+        className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
+      >
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test1"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test1"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test1"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile with really long title that should wrap"
+                  >
+                    Test Tile with really long title that should wrap
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test2"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test2"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test2"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile2"
+                  >
+                    Test Tile2
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test3"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test3"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test3"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile3"
+                  >
+                    Test Tile3
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Tile contents
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test4"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test4"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test4"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile4"
+                  >
+                    Test Tile4
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test5"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test5"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test5"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile5"
+                  >
+                    Test Tile5
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test6"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test6"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test6"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile6"
+                  >
+                    Test Tile6
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <input
+          checked={false}
+          className="bx--tile-input"
+          id="test7"
+          name="entityType"
+          onChange={[Function]}
+          tabIndex={0}
+          type="radio"
+          value="test7"
+        />
+        <label
+          className="bx--tile bx--tile--selectable"
+          htmlFor="test7"
+          onKeyDown={[Function]}
+          tabIndex={0}
+        >
+          <div
+            className="bx--tile__checkmark"
+          >
+            <svg
+              aria-label="Tile checkmark"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              style={
+                Object {
+                  "willChange": "transform",
+                }
+              }
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zM7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+              />
+              <path
+                d="M7 11L4.3 8.3l.9-.8L7 9.3l4-3.9.9.8L7 11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+              <title>
+                Tile checkmark
+              </title>
+            </svg>
+          </div>
+          <div
+            className="bx--tile-content"
+          >
+            <div
+              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+            >
+              <div
+                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={32}
+                  preserveAspectRatio="xMidYMid meet"
+                  style={
+                    Object {
+                      "willChange": "transform",
+                    }
+                  }
+                  viewBox="0 0 32 32"
+                  width={32}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15V7h-2v8H7v2h8v8h2v-8h8v-2h-8z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+              >
+                <div
+                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                >
+                  <span
+                    title="Test Tile7"
+                  >
+                    Test Tile7
+                  </span>
+                </div>
+                <div
+                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                >
+                  Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
+                </div>
+              </div>
+            </div>
+          </div>
+        </label>
+        <div
+          className="bx--tile TileGroup__StyledGreedyTile-eak4ed-1 eTCDyV"
+        />
+      </div>
+      <div
+        className="SimplePagination__StyledContainer-l7ezj3-0 bzKmAQ"
+      >
+        <span
+          className="SimplePagination__StyledPageLabel-l7ezj3-1 hybMqK"
+        >
+          Page 1 of 1
+        </span>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileCatalog loading 1`] = `
 <div
   className="storybook-container"

--- a/src/components/TileCatalog/tileCatalogReducer.js
+++ b/src/components/TileCatalog/tileCatalogReducer.js
@@ -13,14 +13,22 @@ const determineEndingIndex = (page, pageSize) => {
 };
 
 /** This figures out the initial state of the reducer from the props */
-export const determineInitialState = ({ pagination, search, selectedTileId, tiles }) => {
+export const determineInitialState = ({
+  pagination,
+  isSelectedByDefault = true,
+  search,
+  selectedTileId,
+  tiles,
+}) => {
   const page = pagination && pagination.page ? pagination.page : 1;
   const pageSize = pagination && pagination.pageSize ? pagination.pageSize : 10;
   const filteredTiles = search ? searchData(tiles, search.value) : tiles;
   const startingIndex = pagination ? (page - 1) * pageSize : 0;
   const selectedTileIdState =
     selectedTileId ||
-    (filteredTiles && filteredTiles[startingIndex] ? filteredTiles[startingIndex].id : null);
+    (isSelectedByDefault && filteredTiles && filteredTiles[startingIndex]
+      ? filteredTiles[startingIndex].id
+      : null);
   let selectedPage;
   let selectedStartingIndex;
   // If a selected tile id is passed, we should page to it


### PR DESCRIPTION
Closes #809 

**Summary**

- Added new property that allows tile catalogs to start off unselected

**Change List (commits, features, bugs, etc)**

- feat(StatefulTileCatalog): add new isSelectedByDefault prop and only invoke onSelection if set true (true by default)
- feat(tileCatalogReducer): only select by default (in initial state) if isSelectedByDefault is true

**Acceptance Test (how to verify the PR)**

- Check the new story and testcases and confirm the tile catalog is actually unselected
