### PR TITLE
fix(table): for async tables, the column names may not be known

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,4 +17,4 @@
 # These users own any files in the following directory at the root of
 # the repository and any of its subdirectories.
 
-* @bryancboyd @scottdickerson @davidicus @tay1orjones @leetosc @cgirani @stuckless @tomklapiscak @filipecorrea @jessieyan @blechner
+* @bryancboyd @scottdickerson @davidicus @tay1orjones @leetosc @cgirani @stuckless @tomklapiscak @filipecorrea @jessieyan @blechner @sstone2423

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -227,6 +227,8 @@ export const tableReducer = (state = {}, action) => {
       const { view, totalItems } = action.payload;
       const { pageSize, pageSizes } = get(view, 'pagination') || {};
       const paginationFromState = get(state, 'view.pagination');
+      // update the column ordering if I'm passed new columns
+      const ordering = get(view, 'table.ordering') || get(state, 'view.table.ordering');
       const pagination = get(state, 'view.pagination')
         ? {
             totalItems: { $set: totalItems || updatedData.length },
@@ -241,6 +243,7 @@ export const tableReducer = (state = {}, action) => {
         view: {
           pagination,
           table: {
+            ordering: { $set: ordering },
             filteredData: {
               $set: filterSearchAndSort(
                 updatedData,

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -105,7 +105,9 @@ export const formatChartData = (timeDataSourceId = 'timestamp', series, values) 
       ...(color ? { fillColors: [color] } : {}),
       data:
         values &&
-        values.map(i => ({ date: new Date(i[timeDataSourceId]), value: i[dataSourceId] })),
+        values // have to filter out null values from the dataset, as it causes Carbon Charts to break
+          .filter(i => !isNil(i[dataSourceId]))
+          .map(i => ({ date: new Date(i[timeDataSourceId]), value: i[dataSourceId] })),
     })),
   };
 };

--- a/src/components/WizardInline/WizardFooter/WizardFooter.jsx
+++ b/src/components/WizardInline/WizardFooter/WizardFooter.jsx
@@ -37,6 +37,7 @@ const WizardFooter = ({
   onNext,
   onBack,
   onSubmit,
+  className,
   onCancel,
   cancelLabel,
   backLabel,
@@ -52,7 +53,7 @@ const WizardFooter = ({
     {footerLeftContent && (
       <div className="WizardInline-custom-footer-content">{footerLeftContent}</div>
     )}
-    <StyledFooterButtons>
+    <StyledFooterButtons className={className}>
       {!hasPrev ? (
         <Button onClick={onCancel} kind="secondary">
           {cancelLabel}


### PR DESCRIPTION
Closes #

**Summary**

- Because the full list of column names might not be known when data is loaded asynchronously, we need to reinitialize the ordering in our table state once the table Register method is called.  tableRegister gets called when data is refreshed.

**Change List (commits, features, bugs, etc)**

- fix(tableReducer): reload table columns if a table data reloads
- fix(WizardModal): the footer styled component wasn't working due to not passing the classname prop through
