### PR TITLE
fix(tablecard): increase the available rows in a tablecard

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -879,7 +879,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   className="Card__CardContent-v5r71h-1 jAGfWa"
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-2 bsWBhi Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-2 kzFKjW Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -2680,7 +2680,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   className="Card__CardContent-v5r71h-1 jAGfWa"
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-2 bsWBhi Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-2 kzFKjW Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -4513,7 +4513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   className="Card__CardContent-v5r71h-1 jAGfWa"
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-2 bsWBhi Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-2 kzFKjW Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -6069,7 +6069,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   className="Card__CardContent-v5r71h-1 jAGfWa"
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -7554,17 +7554,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                     className="bx--select-option"
                                     disabled={false}
                                     hidden={false}
-                                    value={20}
+                                    value={25}
                                   >
-                                    20
+                                    25
                                   </option>
                                   <option
                                     className="bx--select-option"
                                     disabled={false}
                                     hidden={false}
-                                    value={30}
+                                    value={100}
                                   >
-                                    30
+                                    100
                                   </option>
                                 </select>
                                 <svg
@@ -8668,7 +8668,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   className="Card__CardContent-v5r71h-1 jAGfWa"
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-2 bsWBhi Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-2 kzFKjW Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"
@@ -20487,7 +20487,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   className="Card__CardContent-v5r71h-1 jAGfWa"
                 >
                   <div
-                    className="TableCard__StyledStatefulTable-q9l5bz-2 bsWBhi Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+                    className="TableCard__StyledStatefulTable-q9l5bz-2 kzFKjW Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
                   >
                     <section
                       aria-label="data table toolbar"

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -232,7 +232,7 @@ export const tableReducer = (state = {}, action) => {
       const pagination = get(state, 'view.pagination')
         ? {
             totalItems: { $set: totalItems || updatedData.length },
-            pageSize: { $set: paginationFromState.pageSize || pageSize },
+            pageSize: { $set: pageSize || paginationFromState.pageSize },
             pageSizes: { $set: pageSizes },
           }
         : {};

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -43,11 +43,13 @@ const StyledStatefulTable = styled(({ showHeader, isExpanded, data, ...rest }) =
   flex: inherit;
   height: 100%;
   position: relative;
-  overflow-y: hidden;
+  overflow-y: ${props => (!props.isExpanded ? 'hidden' : 'auto')};
+  padding-bottom: ${props => (props.isExpanded ? '3rem' : '')};
   &&& {
     .bx--pagination {
-      position: absolute;
-      bottom: 0;
+      position: ${props => (!props.isExpanded ? 'absolute' : 'fixed')};
+      bottom: ${props => (!props.isExpanded ? '0px' : '25px')};
+      ${props => (props.isExpanded ? `width: calc(100% - 50px)` : ``)}
     }
     .bx--data-table-container {
       ${props =>
@@ -703,8 +705,8 @@ const TableCard = ({
             view={{
               pagination: {
                 pageSize: numberOfRowsPerPage,
-                pageSizes: [numberOfRowsPerPage],
-                isItemPerPageHidden: true,
+                pageSizes: [numberOfRowsPerPage, 25, 100],
+                isItemPerPageHidden: !isExpanded,
               },
               toolbar: {
                 activeBar: null,

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -50,7 +50,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -1087,17 +1087,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -1337,7 +1337,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -2738,17 +2738,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -3071,7 +3071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 bsWBhi Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 kzFKjW Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -3600,7 +3600,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -5690,17 +5690,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -6031,7 +6031,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -7019,17 +7019,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -7360,7 +7360,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -8349,17 +8349,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -8690,7 +8690,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -9194,17 +9194,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -9535,7 +9535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 eXCCfG Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 RkZqR Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -10039,17 +10039,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -10347,7 +10347,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -11589,17 +11589,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -11897,7 +11897,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -13140,17 +13140,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -13481,7 +13481,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -14469,17 +14469,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -14810,7 +14810,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -16406,17 +16406,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -16747,7 +16747,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -18099,17 +18099,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -18440,7 +18440,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -19756,17 +19756,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -20064,7 +20064,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -22154,17 +22154,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -22462,7 +22462,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -23466,17 +23466,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -23766,7 +23766,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -26220,17 +26220,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg
@@ -26561,7 +26561,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
           className="Card__CardContent-v5r71h-1 jAGfWa"
         >
           <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 dfsRXe Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
+            className="TableCard__StyledStatefulTable-q9l5bz-2 SdwkD Table__StyledTableContainer-sc-1kalfns-0 fkxdXs bx--data-table-container"
           >
             <section
               aria-label="data table toolbar"
@@ -28518,17 +28518,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={20}
+                            value={25}
                           >
-                            20
+                            25
                           </option>
                           <option
                             className="bx--select-option"
                             disabled={false}
                             hidden={false}
-                            value={30}
+                            value={100}
                           >
-                            30
+                            100
                           </option>
                         </select>
                         <svg


### PR DESCRIPTION
Closes #

**Summary**

- https://github.ibm.com/wiotp/monitoring-dashboard/issues/661 Internal issue, more rows should be available in the tablecard

**Change List (commits, features, bugs, etc)**

- fix(tableReducer): update the pageSize in our reduced state if it changes as a prop
- fix(TableCard): show the page selector if the card is expanded 
- fix(TableCard): allow tables to internally scroll on the card if the card isExpanded. Fix some pagination styles to allow this scrolling without scrolilng the pagination widget
- fix(TableCard): increase the default page size choices from 10,20, 30 to 10, 25, 100.

**Acceptance Test (how to verify the PR)**

- tests here
