### PR TITLE
feat(bar): allow time series to show bars

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -2879,6 +2879,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                   <div
                     className="bx--structured-list-td"
                   >
+                    TIME_SERIES_TYPES
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="bx--structured-list-td"
+                  />
+                  <div
+                    className="bx--structured-list-td"
+                  >
                     ListCard
                   </div>
                 </div>

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { text, select, object, boolean } from '@storybook/addon-knobs';
 import memoize from 'lodash/memoize';
 
-import { COLORS, CARD_SIZES } from '../../constants/LayoutConstants';
+import { COLORS, CARD_SIZES, TIME_SERIES_TYPES } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
 import { getIntervalChartData as getFakeData, chartData } from '../../utils/sample';
 
@@ -1129,6 +1129,38 @@ storiesOf('Watson IoT|TimeSeriesCard', module)
           interval={select('interval', ['hour', 'day', 'week', 'month', 'year'], 'hour')}
           breakpoint="lg"
           values={[]}
+          size={size}
+          onCardAction={action('onCardAction')}
+        />
+      </div>
+    );
+  })
+  .add('bar chart', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TimeSeriesCard
+          title={text('title', 'Temperature')}
+          chartType={select('chartType', Object.keys(TIME_SERIES_TYPES), TIME_SERIES_TYPES.BAR)}
+          id="facility-temperature"
+          isLoading={boolean('isLoading', false)}
+          content={object('content', {
+            series: [
+              {
+                label: 'Temperature',
+                dataSourceId: 'temperature',
+                color: text('color', COLORS.MAGENTA),
+              },
+            ],
+            unit: '˚F',
+            xLabel: text('xLabel', 'Time'),
+            yLabel: text('yLabel', 'Temperature'),
+            timeDataSourceId: 'timestamp',
+          })}
+          locale="sq"
+          values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100)}
+          interval="day"
+          breakpoint="lg"
           size={size}
           onCardAction={action('onCardAction')}
         />

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -87,6 +87,93 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeSeriesCard bar chart 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "alignItems": "center",
+      "display": "flex",
+      "flexDirection": "column",
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 kGdXdI"
+        id="facility-temperature"
+      >
+        <div
+          className="card--header"
+        >
+          <span
+            className="card--title"
+            title="Temperature"
+          >
+            Temperature
+             
+          </span>
+          <div
+            className="bx--toolbar card--toolbar"
+          />
+        </div>
+        <div
+          className="Card__CardContent-v5r71h-1 jAGfWa"
+        >
+          <div
+            className="TimeSeriesCard__LineChartWrapper-q25vbg-1 ldWnXS"
+            size="LARGE"
+          >
+            <div
+              className="chart-holder"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeSeriesCard empty 1`] = `
 <div
   className="storybook-container"

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -148,3 +148,8 @@ export const CARD_LAYOUTS = {
 
 export const CARD_TITLE_HEIGHT = 48;
 export const CARD_CONTENT_PADDING = 16;
+
+export const TIME_SERIES_TYPES = {
+  BAR: 'BAR',
+  LINE: 'LINE',
+};

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import { bundledIconNames } from '../utils/bundledIcons';
 
-import { CARD_SIZES, CARD_LAYOUTS, DASHBOARD_SIZES } from './LayoutConstants';
+import { CARD_SIZES, CARD_LAYOUTS, DASHBOARD_SIZES, TIME_SERIES_TYPES } from './LayoutConstants';
 
 export const AttributePropTypes = PropTypes.shape({
   label: PropTypes.string, // optional for little cards
@@ -73,6 +73,7 @@ export const TimeSeriesCardPropTypes = {
     /** Which attribute is the time attribute */
     timeDataSourceId: PropTypes.string,
   }).isRequired,
+  chartType: PropTypes.oneOf(Object.values(TIME_SERIES_TYPES)),
   i18n: PropTypes.shape({
     alertDetected: PropTypes.string,
   }),

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ export {
   CARD_SIZES,
   DASHBOARD_BREAKPOINTS,
   DASHBOARD_SIZES,
+  TIME_SERIES_TYPES,
 } from './constants/LayoutConstants';
 
 // Experimental


### PR DESCRIPTION
Closes #https://github.ibm.com/wiotp/monitoring-dashboard/issues/307

**Summary**

- Add a new chart type prop to allow the time series to render a bar rather than a line chart

**Change List (commits, features, bugs, etc)**

- feat(TimeSeriesCard): update the handleTooltip method to handle the data values that a bar chart sends from carbon
- feat(TimeSeriesCard): switch the StackedBarChart in instead of the LineChart component

**Acceptance Test (how to verify the PR)**

- verify the new story for bar chart types
