### PR TITLE
fix(progressindicator): show step labels by default

### DIFF
--- a/src/components/ProgressIndicator/ProgressIndicator.jsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.jsx
@@ -73,13 +73,16 @@ const propTypes = {
 
 const defaultProps = {
   onClickItem: null,
-  showLabels: false,
+  showLabels: true,
   stepWidth: null,
   currentItemId: null,
   isVerticalMode: false,
 };
 
-/** This component extends the default Carbon ProgressIndicator.  It adds the ability to hideLabels on non-current steps and set a maximum stepWidth in pixels */
+/**
+ * This component extends the default Carbon ProgressIndicator.
+ * It adds the ability to hideLabels on non-current steps and set a maximum stepWidth in pixels
+ */
 const ProgressIndicator = ({
   items,
   showLabels,

--- a/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.story.storyshot
+++ b/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.story.storyshot
@@ -249,7 +249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Progr
       onChange={[Function]}
     >
       <li
-        className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+        className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
       >
         <div
           className="bx--progress-step-button"
@@ -325,7 +325,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Progr
         </div>
       </li>
       <li
-        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
       >
         <div
           className="bx--progress-step-button"
@@ -353,7 +353,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Progr
         </div>
       </li>
       <li
-        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
       >
         <div
           className="bx--progress-step-button"
@@ -381,7 +381,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Progr
         </div>
       </li>
       <li
-        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
       >
         <div
           className="bx--progress-step-button"
@@ -409,7 +409,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Progr
         </div>
       </li>
       <li
-        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+        className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
       >
         <div
           className="bx--progress-step-button"

--- a/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
+++ b/src/components/WizardModal/__snapshots__/WizardModal.story.storyshot
@@ -110,7 +110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Wizar
               </div>
             </li>
             <li
-              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
             >
               <div
                 className="bx--progress-step-button"
@@ -138,7 +138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Wizar
               </div>
             </li>
             <li
-              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
             >
               <div
                 className="bx--progress-step-button"
@@ -337,7 +337,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Wizar
               </div>
             </li>
             <li
-              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
             >
               <div
                 className="bx--progress-step-button"
@@ -365,7 +365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Wizar
               </div>
             </li>
             <li
-              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+              className="bx--progress-step bx--progress-step--incomplete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
             >
               <div
                 className="bx--progress-step-button"
@@ -544,7 +544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Wizar
             onChange={[Function]}
           >
             <li
-              className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+              className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
             >
               <div
                 className="bx--progress-step-button"
@@ -588,7 +588,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Wizar
               </div>
             </li>
             <li
-              className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 iunSsU"
+              className="bx--progress-step bx--progress-step--complete ProgressIndicator__StyledProgressStep-sc-1sy51cd-1 gyomnR"
             >
               <div
                 className="bx--progress-step-button"


### PR DESCRIPTION
Closes #

**Summary**

- fix(progressindicator): according to Luke we should show labels on future progress steps by default

**Change List (commits, features, bugs, etc)**

- items_here
![image](https://user-images.githubusercontent.com/6663002/72465215-652b8c00-379c-11ea-8abc-a80d5346362a.png)


**Acceptance Test (how to verify the PR)**

- Verify the WizardModal stories
