### PR TITLE
fix(build): addons cannot be included due to incorrect scss build paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "rollup": "^1.1.0",
     "rollup-plugin-babel": "^4.3.0",
     "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-copy": "^3.1.0",
+    "rollup-plugin-copy": "^3.2.0",
     "rollup-plugin-filesize": "^6.0.0",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-builtins": "^2.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,18 +12,6 @@ import json from 'rollup-plugin-json';
 const env = process.env.NODE_ENV || 'development';
 const prodSettings = env === 'development' ? [] : [uglify(), filesize()];
 
-// Converts `_component-name.scss` to `ComponentName/_component-name.scss`
-// and handles the word `ui` to be uppercase `UI`
-const sanitizeAndCamelCase = (fileName, extension) => {
-  return `${fileName
-    .replace('_', '')
-    .split('-')
-    .map(word =>
-      word === 'ui' ? `${word.toUpperCase()}` : `${word[0].toUpperCase() + word.substring(1)}`
-    )
-    .join('')}/${fileName}.${extension}`;
-};
-
 export default {
   input: 'src/index.js',
   output: {
@@ -67,6 +55,7 @@ export default {
       plugins: [autoprefixer],
     }),
     copy({
+      flatten: false,
       targets: [
         // Sass entrypoint
         { src: 'src/styles.scss', dest: 'lib/scss' },
@@ -79,23 +68,8 @@ export default {
 
         // Sass components
         {
-          src: [
-            'src/components/**/*.scss',
-            '!src/components/Notification/*.scss',
-            '!src/components/Table/TableHead/*.scss',
-          ],
+          src: ['src/components/**/*.scss'],
           dest: 'lib/scss/components',
-          rename: (name, extension) => sanitizeAndCamelCase(name, extension),
-        },
-
-        // Sass components with non-standard folder structure, or multiple files per folder
-        {
-          src: 'src/components/Notification/*.scss',
-          dest: 'lib/scss/components/Notification',
-        },
-        {
-          src: 'src/components/Table/TableHead/*.scss',
-          dest: 'lib/scss/components/Table/TableHead',
         },
       ],
       verbose: env !== 'development', // logs the file copy list on production builds for easier debugging

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,7 +69,7 @@ export default {
         // Sass components
         {
           src: ['src/components/**/*.scss'],
-          dest: 'lib/scss/components',
+          dest: 'lib/scss',
         },
       ],
       verbose: env !== 'development', // logs the file copy list on production builds for easier debugging

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -149,7 +149,6 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/Skeleton/skeleton';
 @import 'components/InlineLoading/inline-loading';
 @import 'components/PaginationNav/pagination-nav';
-@import 'components/Table/table';
 
 //-------------------------------------
 // 🔬 Experimental
@@ -186,3 +185,4 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/WizardInline/wizard-inline';
 @import 'components/TileGallery/tile-gallery';
 @import 'components/Table/TableToolbar/table-toolbar';
+@import 'components/Table/table';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3464,10 +3464,10 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
 
-"@types/fs-extra@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.0.tgz#d3e2c313ca29f95059f198dd60d1f774642d4b25"
-  integrity sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==
+"@types/fs-extra@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz#a2378d6e7e8afea1564e44aafa2e207dadf77686"
+  integrity sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==
   dependencies:
     "@types/node" "*"
 
@@ -16271,12 +16271,12 @@ rollup-plugin-commonjs@^9.2.0:
     resolve "^1.8.1"
     rollup-pluginutils "^2.3.3"
 
-rollup-plugin-copy@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-3.1.0.tgz#435589857f4e346ea63fc137d99dcc1b25f51c3b"
-  integrity sha512-oVw3ljRV5jv7Yw/6eCEHntVs9Mc+NFglc0iU0J8ei76gldYmtBQ0M/j6WAkZUFVRSrhgfCrEakUllnN87V2f4w==
+rollup-plugin-copy@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-3.2.0.tgz#b401674d406d487ee3acb44c4785d424ff80ad75"
+  integrity sha512-ZA/dt4xMjof24zaoqMVdMbP4/6+exqyvJ7J0oU80q/T1nj2zDvXVm2hCcmy4BPzhBHzgCRyIRQz7pg6M5hAkPA==
   dependencies:
-    "@types/fs-extra" "^8.0.0"
+    "@types/fs-extra" "^8.0.1"
     colorette "^1.1.0"
     fs-extra "^8.1.0"
     globby "10.0.1"


### PR DESCRIPTION
**Summary**

- Our build was putting the TableToolbar scss in the incorrect place preventing anyone downstream from using carbon-addons-iot-react with this build error
![image](https://user-images.githubusercontent.com/6663002/72630358-c6c43580-3917-11ea-8ad7-ad6930c862a9.png)


**Change List (commits, features, bugs, etc)**

- fix(package): upgrade rollup-copy-plugin to support nested directories
- fix(rollup.config.js): remove custom renaming pathing code 
- refactor(styles.scss): just moving our custom table one down

**Acceptance Test (how to verify the PR)**

- Make sure that after you build carbon-addons you can include it's scss in a downstream project without build failures
