### PR TITLE
feat(statefultable): add sortFunction prop for custom column sorts

### DIFF
--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -40,6 +40,7 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
   const [state, dispatch] = useReducer(tableReducer, {
     data: initialData,
     view: initialState,
+    columns,
   });
   const isLoading = get(initialState, 'table.loadingState.isLoading');
   // Need to initially sort and filter the tables data, but preserve the selectedId

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -62,7 +62,6 @@ const renderStatusIcon = ({ value: status }) => {
 };
 // Example custom sort method for the status field.  Will sort the broken to the top, then the running, then the not_running
 const customColumnSort = ({ data, columnId, direction }) => {
-  console.log(`custom sort triggered on ${columnId} for ${direction}`);
   // clone inputData because sort mutates the array
   const sortedData = data.map(i => i);
   sortedData.sort((a, b) => {

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -60,6 +60,31 @@ const renderStatusIcon = ({ value: status }) => {
       );
   }
 };
+// Example custom sort method for the status field.  Will sort the broken to the top, then the running, then the not_running
+const customColumnSort = ({ data, columnId, direction }) => {
+  console.log(`custom sort triggered on ${columnId} for ${direction}`);
+  // clone inputData because sort mutates the array
+  const sortedData = data.map(i => i);
+  sortedData.sort((a, b) => {
+    let compare = -1;
+    // same status
+    if (a.values[columnId] === b.values[columnId]) {
+      compare = 0;
+    } else if (a.values[columnId] === STATUS.RUNNING && b.values[columnId] === STATUS.NOT_RUNNING) {
+      compare = -1;
+    } else if (a.values[columnId] === STATUS.NOT_RUNNING && b.values[columnId] === STATUS.RUNNING) {
+      compare = 1;
+    } else if (b.values[columnId] === STATUS.BROKEN) {
+      compare = 1;
+    } else if (a.values[columnId] === STATUS.BROKEN) {
+      compare = -1;
+    }
+
+    return direction === 'ASC' ? compare : -compare;
+  });
+  return sortedData;
+};
+
 export const tableColumns = [
   {
     id: 'string',
@@ -84,6 +109,7 @@ export const tableColumns = [
     id: 'status',
     name: 'Status',
     renderDataFunction: renderStatusIcon,
+    sortFunction: customColumnSort,
   },
   {
     id: 'number',

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -85,6 +85,11 @@ export const TableColumnsPropTypes = PropTypes.arrayOf(
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     isSortable: PropTypes.bool,
+    /** optional sort function for this column, called back with the column to sort on and the in-memory data as parameters
+     * { columnId: PropTypes.string, direction: PropTypes.oneOf(['ASC','DESC']), data: PropTypes.array }
+     * You should return the updated data
+     */
+    sortFunction: PropTypes.func,
     width: PropTypes.string, // ex: 150px, or 2rem
     align: PropTypes.oneOf(['start', 'center', 'end']), // ex: start, center, end
     /** for each column you can register a render callback function that is called with this object payload

--- a/src/components/Table/tableReducer.test.js
+++ b/src/components/Table/tableReducer.test.js
@@ -152,6 +152,18 @@ describe('table reducer testcases', () => {
         tableSortedNone.view.table.filteredData
       );
     });
+    test('TABLE_COLUMN_SORT custom sort function', () => {
+      const sortColumnAction = tableColumnSort(tableColumns[4].id);
+      const mockSortFunction = jest.fn().mockReturnValue(initialState.data);
+      // Splice in our custom mock sort function
+      initialState.columns.splice(4, 1, {
+        ...initialState.columns[4],
+        sortFunction: mockSortFunction,
+      });
+      // First sort ASC
+      tableReducer(initialState, sortColumnAction);
+      expect(mockSortFunction).toHaveBeenCalled();
+    });
     test('TABLE_COLUMN_ORDER', () => {
       expect(initialState.view.table.ordering[0].isHidden).toBe(false);
       // Hide the first column
@@ -331,5 +343,23 @@ describe('filter, search and sort', () => {
     expect(
       filterSearchAndSort(mockData, {}, {}, [{ columnId: 'string', value: 'none' }])
     ).toHaveLength(0);
+  });
+  test('filterSearchAndSort with custom sort function', () => {
+    const mockData = [
+      { values: { number: 10, severity: 'High', null: null } },
+      { values: { number: 10, severity: 'Low', null: null } },
+      { values: { number: 10, severity: 'Medium', null: null } },
+    ];
+    const mockSortFunction = jest.fn().mockReturnValue(mockData);
+    expect(
+      filterSearchAndSort(
+        mockData,
+        { columnId: 'severity', direction: 'ASC' },
+        {},
+        [],
+        [{ id: 'severity', sortFunction: mockSortFunction }]
+      )
+    ).toHaveLength(3);
+    expect(mockSortFunction).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #https://github.com/IBM/carbon-addons-iot-react/issues/251

**Summary**
Allows the StatefulTable consumers to pass a custom sortFunction prop on their column.

**Change List (commits, features, bugs, etc)**
- feat(StatefulTable): pass the columns to the reducer so it can custom sort if a custom sort function is passed for that column
- test(Table.story): add a customSortFunction on the Status field of the table so we can integration test it
- feat(TablePropTypes): new sortFunction property
- feat(tableReducer): take the custom sort function into account in the filterSearchAndSort (which resorts the table when a new filter is applied)
- feat(tableReducer): use the custom sort function instead of our default getSortedData if it exists on the column

**Acceptance Test (how to verify the PR)**

- Verify the custom sort works on the Status column in the Table story.  Broken should be sorted to the top, then Running, then Not_Running and vice versa on descending sort
