### PR TITLE
fix(card): fixed bug with incorrect child size prop

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -182,17 +182,28 @@ const Card = ({
     id,
   ]);
 
+  const getChildSize = (cardSize, cardTitle) => {
+    const childSize = {
+      ...cardSize,
+      height:
+        cardTitle === null || cardTitle === undefined
+          ? cardSize.height
+          : cardSize.height - CARD_TITLE_HEIGHT,
+    };
+    return childSize;
+  };
+
   const card = (
     <VisibilitySensor partialVisibility offset={{ top: 10 }}>
       {({ isVisible }) => (
         <SizeMe.SizeMe monitorHeight>
-          {({ size: sizeWidth }) => (
+          {({ size: cardSize }) => (
             <CardWrapper
               {...others}
               id={id}
               dimensions={dimensions}
               isExpanded={isExpanded}
-              cardWidthSize={sizeWidth.width}
+              cardWidthSize={cardSize.width}
               style={
                 !isExpanded ? style : { height: 'calc(100% - 50px)', width: 'calc(100% - 50px)' }
               }
@@ -213,7 +224,7 @@ const Card = ({
                     )}
                   </CardTitle>
                   <CardToolbar
-                    width={sizeWidth.width}
+                    width={cardSize.width}
                     availableActions={mergedAvailableActions}
                     i18n={strings}
                     isEditable={isEditable}
@@ -247,7 +258,7 @@ const Card = ({
                     {isXS ? strings.noDataShortLabel : strings.noDataLabel}
                   </EmptyMessageWrapper>
                 ) : typeof children === 'function' ? ( // pass the measured size down to the children if it's an render function
-                  children(sizeWidth)
+                  children(getChildSize(cardSize, title))
                 ) : (
                   children
                 )}

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -28,6 +28,31 @@ storiesOf('Watson IoT|Card', module)
       </div>
     );
   })
+  .add('basic with render prop', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <Card
+          title={text('title', 'Card with render prop')}
+          id="render-prop-basic"
+          size={size}
+          isLoading={boolean('isLoading', false)}
+          isEmpty={boolean('isEmpty', false)}
+          isEditable={boolean('isEditable', false)}
+          isExpanded={boolean('isExpanded', false)}
+          breakpoint="lg"
+          availableActions={{ range: true, expand: true }}
+          onCardAction={action('onCardAction')}
+          // eslint-disable-next-line
+          children={childSize => (
+            <p>
+              Content width is {childSize.width} and height is {childSize.height}
+            </p>
+          )}
+        />
+      </div>
+    );
+  })
   .add('with loading', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (

--- a/src/components/Card/Card.test.jsx
+++ b/src/components/Card/Card.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Tooltip } from 'carbon-components-react';
 import { render, fireEvent, waitForElement } from '@testing-library/react';
 import { Popup20 } from '@carbon/icons-react';
-import { CARD_SIZES } from '../../constants/LayoutConstants';
+import { CARD_SIZES, CARD_TITLE_HEIGHT } from '../../constants/LayoutConstants';
 import { ToolbarSVGWrapper } from './CardToolbar';
 
 import CardRangePicker from './CardRangePicker';
@@ -24,6 +24,26 @@ describe('Card testcases', () => {
 
     // small should have full header
     expect(wrapper.find('.card--header')).toHaveLength(1);
+  });
+
+  test('child size prop', () => {
+    const childRenderInTitleCard = jest.fn();
+
+    mount(<Card title="My Title" size={CARD_SIZES.MEDIUM} children={childRenderInTitleCard} />);
+    expect(childRenderInTitleCard).toHaveBeenCalledWith({
+      width: 0,
+      height: -CARD_TITLE_HEIGHT,
+      position: null,
+    });
+
+    const childRenderInNoTitleCard = jest.fn();
+
+    mount(<Card size={CARD_SIZES.MEDIUM} children={childRenderInNoTitleCard} />);
+    expect(childRenderInNoTitleCard).toHaveBeenCalledWith({
+      width: 0,
+      height: 0,
+      position: null,
+    });
   });
 
   test('render icons', () => {

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -176,6 +176,188 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card basic with render prop 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "520px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 cynIXT"
+            id="render-prop-basic"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Card with render prop"
+              >
+                Card with render prop
+                 
+              </span>
+              <div
+                className="card--toolbar"
+              >
+                <div
+                  className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    aria-label="Menu"
+                    className="card--toolbar-action bx--overflow-menu"
+                    onClick={[Function]}
+                    onClose={[Function]}
+                    onKeyDown={[Function]}
+                    open={false}
+                    tabIndex={0}
+                    title="Open and close list of options"
+                  >
+                    <svg
+                      aria-label="open and close list of options"
+                      className="bx--overflow-menu__icon"
+                      focusable="false"
+                      height={20}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                      />
+                      <path
+                        d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                      />
+                      <path
+                        d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                      />
+                      <title>
+                        open and close list of options
+                      </title>
+                    </svg>
+                  </button>
+                </div>
+                <button
+                  className="card--toolbar-action CardToolbar__ToolbarSVGWrapper-sc-1ekh8ti-0 eapGUf"
+                  onClick={[Function]}
+                >
+                  <svg
+                    description="Expand to fullscreen"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    title="Expand to fullscreen"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                    />
+                    <path
+                      d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 hDVRgE"
+            >
+              <p>
+                Content width is 
+                 and height is 
+                NaN
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card error 1`] = `
 <div
   style={


### PR DESCRIPTION
Closes #781

**Summary**
The size object passed to card children did not consider the height of the card title which made it incorrect. This PR fixes that problem.

tested with title
tested without title
tested expanded
tested as custom card

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**
Create a card with
```
          children={childSize => (
            <p>
              Content width is {childSize.width} and height is {childSize.height}
            </p>
          )}
```
and verify that the printed size corresponds to the actual size of the card content using the DOM inspector. Verify the following scenarios for different cards sizes:
card with title
card without title
card expanded
card as custom card

