### PR TITLE
fix(header): moved state lower for event handling

### DIFF
--- a/src/components/Header/HeaderAction/HeaderAction.jsx
+++ b/src/components/Header/HeaderAction/HeaderAction.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { settings } from 'carbon-components';
 import { HeaderGlobalAction } from 'carbon-components-react/lib/components/UIShell';
 import PropTypes from 'prop-types';
@@ -16,14 +16,6 @@ export const HeaderActionPropTypes = {
   item: PropTypes.shape(HeaderActionItemPropTypes).isRequired,
   /** unique index for the menu item */
   index: PropTypes.number.isRequired,
-  /** callback when the menu item should be opened or closed  */
-  onToggleExpansion: PropTypes.func.isRequired,
-  /** is the action panel showing or not */
-  isExpanded: PropTypes.bool,
-};
-
-const defaultProps = {
-  isExpanded: false,
 };
 
 /**
@@ -36,15 +28,23 @@ const defaultProps = {
  * or dropdown menus
  */
 // eslint-disable-next-line
-const HeaderAction = ({ item, index, onToggleExpansion, isExpanded }) => {
+const HeaderAction = ({ item, index }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
   const parentContainerRef = useRef(null);
   const menuButtonRef = useRef(null);
+
+  // expanded state for HeaderAction dropdowns
+  const toggleExpandedState = () => {
+    setIsExpanded(state => !state);
+  };
+
   /**
    * close header panel when focus is lost as long as we didn't enter into the child panel
    * */
   const handleHeaderClose = event => {
     if (!parentContainerRef.current.contains(event.relatedTarget)) {
-      onToggleExpansion();
+      // Only close the header if the header is already expanded
+      if (isExpanded) toggleExpandedState();
     }
   };
 
@@ -59,7 +59,7 @@ const HeaderAction = ({ item, index, onToggleExpansion, isExpanded }) => {
     ) {
       event.stopPropagation();
       event.preventDefault();
-      onToggleExpansion(item.label);
+      toggleExpandedState();
 
       // Return focus to menu button when the user hits ESC.
       if (menuButtonRef && menuButtonRef.current) {
@@ -83,7 +83,7 @@ const HeaderAction = ({ item, index, onToggleExpansion, isExpanded }) => {
           // Render a subpanel type action
           <HeaderActionPanel
             item={item}
-            onToggleExpansion={() => onToggleExpansion(item.label)}
+            onToggleExpansion={toggleExpandedState}
             isExpanded={isExpanded}
             ref={menuButtonRef}
             index={index}
@@ -98,7 +98,7 @@ const HeaderAction = ({ item, index, onToggleExpansion, isExpanded }) => {
             menuLinkName={item.menuLinkName ? item.menuLinkName : ''}
             isExpanded={isExpanded}
             ref={menuButtonRef}
-            onToggleExpansion={() => onToggleExpansion(item.label)}
+            onToggleExpansion={toggleExpandedState}
             label={item.label}
             data-testid="header-menu"
             title="header-menu"
@@ -122,6 +122,5 @@ const HeaderAction = ({ item, index, onToggleExpansion, isExpanded }) => {
 };
 
 HeaderAction.propTypes = HeaderActionPropTypes;
-HeaderAction.defaultProps = defaultProps;
 
 export default HeaderAction;

--- a/src/components/Header/HeaderAction/HeaderActionPanel.jsx
+++ b/src/components/Header/HeaderAction/HeaderActionPanel.jsx
@@ -41,7 +41,7 @@ const HeaderActionPanel = ({ item, index, onToggleExpansion, isExpanded, focusRe
         aria-label={item.label}
         aria-haspopup="menu"
         aria-expanded={isExpanded}
-        onClick={onToggleExpansion}
+        onClick={() => onToggleExpansion()}
         ref={focusRef}
       >
         {item.btnContent}

--- a/src/components/Header/HeaderActionGroup.jsx
+++ b/src/components/Header/HeaderActionGroup.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { HeaderGlobalBar } from 'carbon-components-react/lib/components/UIShell';
 import PropTypes from 'prop-types';
 
@@ -16,26 +16,11 @@ const propTypes = {
  * or dropdown menus, passing an onToggleExpansion to each action
  */
 const HeaderActionGroup = ({ actionItems }) => {
-  const [expandedItem, setExpandedItem] = useState({});
-
-  // expanded state for header dropdowns
-  const toggleExpandedState = index => {
-    setExpandedItem({
-      [index]: !expandedItem[index],
-    });
-  };
-
   return (
     <>
       <HeaderGlobalBar>
         {actionItems.map((item, i) => (
-          <HeaderAction
-            item={item}
-            index={i}
-            onToggleExpansion={toggleExpandedState}
-            isExpanded={expandedItem[item.label]}
-            key={`header-action-item-${item.label}-${i}`}
-          />
+          <HeaderAction item={item} index={i} key={`header-action-item-${item.label}-${i}`} />
         ))}
       </HeaderGlobalBar>
     </>


### PR DESCRIPTION
Closes #850 

Old behavior: 
![](https://media.giphy.com/media/S3KLiXK1UZS56LqzCV/giphy.gif)


**Summary**

- The `onBlur` and `onClick` events were both being fired if another HeaderAction was already in focus. This behavior was unpredictable and it is believed that the `onBlur` was causing a re-render, which would "throw away" the second event
- The `isExpanded` state was moved into the HeaderAction rather than the HeaderActionGroup in an effort to avoid the event where the `expandedItems` object was getting overwritten by other events. By moving it to the action itself, it became unaware of other action's events.

**Change List (commits, features, bugs, etc)**

- src/components/Header/HeaderAction/HeaderAction.jsx
- src/components/Header/HeaderActionGroup.jsx
- src/components/Header/HeaderAction/HeaderActionPanel.jsx

**Acceptance Test (how to verify the PR)**

1. Go to Header story
2. Click on 1 HeaderAction
3. Rapidly click another HeaderAction
4. Repeat 2 & 3 multiple times
5. See that the bug no longer occurs

**Note:** This primarily occured when the Header was implemented in our actual project
