### PR TITLE
test(table): update filter placeholders

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -88,12 +88,12 @@ export const tableColumns = [
   {
     id: 'string',
     name: 'String',
-    filter: { placeholderText: 'pick a string' },
+    filter: { placeholderText: 'enter a string' },
   },
   {
     id: 'date',
     name: 'Date',
-    filter: { placeholderText: 'pick a date' },
+    filter: { placeholderText: 'enter a date' },
   },
   {
     id: 'select',
@@ -113,7 +113,7 @@ export const tableColumns = [
   {
     id: 'number',
     name: 'Number',
-    filter: { placeholderText: 'pick a number' },
+    filter: { placeholderText: 'enter a number' },
   },
   {
     id: 'boolean',
@@ -126,14 +126,14 @@ export const tableColumnsWithAlignment = [
   {
     id: 'string',
     name: 'String',
-    filter: { placeholderText: 'pick a string' },
+    filter: { placeholderText: 'enter a string' },
     align: 'start',
     isSortable: true,
   },
   {
     id: 'date',
     name: 'Date',
-    filter: { placeholderText: 'pick a date' },
+    filter: { placeholderText: 'enter a date' },
     align: 'center',
     isSortable: true,
   },
@@ -157,7 +157,7 @@ export const tableColumnsWithAlignment = [
   {
     id: 'number',
     name: 'Number',
-    filter: { placeholderText: 'pick a number' },
+    filter: { placeholderText: 'enter a number' },
     align: 'end',
     isSortable: true,
   },

--- a/src/utils/sample.jsx
+++ b/src/utils/sample.jsx
@@ -2513,7 +2513,7 @@ export const tableColumns = [
     dataSourceId: 'count',
     label: 'Count',
     priority: 3,
-    filter: { placeholderText: 'pick a string' },
+    filter: { placeholderText: 'enter a string' },
   },
   {
     dataSourceId: 'hour',


### PR DESCRIPTION
Closes #244

**Summary**
The storybook sample table with filters always use the verb 'Pick'. It should be updated to 'Enter' in case it's a non-picker type of field.

**Acceptance Test (how to verify the PR)**

Verify that on ?path=/story/watson-iot-table--with-filters there's 'enter' as majority of the filter placeholders. There should be only a 'pick' on the Select dropdown
