### PR TITLE
fix(AddCard) added proper color to title

### DIFF
--- a/src/components/AddCard/AddCard.jsx
+++ b/src/components/AddCard/AddCard.jsx
@@ -17,7 +17,7 @@ const propTypes = {
  */
 const AddCard = ({ onClick, title, className }) => (
   <ClickableTile className={classNames('add-card', className)} handleClick={onClick}>
-    <p className="title">{title}</p>
+    <p className="addcard-title">{title}</p>
     <Add fill={g10.icon01} description={title} />
   </ClickableTile>
 );

--- a/src/components/AddCard/AddCard.jsx
+++ b/src/components/AddCard/AddCard.jsx
@@ -5,6 +5,10 @@ import classNames from 'classnames';
 import { g10 } from '@carbon/themes';
 import Add from '@carbon/icons-react/lib/add/20';
 
+import { settings } from '../../constants/Settings';
+
+const { iotPrefix } = settings;
+
 const propTypes = {
   /** Title to show on the card */
   title: PropTypes.string.isRequired,
@@ -16,8 +20,8 @@ const propTypes = {
  * Clickable card that shows "Add" button
  */
 const AddCard = ({ onClick, title, className }) => (
-  <ClickableTile className={classNames('add-card', className)} handleClick={onClick}>
-    <p className="addcard-title">{title}</p>
+  <ClickableTile className={classNames(`${iotPrefix}-add-card`, className)} handleClick={onClick}>
+    <p className={`${iotPrefix}-addcard-title`}>{title}</p>
     <Add fill={g10.icon01} description={title} />
   </ClickableTile>
 );

--- a/src/components/AddCard/__snapshots__/AddCard.story.storyshot
+++ b/src/components/AddCard/__snapshots__/AddCard.story.storyshot
@@ -40,12 +40,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|AddCa
         }
       >
         <a
-          className="bx--link bx--tile bx--tile--clickable add-card"
+          className="bx--link bx--tile bx--tile--clickable iot-add-card"
           onClick={[Function]}
           onKeyDown={[Function]}
         >
           <p
-            className="addcard-title"
+            className="iot-addcard-title"
           >
             Click me
           </p>

--- a/src/components/AddCard/__snapshots__/AddCard.story.storyshot
+++ b/src/components/AddCard/__snapshots__/AddCard.story.storyshot
@@ -45,7 +45,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|AddCa
           onKeyDown={[Function]}
         >
           <p
-            className="title"
+            className="addcard-title"
           >
             Click me
           </p>

--- a/src/components/AddCard/_add-card.scss
+++ b/src/components/AddCard/_add-card.scss
@@ -1,7 +1,8 @@
 @import '~carbon-components/scss/globals/scss/vars';
 @import '~carbon-components/scss/globals/scss/layout';
+@import '../../globals/vars';
 
-.add-card {
+.#{$iot-prefix}-add-card {
   border: 1px solid transparent;
   display: inline-flex;
   flex-direction: column;
@@ -15,8 +16,8 @@
   svg {
     margin: auto 0 0 auto;
   }
+}
 
-  p.addcard-title {
-    color: $text-01;
-  }
+.#{$iot-prefix}-addcard-title {
+  color: $text-01;
 }

--- a/src/components/AddCard/_add-card.scss
+++ b/src/components/AddCard/_add-card.scss
@@ -15,4 +15,8 @@
   svg {
     margin: auto 0 0 auto;
   }
+
+  p.addcard-title {
+    color: $text-01;
+  }
 }


### PR DESCRIPTION
Closes #474 

**Summary**

- Made more descriptive class name for title
- Added `$text-01` to the title's class to match icon

**Before**
<img width="201" alt="Screen Shot 2020-01-28 at 10 50 21 PM" src="https://user-images.githubusercontent.com/25177649/73328765-95553f00-4220-11ea-9e22-2d65bad88aa1.png">

**After**
<img width="174" alt="Screen Shot 2020-01-28 at 10 50 15 PM" src="https://user-images.githubusercontent.com/25177649/73328770-9a19f300-4220-11ea-9a8e-082ad611a6e9.png">

**Change List (commits, features, bugs, etc)**

- src/components/AddCard/AddCard.jsx
- src/components/AddCard/_add-card.scss

**Acceptance Test (how to verify the PR)**

- Go to AddCard story and see that the title color matches the icon
