### PR TITLE
feat: Piglets GRAPHITE-5346: #Health widget extension with donut graph

### DIFF
--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -64,3 +64,32 @@
     }
   }
 }
+
+.donutchart-text {
+  font: 16px/1.4em 'Montserrat', Arial, sans-serif;
+  fill: #000;
+  -moz-transform: translateY(0.25em);
+  -ms-transform: translateY(0.25em);
+  -webkit-transform: translateY(0.25em);
+  transform: translateY(0.25em);
+}
+
+.donutchart-text-value {
+  font-size: 0.6em;
+  line-height: 1;
+  text-anchor: middle;
+  -moz-transform: translateY(-0.25em);
+  -ms-transform: translateY(-0.25em);
+  -webkit-transform: translateY(-0.25em);
+  transform: translateY(-0.25em);
+}
+
+.donutchart-text-label {
+  font-size: 0.4em;
+  text-transform: uppercase;
+  text-anchor: middle;
+  -moz-transform: translateY(0.7em);
+  -ms-transform: translateY(0.7em);
+  -webkit-transform: translateY(0.7em);
+  transform: translateY(0.7em);
+}

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -169,7 +169,7 @@ const CardRenderer = React.memo(
     };
 
     return type === CARD_TYPES.VALUE ? (
-      <ValueCard {...commonCardProps} />
+      <ValueCard {...commonCardProps} cardType="DONUT" />
     ) : type === CARD_TYPES.IMAGE ? (
       <ImageCard {...commonCardProps} error={card.setupError || card.error} />
     ) : type === CARD_TYPES.TIMESERIES ? (

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -169,7 +169,7 @@ const CardRenderer = React.memo(
     };
 
     return type === CARD_TYPES.VALUE ? (
-      <ValueCard {...commonCardProps} cardType="DONUT" />
+      <ValueCard {...commonCardProps} />
     ) : type === CARD_TYPES.IMAGE ? (
       <ImageCard {...commonCardProps} error={card.setupError || card.error} />
     ) : type === CARD_TYPES.TIMESERIES ? (

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -148,14 +148,38 @@ export const originalCards = [
       attributes: [
         {
           dataSourceId: 'health',
-          thresholds: [
-            { comparison: '=', value: 'Healthy', icon: 'checkmark', color: 'green' },
-            { comparison: '=', value: 'Unhealthy', icon: 'close', color: 'red' },
+          cardType: 'DONUT',
+          thresholdRange: [
+            {
+              lower: 80,
+              upper: 100,
+              color: '#4b8400',
+              rangename: 'GOOD',
+            },
+            {
+              lower: 50,
+              upper: 80,
+              color: '#be9b00',
+              rangename: 'FAIR',
+            },
+            {
+              lower: 40,
+              upper: 50,
+              color: '#d74108',
+              rangename: 'POOR',
+            },
+            {
+              lower: 0,
+              upper: 40,
+              color: '#4b8400',
+              rangename: 'PSD',
+            },
           ],
+          secondaryValue: { dataSourceId: 'trend', trend: 'up', color: 'green' },
         },
       ],
     },
-    values: { health: 'Healthy' },
+    values: { health: 90, trend: '22%' },
   },
   {
     title: 'Temperature',

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -654,7 +654,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 eFsDRY"
                             >
                               <svg
                                 className="donutchart"
@@ -2451,7 +2451,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 eFsDRY"
                             >
                               <svg
                                 className="donutchart"
@@ -4280,7 +4280,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 eFsDRY"
                             >
                               <svg
                                 className="donutchart"
@@ -8440,7 +8440,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 eFsDRY"
                             >
                               <svg
                                 className="donutchart"
@@ -20274,7 +20274,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 eFsDRY"
                             >
                               <svg
                                 className="donutchart"

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -654,42 +654,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                              color={null}
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
                             >
-                              <span
-                                className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
-                                title="Healthy "
-                                value="Healthy"
+                              <svg
+                                className="donutchart"
+                                height="100%"
+                                viewBox="0 0 50 50"
+                                width="100%"
                               >
-                                Healthy
-                              </span>
-                            </div>
-                            <div
-                              className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                            >
-                              <div
-                                className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                              >
-                                <svg
-                                  aria-label="= Healthy"
-                                  className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
-                                  fill="green"
-                                  fillRule="evenodd"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
+                                <circle
+                                  className="donutchart-track"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#DAE2E5"
+                                  style={
+                                    Object {
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <circle
+                                  className="donutchart-indicator"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#4b8400"
+                                  style={
+                                    Object {
+                                      "strokeDasharray": "127.23450247038663 141.3716694115407",
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <g
+                                  className="donutchart-text"
                                 >
-                                  <title>
-                                    = Healthy
-                                  </title>
-                                  <path
-                                    d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"
-                                  />
-                                </svg>
-                              </div>
+                                  <text
+                                    className="donutchart-text-value"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    90
+                                  </text>
+                                  <text
+                                    className="donutchart-text-label"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    GOOD
+                                  </text>
+                                </g>
+                              </svg>
                             </div>
                           </div>
                           <div
@@ -2431,42 +2451,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                              color={null}
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
                             >
-                              <span
-                                className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
-                                title="Healthy "
-                                value="Healthy"
+                              <svg
+                                className="donutchart"
+                                height="100%"
+                                viewBox="0 0 50 50"
+                                width="100%"
                               >
-                                Healthy
-                              </span>
-                            </div>
-                            <div
-                              className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                            >
-                              <div
-                                className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                              >
-                                <svg
-                                  aria-label="= Healthy"
-                                  className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
-                                  fill="green"
-                                  fillRule="evenodd"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
+                                <circle
+                                  className="donutchart-track"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#DAE2E5"
+                                  style={
+                                    Object {
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <circle
+                                  className="donutchart-indicator"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#4b8400"
+                                  style={
+                                    Object {
+                                      "strokeDasharray": "127.23450247038663 141.3716694115407",
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <g
+                                  className="donutchart-text"
                                 >
-                                  <title>
-                                    = Healthy
-                                  </title>
-                                  <path
-                                    d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"
-                                  />
-                                </svg>
-                              </div>
+                                  <text
+                                    className="donutchart-text-value"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    90
+                                  </text>
+                                  <text
+                                    className="donutchart-text-label"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    GOOD
+                                  </text>
+                                </g>
+                              </svg>
                             </div>
                           </div>
                           <div
@@ -4240,42 +4280,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                              color={null}
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
                             >
-                              <span
-                                className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
-                                title="Healthy "
-                                value="Healthy"
+                              <svg
+                                className="donutchart"
+                                height="100%"
+                                viewBox="0 0 50 50"
+                                width="100%"
                               >
-                                Healthy
-                              </span>
-                            </div>
-                            <div
-                              className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                            >
-                              <div
-                                className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                              >
-                                <svg
-                                  aria-label="= Healthy"
-                                  className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
-                                  fill="green"
-                                  fillRule="evenodd"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
+                                <circle
+                                  className="donutchart-track"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#DAE2E5"
+                                  style={
+                                    Object {
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <circle
+                                  className="donutchart-indicator"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#4b8400"
+                                  style={
+                                    Object {
+                                      "strokeDasharray": "127.23450247038663 141.3716694115407",
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <g
+                                  className="donutchart-text"
                                 >
-                                  <title>
-                                    = Healthy
-                                  </title>
-                                  <path
-                                    d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"
-                                  />
-                                </svg>
-                              </div>
+                                  <text
+                                    className="donutchart-text-value"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    90
+                                  </text>
+                                  <text
+                                    className="donutchart-text-label"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    GOOD
+                                  </text>
+                                </g>
+                              </svg>
                             </div>
                           </div>
                           <div
@@ -8380,42 +8440,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                              color={null}
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
                             >
-                              <span
-                                className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
-                                title="Healthy "
-                                value="Healthy"
+                              <svg
+                                className="donutchart"
+                                height="100%"
+                                viewBox="0 0 50 50"
+                                width="100%"
                               >
-                                Healthy
-                              </span>
-                            </div>
-                            <div
-                              className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                            >
-                              <div
-                                className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                              >
-                                <svg
-                                  aria-label="= Healthy"
-                                  className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
-                                  fill="green"
-                                  fillRule="evenodd"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
+                                <circle
+                                  className="donutchart-track"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#DAE2E5"
+                                  style={
+                                    Object {
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <circle
+                                  className="donutchart-indicator"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#4b8400"
+                                  style={
+                                    Object {
+                                      "strokeDasharray": "127.23450247038663 141.3716694115407",
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <g
+                                  className="donutchart-text"
                                 >
-                                  <title>
-                                    = Healthy
-                                  </title>
-                                  <path
-                                    d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"
-                                  />
-                                </svg>
-                              </div>
+                                  <text
+                                    className="donutchart-text-value"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    90
+                                  </text>
+                                  <text
+                                    className="donutchart-text-label"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    GOOD
+                                  </text>
+                                </g>
+                              </svg>
                             </div>
                           </div>
                           <div
@@ -20194,42 +20274,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             size="XSMALLWIDE"
                           >
                             <div
-                              className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                              color={null}
+                              className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
                             >
-                              <span
-                                className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
-                                title="Healthy "
-                                value="Healthy"
+                              <svg
+                                className="donutchart"
+                                height="100%"
+                                viewBox="0 0 50 50"
+                                width="100%"
                               >
-                                Healthy
-                              </span>
-                            </div>
-                            <div
-                              className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                            >
-                              <div
-                                className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                              >
-                                <svg
-                                  aria-label="= Healthy"
-                                  className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
-                                  fill="green"
-                                  fillRule="evenodd"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
+                                <circle
+                                  className="donutchart-track"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#DAE2E5"
+                                  style={
+                                    Object {
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <circle
+                                  className="donutchart-indicator"
+                                  cx={25}
+                                  cy={25}
+                                  fill="transparent"
+                                  r={22.5}
+                                  stroke="#4b8400"
+                                  style={
+                                    Object {
+                                      "strokeDasharray": "127.23450247038663 141.3716694115407",
+                                      "strokeWidth": 5,
+                                    }
+                                  }
+                                  transform="rotate(-90 25,25)"
+                                />
+                                <g
+                                  className="donutchart-text"
                                 >
-                                  <title>
-                                    = Healthy
-                                  </title>
-                                  <path
-                                    d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"
-                                  />
-                                </svg>
-                              </div>
+                                  <text
+                                    className="donutchart-text-value"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    90
+                                  </text>
+                                  <text
+                                    className="donutchart-text-label"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    GOOD
+                                  </text>
+                                </g>
+                              </svg>
                             </div>
                           </div>
                           <div

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -92,7 +92,7 @@ const propTypes = {
   ),
   renderIconByName: PropTypes.func,
   precision: PropTypes.number,
-  cardType: PropTypes.string,
+  cardType: PropTypes.oneOf(['VALUE', 'DONUT']),
 };
 
 const defaultProps = {

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -8,6 +8,7 @@ import withSize from 'react-sizeme';
 import icons from '../../utils/bundledIcons';
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
 
+import GraphRenderer from './GraphRenderer';
 import ValueRenderer from './ValueRenderer';
 import UnitRenderer from './UnitRenderer';
 
@@ -81,14 +82,24 @@ const propTypes = {
       icon: PropTypes.string,
     })
   ),
+  thresholdRange: PropTypes.arrayOf(
+    PropTypes.shape({
+      lower: PropTypes.number,
+      upper: PropTypes.number,
+      color: PropTypes.string,
+      rangename: PropTypes.string,
+    })
+  ),
   renderIconByName: PropTypes.func,
   precision: PropTypes.number,
+  cardType: PropTypes.string,
 };
 
 const defaultProps = {
   layout: null,
   precision: 1,
   thresholds: [],
+  thresholdRange: [],
   isVertical: false,
   alignValue: null,
   isSmall: false,
@@ -96,6 +107,7 @@ const defaultProps = {
   label: null,
   renderIconByName: null,
   secondaryValue: null,
+  cardType: 'VALUE',
 };
 
 /**
@@ -114,6 +126,8 @@ const Attribute = ({
   isMini,
   label,
   renderIconByName,
+  cardType,
+  thresholdRange,
   size, // eslint-disable-line
 }) => {
   // matching threshold will be the first match in the list, or a value of null
@@ -173,6 +187,7 @@ const Attribute = ({
             label={label}
           >
             <ValueRenderer
+              isVisible={cardType && cardType === 'VALUE'}
               value={value}
               unit={unit}
               layout={layout}
@@ -185,12 +200,24 @@ const Attribute = ({
               color={valueColor}
             />
             <UnitRenderer
-              isVisible={!measuredSize || measuredSize.width > 100}
+              isVisible={
+                cardType && cardType === 'VALUE' && (!measuredSize || measuredSize.width > 100)
+              }
               value={value}
               unit={unit}
               layout={layout}
               isMini={isMini}
             />
+            {cardType && cardType === 'DONUT' ? (
+              <GraphRenderer
+                size={size}
+                score={value}
+                layout={layout}
+                isSmall={isSmall}
+                isMini={isMini}
+                thresholdRange={thresholdRange}
+              />
+            ) : null}
             {!isNil(secondaryValue) && (!measuredSize || measuredSize.width > 100) ? (
               <AttributeSecondaryValue
                 color={secondaryValue.color}

--- a/src/components/ValueCard/GraphRenderer.jsx
+++ b/src/components/ValueCard/GraphRenderer.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { CARD_LAYOUTS } from '../../constants/LayoutConstants';
+
+const GraphWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  ${props =>
+    props.layout === CARD_LAYOUTS.HORIZONTAL &&
+    `
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-around;
+    padding: 0 1rem;
+    `}
+  ${props =>
+    props.layout === CARD_LAYOUTS.VERTICAL &&
+    `
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-around;
+    padding: 0 0 0.5rem;
+    `}
+`;
+
+const propTypes = {
+  isVisible: PropTypes.bool,
+  cricleSize: PropTypes.number,
+  strokeWidth: PropTypes.number,
+  circleColor: PropTypes.string,
+  layout: PropTypes.string,
+  isMini: PropTypes.bool,
+  score: PropTypes.number,
+  thresholdRange: PropTypes.arrayOf(
+    PropTypes.shape({
+      lower: PropTypes.number,
+      upper: PropTypes.number,
+      color: PropTypes.string,
+      rangename: PropTypes.string,
+    })
+  ),
+};
+
+const defaultProps = {
+  isVisible: true,
+  cricleSize: 50,
+  strokeWidth: 5,
+  circleColor: '#DAE2E5',
+  score: 0,
+  layout: null,
+  isMini: false,
+  thresholdRange: [
+    {
+      lower: 80,
+      upper: 100,
+      color: '#4b8400',
+      rangename: 'GOOD',
+    },
+  ],
+};
+
+/** This components job is determining how to render different kinds of card values */
+const GraphRenderer = ({
+  thresholdRange,
+  score,
+  isVisible,
+  strokeWidth,
+  cricleSize,
+  circleColor,
+  layout,
+  isMini,
+}) => {
+  const halfSize = cricleSize * 0.5;
+  const radius = halfSize - strokeWidth * 0.5;
+  const circumFerence = 2 * Math.PI * radius;
+  const strokeVal = (score * circumFerence) / 100;
+  const trackstyle = { strokeWidth };
+  const indicatorstyle = {
+    strokeWidth,
+    strokeDasharray: `${strokeVal} ${circumFerence}`,
+  };
+  const rotateval = `rotate(-90 ${halfSize},${halfSize})`;
+  const graphData = thresholdRange
+    .filter(obj => {
+      return obj.lower < score && obj.upper > score;
+    })
+    .concat([null])[0];
+
+  return isVisible && graphData ? (
+    <GraphWrapper layout={layout} isMini={isMini}>
+      <svg width="100%" height="100%" viewBox="0 0 50 50" className="donutchart">
+        <circle
+          r={radius}
+          cx={halfSize}
+          cy={halfSize}
+          transform={rotateval}
+          stroke={circleColor}
+          style={trackstyle}
+          fill="transparent"
+          className="donutchart-track"
+        />
+        <circle
+          r={radius}
+          cx={halfSize}
+          cy={halfSize}
+          transform={rotateval}
+          stroke={graphData.color}
+          style={indicatorstyle}
+          fill="transparent"
+          className="donutchart-indicator"
+        />
+        <g className="donutchart-text">
+          <text x="50%" y="50%" className="donutchart-text-value">
+            {score}
+          </text>
+          <text x="50%" y="50%" className="donutchart-text-label">
+            {graphData.rangename}
+          </text>
+        </g>
+      </svg>
+    </GraphWrapper>
+  ) : null;
+};
+GraphRenderer.propTypes = propTypes;
+GraphRenderer.defaultProps = defaultProps;
+
+export default GraphRenderer;

--- a/src/components/ValueCard/GraphRenderer.jsx
+++ b/src/components/ValueCard/GraphRenderer.jsx
@@ -2,29 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { CARD_LAYOUTS } from '../../constants/LayoutConstants';
-
 const GraphWrapper = styled.div`
   display: flex;
-  width: 100%;
-  height: 100%;
-  ${props =>
-    props.layout === CARD_LAYOUTS.HORIZONTAL &&
-    `
-    flex-direction: row;
-    align-items: flex-end;
-    justify-content: space-around;
-    padding: 0 1rem;
-    `}
-  ${props =>
-    props.layout === CARD_LAYOUTS.VERTICAL &&
-    `
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-around;
-    padding: 0 0 0.5rem;
-    `}
+  width: 3rem;
+  height: 3rem;
 `;
 
 const propTypes = {

--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -204,7 +204,7 @@ const isLabelAboveValue = (size, layout, attributes, measuredSize) => {
   }
 };
 
-const ValueCard = ({ title, content, size, values, isEditable, i18n, ...others }) => {
+const ValueCard = ({ title, content, size, values, cardType, isEditable, i18n, ...others }) => {
   const availableActions = {
     expand: false,
     ...others.availableActions,
@@ -271,6 +271,7 @@ const ValueCard = ({ title, content, size, values, isEditable, i18n, ...others }
                             : determineValue(attribute.secondaryValue.dataSourceId, values),
                         }
                       }
+                      cardType={attribute.cardType}
                     />
                     {isMini && <Spacer />}
                     <AttributeLabel

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -97,6 +97,55 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
+  .add('xsmall /donut with trend down', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    return (
+      <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
+        <ValueCard
+          title={text('title', '')}
+          id="donutCard"
+          content={{
+            attributes: object('attributes', [
+              {
+                dataSourceId: 'score',
+                cardType: 'DONUT',
+                thresholdRange: [
+                  {
+                    lower: 80,
+                    upper: 100,
+                    color: '#4b8400',
+                    rangename: 'GOOD',
+                  },
+                  {
+                    lower: 50,
+                    upper: 80,
+                    color: '#be9b00',
+                    rangename: 'FAIR',
+                  },
+                  {
+                    lower: 40,
+                    upper: 50,
+                    color: '#d74108',
+                    rangename: 'POOR',
+                  },
+                  {
+                    lower: 0,
+                    upper: 40,
+                    color: '#4b8400',
+                    rangename: 'PSD',
+                  },
+                ],
+                secondaryValue: { dataSourceId: 'trend', trend: 'down', color: 'red' },
+              },
+            ]),
+          }}
+          breakpoint="lg"
+          size={size}
+          values={{ score: number('score', 90), trend: text('trend', '22%') }}
+        />
+      </div>
+    );
+  })
   .add('xsmall / trend down', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
     return (

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -102,7 +102,7 @@ storiesOf('Watson IoT|ValueCard', module)
     return (
       <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
         <ValueCard
-          title={text('title', '')}
+          title={text('title', 'Health')}
           id="donutCard"
           content={{
             attributes: object('attributes', [

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -16,6 +16,7 @@ const propTypes = {
   size: PropTypes.string.isRequired,
   color: PropTypes.string,
   isVertical: PropTypes.bool,
+  isVisible: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -25,6 +26,7 @@ const defaultProps = {
   precision: 1,
   color: null,
   isVertical: false,
+  isVisible: true,
 };
 
 const Attribute = styled.div`
@@ -82,6 +84,7 @@ const determinePrecision = (size, value, precision) => {
 
 /** This components job is determining how to render different kinds of card values */
 const ValueRenderer = ({
+  isVisible,
   value,
   size,
   unit,
@@ -111,7 +114,7 @@ const ValueRenderer = ({
   } else if (isNil(value)) {
     renderValue = '--';
   }
-  return (
+  return isVisible ? (
     <Attribute unit={unit} isSmall={isSmall} isMini={isMini} color={color} isVertical={isVertical}>
       <AttributeValue
         size={size}
@@ -124,7 +127,7 @@ const ValueRenderer = ({
         {renderValue}
       </AttributeValue>
     </Attribute>
-  );
+  ) : null;
 };
 
 ValueRenderer.propTypes = propTypes;

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -4102,7 +4102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     size="XSMALL"
                   >
                     <div
-                      className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
+                      className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 eFsDRY"
                     >
                       <svg
                         className="donutchart"

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -4021,6 +4021,183 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall /donut with trend down 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "150px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 fbzdtE"
+            id="donutCard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title=""
+              >
+                
+                 
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 hoCWQe"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="XSMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="XSMALL"
+                  >
+                    <div
+                      className="GraphRenderer__GraphWrapper-sc-1clzo2q-0 XQgjE"
+                    >
+                      <svg
+                        className="donutchart"
+                        height="100%"
+                        viewBox="0 0 50 50"
+                        width="100%"
+                      >
+                        <circle
+                          className="donutchart-track"
+                          cx={25}
+                          cy={25}
+                          fill="transparent"
+                          r={22.5}
+                          stroke="#DAE2E5"
+                          style={
+                            Object {
+                              "strokeWidth": 5,
+                            }
+                          }
+                          transform="rotate(-90 25,25)"
+                        />
+                        <circle
+                          className="donutchart-indicator"
+                          cx={25}
+                          cy={25}
+                          fill="transparent"
+                          r={22.5}
+                          stroke="#4b8400"
+                          style={
+                            Object {
+                              "strokeDasharray": "127.23450247038663 141.3716694115407",
+                              "strokeWidth": 5,
+                            }
+                          }
+                          transform="rotate(-90 25,25)"
+                        />
+                        <g
+                          className="donutchart-text"
+                        >
+                          <text
+                            className="donutchart-text-value"
+                            x="50%"
+                            y="50%"
+                          >
+                            90
+                          </text>
+                          <text
+                            className="donutchart-text-label"
+                            x="50%"
+                            y="50%"
+                          >
+                            GOOD
+                          </text>
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="XSMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmallwide / horizontal 2 1`] = `
 <div
   style={

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -4077,9 +4077,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                title=""
+                title="Health"
               >
-                
+                Health
                  
               </span>
               <div


### PR DESCRIPTION
Closes #

Summary

Allow to display donut graph in valuecard

Change List (commits, features, bugs, etc)

src/components/Card/_card.scss 
src/components/Dashboard/CardRenderer.jsx 
src/components/Dashboard/Dashboard.story.jsx 
src/components/Dashboard/__snapshots__/Dashboard.story.storyshot 
src/components/ValueCard/Attribute.jsx 
src/components/ValueCard/GraphRenderer.jsx 
src/components/ValueCard/ValueCard.jsx 
src/components/ValueCard/ValueCard.story.jsx 
src/components/ValueCard/ValueRenderer.jsx 
src/components/ValueCard/__snapshots__/ValueCard.story.storyshot 

Acceptance Test (how to verify the PR)

Allow to show donut graph in side the valuecard by passing cardType,
The valuecard getting tow parameters ( value , thresholdRange) as attributes.
On the behalf of value and thresholdRange, card display as donut chart

- tests here
