### PR TITLE
test(table): wip for pre-set toolbar search value

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -2528,6 +2528,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                       <div
                         className="bx--structured-list-td"
                       >
+                        EmptyTable
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="bx--structured-list-td"
+                      />
+                      <div
+                        className="bx--structured-list-td"
+                      >
+                        TableSkeletonWithHeaders
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="bx--structured-list-td"
+                      />
+                      <div
+                        className="bx--structured-list-td"
+                      >
                         WizardModal
                       </div>
                     </div>
@@ -2553,30 +2577,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                         className="bx--structured-list-td"
                       >
                         StatefulWizardInline
-                      </div>
-                    </div>
-                    <div
-                      className="bx--structured-list-row"
-                    >
-                      <div
-                        className="bx--structured-list-td"
-                      />
-                      <div
-                        className="bx--structured-list-td"
-                      >
-                        EmptyTable
-                      </div>
-                    </div>
-                    <div
-                      className="bx--structured-list-row"
-                    >
-                      <div
-                        className="bx--structured-list-td"
-                      />
-                      <div
-                        className="bx--structured-list-td"
-                      >
-                        TableSkeletonWithHeaders
                       </div>
                     </div>
                     <div

--- a/src/components/StorybookSnapshots.test.js
+++ b/src/components/StorybookSnapshots.test.js
@@ -82,8 +82,10 @@ describe(`Storybook Snapshot tests and console checks`, () => {
         const storiesNeedingNestedInputRefs = [
           'Watson IoT|Table.minitable',
           'Watson IoT|Table.with simple search',
+          'Watson IoT|Table.with pre-filled simple search',
           'Watson IoT|Table.Stateful Example with row nesting',
           'Watson IoT|Table.Stateful Example with expansion',
+          'Watson IoT|Table.Stateful Example with initial search value',
           'Watson IoT|TileCatalog.with search',
           'Watson IoT|TableCard',
         ];

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -467,19 +467,36 @@ storiesOf('Watson IoT|Table', module)
     }
   )
   .add('Stateful Example with Secondary Title', () => (
+    <StatefulTable
+      {...initialState}
+      secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
+      options={{
+        hasSearch: boolean('Show Search', true),
+        hasPagination: boolean('Show Pagination', true),
+        hasRowSelection: 'multi',
+        hasFilter: boolean('Show Filter', true),
+        hasRowActions: boolean('Show Row Action', true),
+      }}
+      view={{
+        toolbar: { activeBar: null },
+      }}
+    />
+  ))
+  .add('Stateful Example with initial search value', () => (
     <FullWidthWrapper>
       <StatefulTable
         {...initialState}
-        secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
         options={{
-          hasSearch: boolean('Show Search', true),
-          hasPagination: boolean('Show Pagination', true),
-          hasRowSelection: 'multi',
-          hasFilter: boolean('Show Filter', true),
-          hasRowActions: boolean('Show Row Action', true),
+          hasSearch: true,
         }}
         view={{
-          toolbar: { activeBar: null },
+          toolbar: {
+            activeBar: null,
+            search: {
+              value: 'option-A',
+              expanded: true,
+            },
+          },
         }}
       />
     </FullWidthWrapper>
@@ -703,11 +720,41 @@ storiesOf('Watson IoT|Table', module)
         data={tableData}
         actions={actions}
         options={{ hasSearch: true }}
+        view={{
+          toolbar: {
+            activeBar: null,
+          },
+        }}
       />
     ),
     {
       info: {
-        text: `To enable simple search on a table, simply set the prop options.hasSearch=true.  We wouldn't recommend enabling column filters on a table and simple search for UX reasons, but it is supported.`,
+        text: `To enable simple search on a table, simply set the prop options.hasSearch=true.  We wouldn't recommend enabling column filters on a table and simple search for UX reasons, but it is supported. To programmatically pass a value to the search field, you can set the prop view.toolbar.search.value='your value'`,
+      },
+    }
+  )
+  .add(
+    'with pre-filled simple search',
+    () => (
+      <Table
+        columns={tableColumns}
+        data={tableData}
+        actions={actions}
+        options={{ hasSearch: true }}
+        view={{
+          toolbar: {
+            activeBar: null,
+            search: {
+              value: text('Search Value', 'hello world.'),
+              expanded: true,
+            },
+          },
+        }}
+      />
+    ),
+    {
+      info: {
+        text: `To programmatically pass a value to the search field, you can set the prop view.toolbar.search.value='your value' and view.toolbar.search.expanded=true`,
       },
     }
   )

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -212,4 +212,5 @@ export const defaultI18NPropTypes = {
 
 export const TableSearchPropTypes = PropTypes.shape({
   value: PropTypes.string,
+  expanded: PropTypes.bool,
 });


### PR DESCRIPTION
DO NOT MERGE

Closes #429

**Summary**
There's a new test on the story for the stateful available at ?path=/story/watson-iot-table--stateful-example-with-initial-search-value where you can see that setting it (to 'option-A') actually filters the table

In the stateless table there's a new knob to test it as well