### PR TITLE
fix(dashboardgrid): if card is missing from layout regenerate the layout

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -2528,6 +2528,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                       <div
                         className="bx--structured-list-td"
                       >
+                        EmptyTable
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="bx--structured-list-td"
+                      />
+                      <div
+                        className="bx--structured-list-td"
+                      >
+                        TableSkeletonWithHeaders
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="bx--structured-list-td"
+                      />
+                      <div
+                        className="bx--structured-list-td"
+                      >
                         WizardModal
                       </div>
                     </div>
@@ -2553,30 +2577,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                         className="bx--structured-list-td"
                       >
                         StatefulWizardInline
-                      </div>
-                    </div>
-                    <div
-                      className="bx--structured-list-row"
-                    >
-                      <div
-                        className="bx--structured-list-td"
-                      />
-                      <div
-                        className="bx--structured-list-td"
-                      >
-                        EmptyTable
-                      </div>
-                    </div>
-                    <div
-                      className="bx--structured-list-row"
-                    >
-                      <div
-                        className="bx--structured-list-td"
-                      />
-                      <div
-                        className="bx--structured-list-td"
-                      >
-                        TableSkeletonWithHeaders
                       </div>
                     </div>
                     <div

--- a/src/components/Dashboard/DashboardGrid.jsx
+++ b/src/components/Dashboard/DashboardGrid.jsx
@@ -2,11 +2,11 @@ import React, { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Responsive, WidthProvider } from 'react-grid-layout';
 import styled from 'styled-components';
+import some from 'lodash/some';
 import find from 'lodash/find';
 
 import { getLayout } from '../../utils/componentUtilityFunctions';
 import {
-  CARD_SIZES,
   GUTTER,
   ROW_HEIGHT,
   CARD_DIMENSIONS,
@@ -67,6 +67,39 @@ const defaultProps = {
 };
 
 /**
+ * This function finds an existing layout for each dashboard breakpoint, validates it, and or generates a new one to return
+ * @param {*} layouts an keyed object of each layout for each breakpoint
+ * @param {*} cards an array of the card props for each card
+ */
+export const findLayoutOrGenerate = (layouts, cards) => {
+  // iterate through each breakpoint
+  return Object.keys(DASHBOARD_BREAKPOINTS).reduce((acc, layoutName) => {
+    let layout = layouts && layouts[layoutName];
+    // If layout exists for this breakpoint, make sure it contains all the cards
+    if (layout) {
+      // If you find a card that's missing from the current layout, you need to regenerate the layout
+      if (cards.some(card => !some(layouts[layoutName], { i: card.id }))) {
+        layout = getLayout(layoutName, cards, DASHBOARD_COLUMNS, CARD_DIMENSIONS);
+      } else {
+        // if we're using an existing layout, we need to add CARD_DIMENSIONS because they are not stored in our JSON document
+        layout = layout.map(cardFromLayout => {
+          const matchingCard = find(cards, { id: cardFromLayout.i });
+          return { ...cardFromLayout, ...CARD_DIMENSIONS[matchingCard.size][layoutName] };
+        });
+      }
+    } else {
+      // generate the layout if we're not passed from the parent
+      layout = getLayout(layoutName, cards, DASHBOARD_COLUMNS, CARD_DIMENSIONS);
+    }
+
+    return {
+      ...acc,
+      [layoutName]: layout,
+    };
+  }, {});
+};
+
+/**
  * Renders the grid of cards according to the standardized PAL patterns for IoT.
  *
  * This is a stateless component but it does have some caching to help optimize performance.
@@ -98,31 +131,7 @@ const DashboardGrid = ({
     children,
   ]);
   const generatedLayouts = useMemo(
-    () =>
-      // iterate through each breakpoint
-      Object.keys(DASHBOARD_BREAKPOINTS).reduce((acc, layoutName) => {
-        return {
-          ...acc, // only generate the layout if we're not passed from the parent
-          [layoutName]:
-            layouts && layouts[layoutName]
-              ? layouts[layoutName].map(layout => {
-                  // iterate through all the cards of the laout
-                  // if we can't find the card from the layout, assume small
-                  let matchingCard = find(childrenArray, { props: { id: layout.i } });
-                  if (!matchingCard) {
-                    console.warn(`Error with your layout. Card with id: ${layout.i} not found`); //eslint-disable-line
-                    matchingCard = { props: { size: CARD_SIZES.SMALL } };
-                  }
-                  return { ...layout, ...CARD_DIMENSIONS[matchingCard.props.size][layoutName] };
-                })
-              : getLayout(
-                  layoutName,
-                  childrenArray.map(card => card.props),
-                  DASHBOARD_COLUMNS,
-                  CARD_DIMENSIONS
-                ),
-        };
-      }, {}),
+    () => findLayoutOrGenerate(layouts, childrenArray.map(card => card.props)),
     [childrenArray, layouts]
   );
   const cachedMargin = useMemo(() => [GUTTER, GUTTER], []);

--- a/src/components/Dashboard/DashboardGrid.test.jsx
+++ b/src/components/Dashboard/DashboardGrid.test.jsx
@@ -1,0 +1,36 @@
+import { CARD_SIZES } from '../../constants/LayoutConstants';
+
+import { findLayoutOrGenerate } from './DashboardGrid';
+
+jest.mock('../../utils/componentUtilityFunctions.js'); // this happens automatically with automocking
+const componentUtilityFunctions = require('../../utils/componentUtilityFunctions.js');
+
+describe('DashboardGrid', () => {
+  test('findLayoutOrGenerate', () => {
+    // if no layouts exist they should be generated
+    findLayoutOrGenerate({}, [{ id: 'mycard', size: CARD_SIZES.SMALL }]);
+    expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
+    componentUtilityFunctions.getLayout.mockClear();
+    // if layout is missing card it should be regenerated
+    findLayoutOrGenerate({ max: [], xl: [], lg: [], md: [], sm: [], xs: [] }, [
+      { id: 'mycard', size: CARD_SIZES.SMALL },
+    ]);
+    expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
+    componentUtilityFunctions.getLayout.mockClear();
+    // if every layout already exists, the card should have dimensions added
+    const newLayouts = findLayoutOrGenerate(
+      {
+        max: [{ i: 'mycard', x: 0, y: 0 }],
+        xl: [{ i: 'mycard', x: 0, y: 0 }],
+        lg: [{ i: 'mycard', x: 0, y: 0 }],
+        md: [{ i: 'mycard', x: 0, y: 0 }],
+        sm: [{ i: 'mycard', x: 0, y: 0 }],
+        xs: [{ i: 'mycard', x: 0, y: 0 }],
+      },
+      [{ id: 'mycard', size: CARD_SIZES.SMALL }]
+    );
+    expect(componentUtilityFunctions.getLayout).not.toHaveBeenCalled();
+    expect(newLayouts.max[0]).toHaveProperty('w');
+    expect(newLayouts.max[0]).toHaveProperty('h');
+  });
+});

--- a/src/utils/__tests__/componentUtilityFunctions.test.js
+++ b/src/utils/__tests__/componentUtilityFunctions.test.js
@@ -1,4 +1,4 @@
-import { getSortedData } from '../componentUtilityFunctions';
+import { getSortedData, canFit } from '../componentUtilityFunctions';
 
 const mockData = [
   { values: { number: 10, string: 'string', null: null } },
@@ -16,5 +16,13 @@ describe('componentUtilityFunctions', () => {
     expect(getSortedData(mockData, 'number', 'ASC')[0].values.number).toEqual(10);
     expect(getSortedData(mockData, 'number', 'ASC')[1].values.number).toEqual(20);
     expect(getSortedData(mockData, 'number', 'ASC')[2].values.number).toEqual(100);
+  });
+  test('canFit', () => {
+    expect(canFit(0, 0, 1, 1, [[1, 1, 1, 1], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])).toEqual(
+      false
+    );
+    expect(canFit(0, 0, 1, 1, [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])).toEqual(
+      true
+    );
   });
 });

--- a/src/utils/componentUtilityFunctions.js
+++ b/src/utils/componentUtilityFunctions.js
@@ -2,6 +2,8 @@ import delay from 'lodash/delay';
 import moment from 'moment';
 import { sortStates } from 'carbon-components-react/lib/components/DataTable/state/sorting';
 import fileDownload from 'js-file-download';
+import find from 'lodash/find';
+import some from 'lodash/some';
 
 import {
   GUTTER,
@@ -125,6 +127,12 @@ export const getSortedData = (inputData, columnId, direction, isTimestampColumn)
   });
 };
 
+/**
+ * A simple helper function that stops prop on an event before calling back the callback function
+ * @param {*} evt  event to stop
+ * @param {*} callback  callback to call
+ * @param  {...any} args
+ */
 export const stopPropagationAndCallback = (evt, callback, ...args) => {
   evt.stopPropagation();
   callback(...args);
@@ -145,6 +153,14 @@ export const printGrid = grid => {
   console.log(result); // eslint-disable-line
 };
 
+/**
+ *
+ * @param {*} x  the current x location of a card
+ * @param {*} y  the current y location of a card
+ * @param {*} w  current width of a card
+ * @param {*} h  current height of a card
+ * @param {*} grid nested array of rows and columns with the current card index that is occupying them. for example, if the entire top row was taken by the first card it would look like this [[1, 1, 1, 1], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
+ */
 export const canFit = (x, y, w, h, grid) => {
   // console.log(`canFit? x=${x}, y=${y}, w=${w}, h=${h}`);
   for (let i = x; i < x + w; i += 1) {
@@ -157,7 +173,14 @@ export const canFit = (x, y, w, h, grid) => {
   return true;
 };
 
-/** Generates a non overlapping layout given the cards and column/dimension configuration for a given layout */
+/**
+ * Generates a non overlapping layout given the cards and column/dimension configuration for a given layout
+ * @param {*} layoutName
+ * @param {*} cards
+ * @param {*} dashboardColumns array of column counts for the different breakpoints (see DASHBOARD_COLUMNS)
+ * @param {*} cardDimensions double object of card height and width keyed by card size and layout (see CARD_DIMENSIONS)
+ * returns
+ */
 export const getLayout = (layoutName, cards, dashboardColumns, cardDimensions) => {
   let currX = 0;
   let currY = 0;

--- a/src/utils/componentUtilityFunctions.js
+++ b/src/utils/componentUtilityFunctions.js
@@ -2,8 +2,6 @@ import delay from 'lodash/delay';
 import moment from 'moment';
 import { sortStates } from 'carbon-components-react/lib/components/DataTable/state/sorting';
 import fileDownload from 'js-file-download';
-import find from 'lodash/find';
-import some from 'lodash/some';
 
 import {
   GUTTER,
@@ -142,7 +140,6 @@ export const stopPropagationAndCallback = (evt, callback, ...args) => {
 const gridHeight = 50;
 
 export const printGrid = grid => {
-  // console.log(`printGrid: ${grid}`);
   let result = '';
   for (let j = 0; j < gridHeight; j += 1) {
     for (let i = 0; i < grid.length; i += 1) {
@@ -162,7 +159,6 @@ export const printGrid = grid => {
  * @param {*} grid nested array of rows and columns with the current card index that is occupying them. for example, if the entire top row was taken by the first card it would look like this [[1, 1, 1, 1], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
  */
 export const canFit = (x, y, w, h, grid) => {
-  // console.log(`canFit? x=${x}, y=${y}, w=${w}, h=${h}`);
   for (let i = x; i < x + w; i += 1) {
     for (let j = y; j < y + h; j += 1) {
       if (grid.length === i) return false;
@@ -189,7 +185,6 @@ export const getLayout = (layoutName, cards, dashboardColumns, cardDimensions) =
     .map(() => Array(gridHeight).fill(0));
 
   const placeCard = (x, y, w, h, num) => {
-    // console.log(`placeCard: x=${x}, y=${y}, w=${w}, h=${h}, cardNum=${num}`);
     for (let i = x; i < x + w; i += 1) {
       for (let j = y; j < y + h; j += 1) {
         grid[i][j] = num;
@@ -200,9 +195,7 @@ export const getLayout = (layoutName, cards, dashboardColumns, cardDimensions) =
   const layout = cards
     .map((card, index) => {
       const { w, h } = cardDimensions[card.size][layoutName];
-      // console.log(`trying ${card.id} (w = ${w}, h = ${h}) at ${currX},${currY}`);
       while (!canFit(currX, currY, w, h, grid)) {
-        // console.log('didnt fit...');
         currX += 1;
         if (currX > dashboardColumns[layoutName]) {
           currX = 0;
@@ -212,7 +205,6 @@ export const getLayout = (layoutName, cards, dashboardColumns, cardDimensions) =
           }
         }
       }
-      // console.log('it fits!');
       placeCard(currX, currY, w, h, index + 1);
       // printGrid(grid);
       const cardLayout = {
@@ -223,7 +215,6 @@ export const getLayout = (layoutName, cards, dashboardColumns, cardDimensions) =
         h,
       };
       currX += w;
-      // console.log(`adding ${card.id} (w = ${w}, h = ${h}) at ${cardLayout.x},${cardLayout.y}`);
       return cardLayout;
     })
     .filter(i => i !== null);
@@ -252,6 +243,5 @@ export const getCardMinSize = (
     x: cardColumns * columnWidth + (cardColumns - 1) * GUTTER,
     y: cardRows * rowHeight[breakpoint] + (cardRows - 1) * GUTTER,
   };
-  // console.log('getCardMinSize', breakpoint, size, rowHeight, ` = ${JSON.stringify(cardSize)}`);
   return cardSize;
 };


### PR DESCRIPTION
Closes #https://github.ibm.com/wiotp/monitoring-dashboard/issues/717

This is to fix this bug where if the user hasn't been to a layout breakpoint before (i.e. they added a card but didn't visit all the possible layout sizes to generate the layout), the cards were assuming that they were SMALL instead of using their true size.

![image](https://user-images.githubusercontent.com/6663002/73462400-5cf95200-4341-11ea-876c-1c8cf2258895.png)


**Summary**

- refactor(DashboardGrid): extract the layout generation to another function
- fix(DashboardGrid): add validation of layout to make sure all cards exist
- test(DashboardGrid): added testcases to validate the layout gets regenerated if a card is missing

