### PR TITLE
feat(card): pass full props and toolbar to custom cards

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -2528,6 +2528,30 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                       <div
                         className="bx--structured-list-td"
                       >
+                        EmptyTable
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="bx--structured-list-td"
+                      />
+                      <div
+                        className="bx--structured-list-td"
+                      >
+                        TableSkeletonWithHeaders
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="bx--structured-list-td"
+                      />
+                      <div
+                        className="bx--structured-list-td"
+                      >
                         WizardModal
                       </div>
                     </div>
@@ -2553,30 +2577,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                         className="bx--structured-list-td"
                       >
                         StatefulWizardInline
-                      </div>
-                    </div>
-                    <div
-                      className="bx--structured-list-row"
-                    >
-                      <div
-                        className="bx--structured-list-td"
-                      />
-                      <div
-                        className="bx--structured-list-td"
-                      >
-                        EmptyTable
-                      </div>
-                    </div>
-                    <div
-                      className="bx--structured-list-row"
-                    >
-                      <div
-                        className="bx--structured-list-td"
-                      />
-                      <div
-                        className="bx--structured-list-td"
-                      >
-                        TableSkeletonWithHeaders
                       </div>
                     </div>
                     <div

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -3,7 +3,6 @@ import VisibilitySensor from 'react-visibility-sensor';
 import { Tooltip, SkeletonText } from 'carbon-components-react';
 import styled from 'styled-components';
 import SizeMe from 'react-sizeme';
-import isNil from 'lodash/isNil';
 
 import { settings } from '../../constants/Settings';
 import {

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -78,6 +78,7 @@ export const defaultProps = {
   layout: CARD_SIZES.HORIZONTAL,
   title: undefined,
   toolbar: undefined,
+  hideHeader: false,
   timeRange: undefined,
   isLoading: false,
   isEmpty: false,
@@ -143,6 +144,7 @@ const Card = props => {
     isExpanded,
     isLazyLoading,
     error,
+    hideHeader,
     id,
     tooltip,
     timeRange,
@@ -225,7 +227,7 @@ const Card = props => {
                 }
                 className={className}
               >
-                {!isNil(title) && (
+                {!hideHeader && (
                   <CardHeader>
                     <CardTitle title={title}>
                       {title}&nbsp;

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -3,6 +3,7 @@ import VisibilitySensor from 'react-visibility-sensor';
 import { Tooltip, SkeletonText } from 'carbon-components-react';
 import styled from 'styled-components';
 import SizeMe from 'react-sizeme';
+import isNil from 'lodash/isNil';
 
 import { settings } from '../../constants/Settings';
 import {
@@ -130,28 +131,29 @@ export const defaultProps = {
 };
 
 /** Dumb component that renders the card basics */
-const Card = ({
-  size,
-  children,
-  title,
-  layout,
-  isLoading,
-  isEmpty,
-  isEditable,
-  isExpanded,
-  isLazyLoading,
-  error,
-  id,
-  tooltip,
-  timeRange,
-  onCardAction,
-  availableActions,
-  breakpoint,
-  i18n,
-  style,
-  className,
-  ...others
-}) => {
+const Card = props => {
+  const {
+    size,
+    children,
+    title,
+    layout,
+    isLoading,
+    isEmpty,
+    isEditable,
+    isExpanded,
+    isLazyLoading,
+    error,
+    id,
+    tooltip,
+    timeRange,
+    onCardAction,
+    availableActions,
+    breakpoint,
+    i18n,
+    style,
+    className,
+    ...others
+  } = props;
   const isXS = size === CARD_SIZES.XSMALL;
   const dimensions = getCardMinSize(
     breakpoint,
@@ -197,74 +199,81 @@ const Card = ({
     <VisibilitySensor partialVisibility offset={{ top: 10 }}>
       {({ isVisible }) => (
         <SizeMe.SizeMe monitorHeight>
-          {({ size: cardSize }) => (
-            <CardWrapper
-              {...others}
-              id={id}
-              dimensions={dimensions}
-              isExpanded={isExpanded}
-              cardWidthSize={cardSize.width}
-              style={
-                !isExpanded ? style : { height: 'calc(100% - 50px)', width: 'calc(100% - 50px)' }
-              }
-              className={className}
-            >
-              {title !== undefined && (
-                <CardHeader>
-                  <CardTitle title={title}>
-                    {title}&nbsp;
-                    {tooltip && (
-                      <Tooltip
-                        triggerId={`card-tooltip-trigger-${id}`}
-                        tooltipId={`card-tooltip-${id}`}
-                        triggerText=""
-                      >
-                        {tooltip}
-                      </Tooltip>
-                    )}
-                  </CardTitle>
-                  <CardToolbar
-                    width={cardSize.width}
-                    availableActions={mergedAvailableActions}
-                    i18n={strings}
-                    isEditable={isEditable}
-                    isExpanded={isExpanded}
-                    timeRange={timeRange}
-                    onCardAction={cachedOnCardAction}
-                  />
-                </CardHeader>
-              )}
-              <CardContent dimensions={dimensions}>
-                {!isVisible && isLazyLoading ? ( // if not visible don't show anything
-                  ''
-                ) : isLoading ? (
-                  <SkeletonWrapper>
-                    <OptimizedSkeletonText
-                      paragraph
-                      lineCount={
-                        size === CARD_SIZES.XSMALL || size === CARD_SIZES.XSMALLWIDE ? 2 : 3
-                      }
-                      width="100%"
-                    />
-                  </SkeletonWrapper>
-                ) : error ? (
-                  <EmptyMessageWrapper>
-                    {size === CARD_SIZES.XSMALL || size === CARD_SIZES.XSMALLWIDE
-                      ? strings.errorLoadingDataShortLabel
-                      : `${strings.errorLoadingDataLabel} ${error}`}
-                  </EmptyMessageWrapper>
-                ) : isEmpty && !isEditable ? (
-                  <EmptyMessageWrapper>
-                    {isXS ? strings.noDataShortLabel : strings.noDataLabel}
-                  </EmptyMessageWrapper>
-                ) : typeof children === 'function' ? ( // pass the measured size down to the children if it's an render function
-                  children(getChildSize(cardSize, title))
-                ) : (
-                  children
+          {({ size: cardSize }) => {
+            // support passing the card toolbar through to the custom card
+            const cardToolbar = (
+              <CardToolbar
+                width={cardSize.width}
+                availableActions={mergedAvailableActions}
+                i18n={strings}
+                isEditable={isEditable}
+                isExpanded={isExpanded}
+                timeRange={timeRange}
+                onCardAction={cachedOnCardAction}
+              />
+            );
+
+            return (
+              <CardWrapper
+                {...others}
+                id={id}
+                dimensions={dimensions}
+                isExpanded={isExpanded}
+                cardWidthSize={cardSize.width}
+                style={
+                  !isExpanded ? style : { height: 'calc(100% - 50px)', width: 'calc(100% - 50px)' }
+                }
+                className={className}
+              >
+                {!isNil(title) && (
+                  <CardHeader>
+                    <CardTitle title={title}>
+                      {title}&nbsp;
+                      {tooltip && (
+                        <Tooltip
+                          triggerId={`card-tooltip-trigger-${id}`}
+                          tooltipId={`card-tooltip-${id}`}
+                          triggerText=""
+                        >
+                          {tooltip}
+                        </Tooltip>
+                      )}
+                    </CardTitle>
+                    {cardToolbar}
+                  </CardHeader>
                 )}
-              </CardContent>
-            </CardWrapper>
-          )}
+                <CardContent dimensions={dimensions}>
+                  {!isVisible && isLazyLoading ? ( // if not visible don't show anything
+                    ''
+                  ) : isLoading ? (
+                    <SkeletonWrapper>
+                      <OptimizedSkeletonText
+                        paragraph
+                        lineCount={
+                          size === CARD_SIZES.XSMALL || size === CARD_SIZES.XSMALLWIDE ? 2 : 3
+                        }
+                        width="100%"
+                      />
+                    </SkeletonWrapper>
+                  ) : error ? (
+                    <EmptyMessageWrapper>
+                      {size === CARD_SIZES.XSMALL || size === CARD_SIZES.XSMALLWIDE
+                        ? strings.errorLoadingDataShortLabel
+                        : `${strings.errorLoadingDataLabel} ${error}`}
+                    </EmptyMessageWrapper>
+                  ) : isEmpty && !isEditable ? (
+                    <EmptyMessageWrapper>
+                      {isXS ? strings.noDataShortLabel : strings.noDataLabel}
+                    </EmptyMessageWrapper>
+                  ) : typeof children === 'function' ? ( // pass the measured size down to the children if it's an render function
+                    children(getChildSize(cardSize, title), { cardToolbar, ...props })
+                  ) : (
+                    children
+                  )}
+                </CardContent>
+              </CardWrapper>
+            );
+          }}
         </SizeMe.SizeMe>
       )}
     </VisibilitySensor>

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -5,6 +5,7 @@ import { action } from '@storybook/addon-actions';
 
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
+import Table from '../Table/Table';
 
 import Card from './Card';
 
@@ -211,17 +212,43 @@ storiesOf('Watson IoT|Card', module)
   .add(
     'implementing a custom card',
     () => {
-      const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
-      const SampleCustomCard = ({ values, isEditable, ...others }) => (
-        <Card {...others}>{!isEditable ? JSON.stringify(values) : 'Fake Sample Data'}</Card>
+      const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+      const SampleCustomCard = ({ title, isEditable, ...others }) => (
+        <Card {...others} hideHeader>
+          {!isEditable
+            ? (_$, { cardToolbar, values }) => (
+                <Table
+                  id="my table"
+                  secondaryTitle={title}
+                  columns={[
+                    {
+                      id: 'value1',
+                      name: 'String',
+                      filter: { placeholderText: 'enter a string' },
+                    },
+                    {
+                      id: 'timestamp',
+                      name: 'Date',
+                      filter: { placeholderText: 'enter a date' },
+                    },
+                  ]}
+                  data={values.map((value, index) => ({ id: `rowid-${index}`, values: value }))}
+                  view={{ toolbar: { customToolbarContent: cardToolbar } }}
+                />
+              )
+            : 'Fake Sample Data'}
+        </Card>
       );
 
       return (
         <SampleCustomCard
-          id={text('title', 'Card Title')}
+          id="mycard"
+          title={text('title', 'Card Title')}
           size={size}
           isEditable={boolean('isEditable', false)}
           values={[{ timestamp: 12341231231, value1: 'my value' }]}
+          availableActions={{ range: size !== CARD_SIZES.XSMALL, expand: true }}
+          onCardAction={action('onCardAction')}
         />
       );
     },

--- a/src/components/Card/Card.test.jsx
+++ b/src/components/Card/Card.test.jsx
@@ -30,20 +30,26 @@ describe('Card testcases', () => {
     const childRenderInTitleCard = jest.fn();
 
     mount(<Card title="My Title" size={CARD_SIZES.MEDIUM} children={childRenderInTitleCard} />);
-    expect(childRenderInTitleCard).toHaveBeenCalledWith({
-      width: 0,
-      height: -CARD_TITLE_HEIGHT,
-      position: null,
-    });
+    expect(childRenderInTitleCard).toHaveBeenCalledWith(
+      {
+        width: 0,
+        height: -CARD_TITLE_HEIGHT,
+        position: null,
+      },
+      expect.anything()
+    );
 
     const childRenderInNoTitleCard = jest.fn();
 
     mount(<Card size={CARD_SIZES.MEDIUM} children={childRenderInNoTitleCard} />);
-    expect(childRenderInNoTitleCard).toHaveBeenCalledWith({
-      width: 0,
-      height: 0,
-      position: null,
-    });
+    expect(childRenderInNoTitleCard).toHaveBeenCalledWith(
+      {
+        width: 0,
+        height: 0,
+        position: null,
+      },
+      expect.anything()
+    );
   });
 
   test('render icons', () => {

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -608,13 +608,240 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
         }
       >
         <div
-          className="Card__CardWrapper-v5r71h-0 fbzdtE"
-          id="Card Title"
+          className="Card__CardWrapper-v5r71h-0 cynIXT"
+          id="mycard"
+          values={
+            Array [
+              Object {
+                "timestamp": 12341231231,
+                "value1": "my value",
+              },
+            ]
+          }
         >
           <div
-            className="Card__CardContent-v5r71h-1 hoCWQe"
+            className="Card__CardContent-v5r71h-1 hDVRgE"
           >
-            [{"timestamp":12341231231,"value1":"my value"}]
+            <div
+              className="Table__StyledTableContainer-sc-1kalfns-0 buETAI bx--data-table-container"
+            >
+              <section
+                aria-label="data table toolbar"
+                className="bx--table-toolbar"
+              >
+                <div
+                  className="bx--batch-actions TableToolbar__StyledTableBatchActions-sc-17lb3av-3 gnkbSD"
+                >
+                  <div
+                    className="bx--action-list"
+                  >
+                    <button
+                      className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                  <div
+                    className="bx--batch-summary"
+                  >
+                    <p
+                      className="bx--batch-summary__para"
+                    >
+                      <span>
+                        0 item selected
+                      </span>
+                    </p>
+                  </div>
+                </div>
+                <label
+                  className="table-toolbar-secondary-title"
+                >
+                  Card Title
+                </label>
+                <div
+                  className="bx--toolbar-content TableToolbar__StyledTableToolbarContent-sc-17lb3av-2 ksiTUe"
+                >
+                  <div
+                    className="card--toolbar"
+                  >
+                    <div
+                      className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
+                    >
+                      <button
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        aria-label="Menu"
+                        className="card--toolbar-action bx--overflow-menu"
+                        onClick={[Function]}
+                        onClose={[Function]}
+                        onKeyDown={[Function]}
+                        open={false}
+                        tabIndex={0}
+                        title="Open and close list of options"
+                      >
+                        <svg
+                          aria-label="open and close list of options"
+                          className="bx--overflow-menu__icon"
+                          focusable="false"
+                          height={20}
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                          />
+                          <path
+                            d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                          />
+                          <path
+                            d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                          />
+                          <title>
+                            open and close list of options
+                          </title>
+                        </svg>
+                      </button>
+                    </div>
+                    <button
+                      className="card--toolbar-action CardToolbar__ToolbarSVGWrapper-sc-1ekh8ti-0 eapGUf"
+                      onClick={[Function]}
+                    >
+                      <svg
+                        description="Expand to fullscreen"
+                        focusable="false"
+                        height={20}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        title="Expand to fullscreen"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                        />
+                        <path
+                          d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </section>
+              <div
+                className="addons-iot-table-container"
+              >
+                <table
+                  className="bx--data-table bx--data-table--no-border"
+                  title={null}
+                >
+                  <thead
+                    className="TableHead__StyledCarbonTableHead-sc-1fviaow-1 jDaLBC"
+                  >
+                    <tr>
+                      <th
+                        align="start"
+                        className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-2 dSXhWB"
+                        data-column="value1"
+                        id="column-value1"
+                        scope="col"
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="String"
+                          >
+                            String
+                          </span>
+                        </span>
+                      </th>
+                      <th
+                        align="start"
+                        className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-2 dSXhWB"
+                        data-column="timestamp"
+                        id="column-timestamp"
+                        scope="col"
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Date"
+                          >
+                            Date
+                          </span>
+                        </span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    aria-live="polite"
+                  >
+                    <tr
+                      className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
+                      onClick={[Function]}
+                    >
+                      <td
+                        align="start"
+                        className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                        data-column="value1"
+                        data-offset={0}
+                        id="cell-my table-rowid-0-value1"
+                        offset={0}
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                        >
+                          <span
+                            title="my value"
+                          >
+                            my value
+                          </span>
+                        </span>
+                      </td>
+                      <td
+                        align="start"
+                        className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                        data-column="timestamp"
+                        data-offset={0}
+                        id="cell-my table-rowid-0-timestamp"
+                        offset={0}
+                      >
+                        <span
+                          className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                        >
+                          <span
+                            title={12341231231}
+                          >
+                            12341231231
+                          </span>
+                        </span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import merge from 'lodash/merge';
 import isEmpty from 'lodash/isEmpty';
+import isNil from 'lodash/isNil';
 import omit from 'lodash/omit';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 
@@ -180,7 +181,9 @@ const CardRenderer = React.memo(
     ) : type === CARD_TYPES.LIST ? (
       <ListCard {...commonCardProps} data={card.content.data} loadData={card.content.loadData} />
     ) : type === CARD_TYPES.CUSTOM ? (
-      <Card {...commonCardProps}>{card.content}</Card>
+      <Card hideHeader={isNil(card.title)} {...commonCardProps}>
+        {card.content}
+      </Card>
     ) : null;
   }
 );

--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -109,7 +109,8 @@ const CardRenderer = React.memo(
           expand:
             type === CARD_TYPES.IMAGE ||
             type === CARD_TYPES.TIMESERIES ||
-            type === CARD_TYPES.TABLE, // image and line chart cards should have expand
+            type === CARD_TYPES.TABLE ||
+            availableActions?.expand, // image and line chart cards should have expand
         }),
       [availableActions, dataSource, type]
     );

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -32,7 +32,7 @@ const propTypes = {
   ),
   cards: PropTypes.arrayOf(
     PropTypes.shape({
-      content: PropTypes.object,
+      content: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
       values: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
       /** is the card actively loading, it will override the dashboard loading state if true */
       isLoading: PropTypes.bool,

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -709,6 +709,7 @@ const TableCard = ({
       isEditable={isEditable}
       isExpanded={isExpanded}
       i18n={i18n}
+      hideHeader
       {...others}
     >
       {({ height }) => {

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -229,6 +229,8 @@ export const CardPropTypes = {
   isEditable: PropTypes.bool,
   /** goes full screen if expanded */
   isExpanded: PropTypes.bool,
+  /** should hide the header */
+  hideHeader: PropTypes.bool,
   size: PropTypes.oneOf(Object.values(CARD_SIZES)),
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
   breakpoint: PropTypes.oneOf(Object.values(DASHBOARD_SIZES)),


### PR DESCRIPTION
Closes #

**Summary**

- Need to be able to receive the full list of props downstream in custom cards

**Change List (commits, features, bugs, etc)**

- feat(Card): pregenerate the card toolbar so it can be passed downstream to custom card components
- feat(Card): pass the main props of the card and the generated toolbar downstream to the custom card component
- feat(Card): add hideHeader prop instead of just relying on the title of the card to hide the header
- fix(CardRenderer): allow custom cards to show an Expand button if they pass it

**Acceptance Test (how to verify the PR)**

- Verify that no major changes occurred to the existing Dashboard and Card stories except for the Custom Card story which I extended to be more like my usage inside Monitor
