### PR TITLE
fix(floating-menu): add floating menu container to Storybook

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -483,7 +483,10 @@ storiesOf('Watson IoT|Table', module)
         }}
       />
     </FullWidthWrapper>
-  ))
+  ),
+  {
+    centered: { disable: true },
+  })
   .add(
     'Stateful Example with every third row unselectable',
     () => (


### PR DESCRIPTION
Closes #576

**Summary**

To get the floating menu to scroll together with the page, it should be attached to its parent element instead of `<body>` itself. To do that, you just need to add `data-floating-menu-container` to the element you want the menu to attach to (in this case the storybook container)

**Acceptance Test (how to verify the PR)**

Verify it on ?path=/story/watson-iot-table--stateful-example-with-secondary-title

Please not that our storybook has a wrapping element with the styling `position: fixed` wrapping the stories, so the menu offset calculation fails sometimes. It's not a problem in normal apps.