### PR TITLE
[PageWizard] Add horizontal layout

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -2984,18 +2984,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                       <div
                         className="bx--structured-list-td"
                       >
-                        PageWizardStepTitle
-                      </div>
-                    </div>
-                    <div
-                      className="bx--structured-list-row"
-                    >
-                      <div
-                        className="bx--structured-list-td"
-                      />
-                      <div
-                        className="bx--structured-list-td"
-                      >
                         PageWizardStepDescription
                       </div>
                     </div>
@@ -3009,6 +2997,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Getting Started|
                         className="bx--structured-list-td"
                       >
                         PageWizardStepExtraContent
+                      </div>
+                    </div>
+                    <div
+                      className="bx--structured-list-row"
+                    >
+                      <div
+                        className="bx--structured-list-td"
+                      />
+                      <div
+                        className="bx--structured-list-td"
+                      >
+                        PageWizardStepTitle
                       </div>
                     </div>
                     <div

--- a/src/components/PageWizard/PageWizard.jsx
+++ b/src/components/PageWizard/PageWizard.jsx
@@ -1,126 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { InlineNotification, ProgressIndicator, ProgressStep } from 'carbon-components-react';
+import { ProgressIndicator, ProgressStep } from 'carbon-components-react';
 
-import Button from '../Button/Button';
+import { settings } from '../../constants/Settings';
 
-const childrenPropType = PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]);
+const { iotPrefix, prefix: carbonPrefix } = settings;
 
-/* TODO: move these components to separate files */
-const PageWizardStep = ({
-  children,
-  onValidate,
-  error,
-  onClearError,
-  i18n,
-  hasStickyFooter,
-  onClose,
-  hasPrev,
-  hasNext,
-  onNext,
-  nextDisabled,
-  onBack,
-  sendingData,
-  onSubmit,
-}) => (
-  <div className="page-wizard--step">
-    {error ? (
-      <InlineNotification
-        lowContrast
-        title={error}
-        subtitle=""
-        kind="error"
-        onCloseButtonClick={onClearError}
-        iconDescription={i18n.close}
-      />
-    ) : null}
-    {children}
-    <div
-      className={
-        hasStickyFooter ? 'page-wizard--content--actions--sticky' : 'page-wizard--content--actions'
-      }
-    >
-      {!hasPrev ? (
-        <Button onClick={onClose} kind="secondary">
-          {i18n.cancel}
-        </Button>
-      ) : null}
-      {hasPrev ? (
-        <Button onClick={onBack} kind="secondary">
-          {i18n.back}
-        </Button>
-      ) : null}
-      {hasNext ? (
-        <Button onClick={() => onValidate() && onNext()} disabled={nextDisabled}>
-          {i18n.next}
-        </Button>
-      ) : (
-        <Button
-          onClick={() => onValidate() && onSubmit()}
-          disabled={nextDisabled}
-          loading={sendingData}
-        >
-          {i18n.submit}
-        </Button>
-      )}
-    </div>
-  </div>
-);
-PageWizardStep.propTypes = {
-  id: PropTypes.string.isRequired, // eslint-disable-line
-  onValidate: PropTypes.func, // eslint-disable-line
-  children: childrenPropType,
-  /** optional error to show for this step */
-  error: PropTypes.node,
-  /** optional callback to clear the error */
-  onClearError: PropTypes.func,
-  /** Internationalized strings */
-  i18n: PropTypes.objectOf(PropTypes.string).isRequired,
-  hasStickyFooter: PropTypes.bool,
-  onClose: PropTypes.func.isRequired,
-  hasPrev: PropTypes.bool.isRequired,
-  hasNext: PropTypes.bool.isRequired,
-  onNext: PropTypes.func.isRequired,
-  nextDisabled: PropTypes.bool,
-  onBack: PropTypes.func.isRequired,
-  sendingData: PropTypes.bool,
-  onSubmit: PropTypes.func.isRequired,
-};
-PageWizardStep.defaultProps = {
-  children: [],
-  error: null,
-  onClearError: null,
-  onValidate: () => true,
-  hasStickyFooter: false,
-  nextDisabled: false,
-  sendingData: false,
-};
+export const childrenPropType = PropTypes.oneOfType([
+  PropTypes.arrayOf(PropTypes.node),
+  PropTypes.node,
+]);
 
-const PageWizardStepTitle = ({ children }) => (
-  <div className="page-wizard--step--title">{children}</div>
-);
-PageWizardStepTitle.propTypes = { children: childrenPropType };
-PageWizardStepTitle.defaultProps = { children: [] };
-
-const PageWizardStepDescription = ({ children }) => (
-  <div className="page-wizard--step--description">{children}</div>
-);
-PageWizardStepDescription.propTypes = { children: childrenPropType };
-PageWizardStepDescription.defaultProps = { children: [] };
-
-const PageWizardStepContent = ({ children }) => (
-  <div className="page-wizard--step--content">{children}</div>
-);
-PageWizardStepContent.propTypes = { children: childrenPropType };
-PageWizardStepContent.defaultProps = { children: [] };
-
-const PageWizardStepExtraContent = ({ children }) => (
-  <div className="page-wizard--step--extra-content">{children}</div>
-);
-PageWizardStepExtraContent.propTypes = { children: childrenPropType };
-PageWizardStepExtraContent.defaultProps = { children: [] };
-
-export const propTypes = {
+export const PageWizardPropTypes = {
   children: childrenPropType,
   /** Id of current step */
   currentStepId: PropTypes.string,
@@ -144,21 +35,20 @@ export const propTypes = {
     /** label to show on the close notification button */
     close: PropTypes.string,
   }),
-  /** label to show on the cancel button */
   /** function to go to step when click ProgressIndicator step. */
   setStep: PropTypes.func,
   /** next button disabled */
   nextDisabled: PropTypes.bool,
   /** show progress indicator on finish button */
   sendingData: PropTypes.bool,
-
   /** Form Error Details */
   error: PropTypes.string,
   /** required callback to clear the error */
   onClearError: PropTypes.func.isRequired,
-
   /** use sticky footer to show buttons at the bottom */
   hasStickyFooter: PropTypes.bool,
+  /** Displays the progress indicator vertically */
+  isProgressIndicatorVertical: PropTypes.bool,
 };
 
 export const defaultProps = {
@@ -180,6 +70,7 @@ export const defaultProps = {
   sendingData: false,
   error: null,
   hasStickyFooter: false,
+  isProgressIndicatorVertical: true,
 };
 
 const PageWizard = ({
@@ -197,6 +88,7 @@ const PageWizard = ({
   error,
   hasStickyFooter,
   onClearError,
+  isProgressIndicatorVertical,
 }) => {
   const children = ch.length ? ch : [ch];
   const steps = React.Children.map(children, step => step.props);
@@ -221,12 +113,22 @@ const PageWizard = ({
 
   return (
     <div
-      className={['page-wizard', className, hasStickyFooter ? 'page-wizard__sticky' : ''].join(' ')}
+      className={[
+        isProgressIndicatorVertical ? `${iotPrefix}--page-wizard` : '',
+        className,
+        hasStickyFooter ? `${iotPrefix}--page-wizard__sticky` : '',
+      ].join(' ')}
     >
       {steps.length > 1 ? (
-        <div className="page-wizard--progress">
+        <div
+          className={
+            isProgressIndicatorVertical
+              ? `${iotPrefix}--page-wizard--progress--vertical`
+              : `${iotPrefix}--page-wizard--progress--horizontal`
+          }
+        >
           <ProgressIndicator
-            className="bx--progress--vertical"
+            className={isProgressIndicatorVertical ? `${carbonPrefix}--progress--vertical` : null}
             currentIndex={currentStepIdx}
             onChange={idx => setStep(steps[idx].id)}
           >
@@ -236,18 +138,12 @@ const PageWizard = ({
           </ProgressIndicator>
         </div>
       ) : null}
-      <div className="page-wizard--content">{currentStepToRender}</div>
+      <div className={`${iotPrefix}--page-wizard--content`}>{currentStepToRender}</div>
     </div>
   );
 };
 
-PageWizard.propTypes = propTypes;
+PageWizard.propTypes = PageWizardPropTypes;
 PageWizard.defaultProps = defaultProps;
-export {
-  PageWizard,
-  PageWizardStep,
-  PageWizardStepTitle,
-  PageWizardStepDescription,
-  PageWizardStepContent,
-  PageWizardStepExtraContent,
-};
+
+export default PageWizard;

--- a/src/components/PageWizard/PageWizard.jsx
+++ b/src/components/PageWizard/PageWizard.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ProgressIndicator, ProgressStep } from 'carbon-components-react';
+import classNames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 
@@ -16,9 +17,9 @@ export const PageWizardPropTypes = {
   /** Id of current step */
   currentStepId: PropTypes.string,
   /** action when click next button called with no param */
-  onNext: PropTypes.func.isRequired,
+  onNext: PropTypes.func,
   /** action when click back button called with no param */
-  onBack: PropTypes.func.isRequired,
+  onBack: PropTypes.func,
   /** action if the inline wizard is closed or canceled */
   onClose: PropTypes.func.isRequired,
   /** action triggered if the inline wizard has submitted final step */
@@ -36,7 +37,7 @@ export const PageWizardPropTypes = {
     close: PropTypes.string,
   }),
   /** function to go to step when click ProgressIndicator step. */
-  setStep: PropTypes.func.isRequired,
+  setStep: PropTypes.func,
   /** next button disabled */
   nextDisabled: PropTypes.bool,
   /** show progress indicator on finish button */
@@ -66,6 +67,9 @@ export const defaultProps = {
   error: null,
   hasStickyFooter: false,
   isProgressIndicatorVertical: true,
+  onNext: null,
+  onBack: null,
+  setStep: null,
 };
 
 const PageWizard = ({
@@ -108,11 +112,11 @@ const PageWizard = ({
 
   return (
     <div
-      className={[
-        isProgressIndicatorVertical ? `${iotPrefix}--page-wizard` : '',
+      className={classNames(
+        isProgressIndicatorVertical ? `${iotPrefix}--page-wizard` : null,
         className,
-        hasStickyFooter ? `${iotPrefix}--page-wizard__sticky` : '',
-      ].join(' ')}
+        hasStickyFooter ? `${iotPrefix}--page-wizard__sticky` : null
+      )}
     >
       {steps.length > 1 ? (
         <div

--- a/src/components/PageWizard/PageWizard.jsx
+++ b/src/components/PageWizard/PageWizard.jsx
@@ -16,13 +16,13 @@ export const PageWizardPropTypes = {
   /** Id of current step */
   currentStepId: PropTypes.string,
   /** action when click next button called with no param */
-  onNext: PropTypes.func,
+  onNext: PropTypes.func.isRequired,
   /** action when click back button called with no param */
-  onBack: PropTypes.func,
+  onBack: PropTypes.func.isRequired,
   /** action if the inline wizard is closed or canceled */
-  onClose: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
   /** action triggered if the inline wizard has submitted final step */
-  onSubmit: PropTypes.func,
+  onSubmit: PropTypes.func.isRequired,
   i18n: PropTypes.shape({
     /** label to show on the cancel button */
     cancel: PropTypes.string,
@@ -36,7 +36,7 @@ export const PageWizardPropTypes = {
     close: PropTypes.string,
   }),
   /** function to go to step when click ProgressIndicator step. */
-  setStep: PropTypes.func,
+  setStep: PropTypes.func.isRequired,
   /** next button disabled */
   nextDisabled: PropTypes.bool,
   /** show progress indicator on finish button */
@@ -55,11 +55,6 @@ export const defaultProps = {
   children: [],
   nextDisabled: false,
   currentStepId: null,
-  onNext: () => {},
-  onBack: () => {},
-  setStep: () => {},
-  onClose: () => {},
-  onSubmit: () => {},
   i18n: {
     back: 'Back',
     next: 'Next',
@@ -132,8 +127,8 @@ const PageWizard = ({
             currentIndex={currentStepIdx}
             onChange={idx => setStep(steps[idx].id)}
           >
-            {steps.map((i, idx) => (
-              <ProgressStep key={idx} description={i.description} label={i.label} />
+            {steps.map((step, idx) => (
+              <ProgressStep key={idx} description={step.description} label={step.label} />
             ))}
           </ProgressIndicator>
         </div>

--- a/src/components/PageWizard/PageWizard.story.jsx
+++ b/src/components/PageWizard/PageWizard.story.jsx
@@ -7,18 +7,23 @@ import { Form, FormGroup, FormItem, Link, TextInput } from 'carbon-components-re
 
 import PageTitleBar from '../PageTitleBar/PageTitleBar';
 
-import {
-  PageWizard,
-  PageWizardStep,
-  PageWizardStepContent,
-  PageWizardStepTitle,
-  PageWizardStepDescription,
-  PageWizardStepExtraContent,
-} from './PageWizard';
+import PageWizard from './PageWizard';
+import PageWizardStep from './PageWizardStep/PageWizardStep';
+import PageWizardStepContent from './PageWizardStep/PageWizardStepContent';
+import PageWizardStepDescription from './PageWizardStep/PageWizardStepDescription';
+import PageWizardStepTitle from './PageWizardStep/PageWizardStepTitle';
+import PageWizardStepExtraContent from './PageWizardStep/PageWizardStepExtraContent';
 import StatefulPageWizard from './StatefulPageWizard';
 
 export const content = [
-  <PageWizardStep id="step1" label="Step 1">
+  <PageWizardStep
+    id="step1"
+    label="Step 1"
+    onClose={() => {}}
+    onSubmit={() => {}}
+    onNext={() => {}}
+    onBack={() => {}}
+  >
     <PageWizardStepTitle>Step 1: Define the data</PageWizardStepTitle>
     <PageWizardStepDescription>
       You can create summaries lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros
@@ -42,7 +47,14 @@ export const content = [
       </p>
     </PageWizardStepExtraContent>
   </PageWizardStep>,
-  <PageWizardStep id="step2" label="Step 2">
+  <PageWizardStep
+    id="step2"
+    label="Step 2"
+    onClose={() => {}}
+    onSubmit={() => {}}
+    onNext={() => {}}
+    onBack={() => {}}
+  >
     <PageWizardStepTitle>Step 2: Pick the contents</PageWizardStepTitle>
     <PageWizardStepDescription>
       You can add content lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros
@@ -74,7 +86,14 @@ export const content = [
       </p>
     </PageWizardStepExtraContent>
   </PageWizardStep>,
-  <PageWizardStep id="step3" label="Step 3">
+  <PageWizardStep
+    id="step3"
+    label="Step 3"
+    onClose={() => {}}
+    onSubmit={() => {}}
+    onNext={() => {}}
+    onBack={() => {}}
+  >
     <PageWizardStepTitle>Step 3: Define your dashboard</PageWizardStepTitle>
     <PageWizardStepDescription>
       Dashboards are useful lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros
@@ -175,16 +194,32 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
         content={
           <PageWizard
             currentStepId="step1"
-            onClose={action('closed')}
-            onSubmit={action('submit')}
-            onNext={action('next')}
-            onBack={action('back')}
-            setStep={action('step clicked')}
+            onClose={action('closed', () => {})}
+            onSubmit={action('submit', () => {})}
+            onNext={action('next', () => {})}
+            onBack={action('back', () => {})}
+            setStep={action('step clicked', () => {})}
+            isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
           >
             {content}
           </PageWizard>
         }
       />
+    </div>
+  ))
+  .add('horizontal progress indicator', () => (
+    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
+      <PageWizard
+        currentStepId="step1"
+        onClose={action('closed', () => {})}
+        onSubmit={action('submit', () => {})}
+        onNext={action('next', () => {})}
+        onBack={action('back', () => {})}
+        setStep={action('step clicked', () => {})}
+        isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
+      >
+        {content}
+      </PageWizard>
     </div>
   ))
   .add('only one step, in PageTitleBar', () => (
@@ -200,11 +235,13 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
         content={
           <PageWizard
             currentStepId="step1"
-            onClose={action('closed')}
-            onSubmit={action('submit')}
-            onNext={action('next')}
-            onBack={action('back')}
-            setStep={action('step clicked')}
+            onClose={action('closed', () => {})}
+            onSubmit={action('submit', () => {})}
+            onNext={action('next', () => {})}
+            onBack={action('back', () => {})}
+            setStep={action('step clicked', () => {})}
+            sendingData={boolean('sendingData', false)}
+            hasStickyFooter={boolean('hasStickyFooter', false)}
           >
             {[content[0]]}
           </PageWizard>
@@ -223,7 +260,10 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
           <Link to="www.ibm.com">Something Else</Link>,
         ]}
         tabs={
-          <StatefulPageWizard hasStickyFooter={boolean('hasStickyFooter', true)}>
+          <StatefulPageWizard
+            hasStickyFooter={boolean('hasStickyFooter', true)}
+            isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
+          >
             <StepValidation id="step1" label="Step with validation" />
             {content[1]}
           </StatefulPageWizard>
@@ -231,57 +271,5 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
       />
     </div>
   ))
-  .add('With Sticky Footer: only one step, in PageTitleBar', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
-      <PageTitleBar
-        title="A cool PageWizard!"
-        description="The description from the PageTitleBar"
-        breadcrumb={[
-          <Link to="www.ibm.com">Home</Link>,
-          <Link to="www.ibm.com">Something</Link>,
-          <Link to="www.ibm.com">Something Else</Link>,
-        ]}
-        tabs={
-          <PageWizard
-            currentStepId="step1"
-            onClose={action('closed')}
-            onSubmit={action('submit')}
-            onNext={action('next')}
-            onBack={action('back')}
-            setStep={action('step clicked')}
-            hasStickyFooter={boolean('hasStickyFooter', true)}
-          >
-            {[content[0]]}
-          </PageWizard>
-        }
-      />
-    </div>
-  ))
-  .add('One step page with loading button in sticky footer, in PageTitleBar', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
-      <PageTitleBar
-        title="A cool PageWizard!"
-        description="The description from the PageTitleBar"
-        breadcrumb={[
-          <Link to="www.ibm.com">Home</Link>,
-          <Link to="www.ibm.com">Something</Link>,
-          <Link to="www.ibm.com">Something Else</Link>,
-        ]}
-        content={
-          <PageWizard
-            currentStepId="step1"
-            onClose={action('closed')}
-            onSubmit={action('submit')}
-            onNext={action('next')}
-            onBack={action('back')}
-            setStep={action('step clicked')}
-            sendingData={boolean('sendingData', true)}
-            hasStickyFooter={boolean('hasStickyFooter', true)}
-          >
-            {[content[0]]}
-          </PageWizard>
-        }
-      />
-    </div>
-  ))
+
   .add('w/ i18n', () => <div>TODO</div>);

--- a/src/components/PageWizard/PageWizard.story.jsx
+++ b/src/components/PageWizard/PageWizard.story.jsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { Form, FormGroup, FormItem, Link, TextInput } from 'carbon-components-react';
 
 import PageTitleBar from '../PageTitleBar/PageTitleBar';
@@ -159,9 +159,9 @@ export const StepValidation = ({ ...props }) => {
   );
 };
 
-storiesOf('Watson IoT Experimental|PageWizard', module)
+storiesOf('Watson IoT|PageWizard', module)
   .add('stateful example', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, padding: '2rem' }}>
+    <div>
       <StatefulPageWizard
         onClearError={() => {}}
         onClose={() => {}}
@@ -175,7 +175,7 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
     </div>
   ))
   .add('stateful example w/ validation in PageTitleBar', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
+    <div>
       <PageTitleBar
         title="A cool PageWizard!"
         description="The description from the PageTitleBar"
@@ -201,7 +201,7 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
     </div>
   ))
   .add('wrapped in PageTitleBar', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
+    <div>
       <PageTitleBar
         title="A cool PageWizard!"
         description="The description from the PageTitleBar"
@@ -227,8 +227,8 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
       />
     </div>
   ))
-  .add('horizontal progress indicator', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
+  .add('With Horizontal ProgressIndicator', () => (
+    <div>
       <PageWizard
         currentStepId="step1"
         onClose={action('closed', () => {})}
@@ -244,7 +244,7 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
     </div>
   ))
   .add('only one step, in PageTitleBar', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
+    <div>
       <PageTitleBar
         title="A cool PageWizard!"
         description="The description from the PageTitleBar"
@@ -272,7 +272,7 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
     </div>
   ))
   .add('With Sticky Footer: stateful example w/ validation in PageTitleBar', () => (
-    <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0 }}>
+    <div>
       <PageTitleBar
         title="A cool PageWizard!"
         description="The description from the PageTitleBar"
@@ -300,4 +300,27 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
     </div>
   ))
 
-  .add('w/ i18n', () => <div>TODO</div>);
+  .add('w/ i18n', () => (
+    <div>
+      <PageWizard
+        currentStepId="step1"
+        onClose={action('closed', () => {})}
+        onSubmit={action('submit', () => {})}
+        onNext={action('next', () => {})}
+        onBack={action('back', () => {})}
+        onClearError={() => {}}
+        setStep={action('step clicked', () => {})}
+        sendingData={boolean('sendingData', false)}
+        hasStickyFooter={boolean('hasStickyFooter', false)}
+        i18={{
+          close: text('Close label', 'Close'),
+          cancel: text('Cancel label', 'Cancel'),
+          back: text('Back label', 'Back'),
+          next: text('Next label', 'Next'),
+          submit: text('Submit label', 'Submit'),
+        }}
+      >
+        {content}
+      </PageWizard>
+    </div>
+  ));

--- a/src/components/PageWizard/PageWizard.story.jsx
+++ b/src/components/PageWizard/PageWizard.story.jsx
@@ -19,6 +19,7 @@ export const content = [
   <PageWizardStep
     id="step1"
     label="Step 1"
+    key="step1"
     onClose={() => {}}
     onSubmit={() => {}}
     onNext={() => {}}
@@ -49,6 +50,7 @@ export const content = [
   </PageWizardStep>,
   <PageWizardStep
     id="step2"
+    key="step2"
     label="Step 2"
     onClose={() => {}}
     onSubmit={() => {}}
@@ -88,6 +90,7 @@ export const content = [
   </PageWizardStep>,
   <PageWizardStep
     id="step3"
+    key="step3"
     label="Step 3"
     onClose={() => {}}
     onSubmit={() => {}}
@@ -159,7 +162,16 @@ export const StepValidation = ({ ...props }) => {
 storiesOf('Watson IoT Experimental|PageWizard', module)
   .add('stateful example', () => (
     <div style={{ position: 'fixed', left: 0, right: 0, top: 0, bottom: 0, padding: '2rem' }}>
-      <StatefulPageWizard>{content}</StatefulPageWizard>
+      <StatefulPageWizard
+        onClearError={() => {}}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onNext={() => {}}
+        onBack={() => {}}
+        setStep={() => {}}
+      >
+        {content}
+      </StatefulPageWizard>
     </div>
   ))
   .add('stateful example w/ validation in PageTitleBar', () => (
@@ -173,7 +185,14 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
           <Link to="www.ibm.com">Something Else</Link>,
         ]}
         content={
-          <StatefulPageWizard>
+          <StatefulPageWizard
+            onClearError={() => {}}
+            onClose={() => {}}
+            onSubmit={() => {}}
+            onNext={() => {}}
+            onBack={() => {}}
+            setStep={() => {}}
+          >
             <StepValidation id="step1" label="Step with validation" />
             {content[1]}
           </StatefulPageWizard>
@@ -196,6 +215,7 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
             currentStepId="step1"
             onClose={action('closed', () => {})}
             onSubmit={action('submit', () => {})}
+            onClearError={action('Clear error', () => {})}
             onNext={action('next', () => {})}
             onBack={action('back', () => {})}
             setStep={action('step clicked', () => {})}
@@ -216,6 +236,7 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
         onNext={action('next', () => {})}
         onBack={action('back', () => {})}
         setStep={action('step clicked', () => {})}
+        onClearError={action('Clear error', () => {})}
         isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', false)}
       >
         {content}
@@ -239,6 +260,7 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
             onSubmit={action('submit', () => {})}
             onNext={action('next', () => {})}
             onBack={action('back', () => {})}
+            onClearError={() => {}}
             setStep={action('step clicked', () => {})}
             sendingData={boolean('sendingData', false)}
             hasStickyFooter={boolean('hasStickyFooter', false)}
@@ -259,10 +281,16 @@ storiesOf('Watson IoT Experimental|PageWizard', module)
           <Link to="www.ibm.com">Something</Link>,
           <Link to="www.ibm.com">Something Else</Link>,
         ]}
-        tabs={
+        content={
           <StatefulPageWizard
             hasStickyFooter={boolean('hasStickyFooter', true)}
             isProgressIndicatorVertical={boolean('Toggle Progress Indicator Alignment', true)}
+            onClearError={() => {}}
+            onClose={() => {}}
+            onSubmit={() => {}}
+            onNext={() => {}}
+            onBack={() => {}}
+            setStep={() => {}}
           >
             <StepValidation id="step1" label="Step with validation" />
             {content[1]}

--- a/src/components/PageWizard/PageWizard.test.jsx
+++ b/src/components/PageWizard/PageWizard.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { render, fireEvent } from '@testing-library/react';
+import { ProgressIndicator } from 'carbon-components-react';
 
 import PageWizard from './PageWizard';
 import { content, StepValidation } from './PageWizard.story';
@@ -26,10 +27,12 @@ describe('PageWizard tests', () => {
     expect(mocks.onClearError).toHaveBeenCalledTimes(1);
     expect(queryByText('My Custom Error')).toBeNull();
   });
+
   test('currentStepId prop', () => {
     const wrapper = shallow(<PageWizard currentStepId="step1">{content}</PageWizard>);
     expect(wrapper.find('PageWizardStep').prop('id')).toEqual('step1');
   });
+
   test('button events during first step (no validation)', () => {
     const mocks = {
       onNext: jest.fn(),
@@ -101,7 +104,7 @@ describe('PageWizard tests', () => {
       cancel: 'Cancel',
     };
     const { getByTestId, getByText } = render(
-      <PageWizard currentStepId="step1" {...mocks} i18n={i18n}>
+      <PageWizard currentStepId="step1" {...mocks} i18n={i18n} isProgressIndicatorVertical={false}>
         <StepValidation id="step1" label="Step with validation" />
         {content[1]}
         {content[2]}
@@ -116,5 +119,10 @@ describe('PageWizard tests', () => {
     fireEvent.change(getByTestId('last-name'), { target: { value: 'Last Name' } });
     fireEvent.click(getByText(i18n.next));
     expect(mocks.onNext).toHaveBeenCalledTimes(1);
+  });
+
+  test('progress indicator should not render if there is only 1 step', () => {
+    const wrapper = shallow(<PageWizard currentStepId="step1">{content[0]}</PageWizard>);
+    expect(wrapper.find(ProgressIndicator)).toHaveLength(0);
   });
 });

--- a/src/components/PageWizard/PageWizard.test.jsx
+++ b/src/components/PageWizard/PageWizard.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { render, fireEvent } from '@testing-library/react';
 
-import { PageWizard } from './PageWizard';
+import PageWizard from './PageWizard';
 import { content, StepValidation } from './PageWizard.story';
 
 describe('PageWizard tests', () => {

--- a/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
+++ b/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
@@ -30,11 +30,11 @@ const PageWizardStepPropTypes = {
   /** Determines if Next or Submit button is rendered */
   hasNext: PropTypes.bool,
   /** Callback function when Next button is clicked */
-  onNext: PropTypes.func.isRequired,
+  onNext: PropTypes.func,
   /** Optionally determines if Next button is disabled */
   nextDisabled: PropTypes.bool,
   /** Callback function when Previous button is clicked */
-  onBack: PropTypes.func.isRequired,
+  onBack: PropTypes.func,
   /** Renders a loading icon in the Next button */
   sendingData: PropTypes.bool,
   /** Callback function when Submit button is clicked */
@@ -58,6 +58,8 @@ const PageWizardStepDefaultProps = {
   },
   hasPrev: false,
   hasNext: false,
+  onNext: null,
+  onBack: null,
 };
 
 const PageWizardStep = ({
@@ -107,7 +109,14 @@ const PageWizardStep = ({
         </Button>
       ) : null}
       {hasNext ? (
-        <Button onClick={() => onValidate() && onNext()} disabled={nextDisabled}>
+        <Button
+          onClick={() => {
+            if (onValidate()) {
+              if (onNext) onNext();
+            }
+          }}
+          disabled={nextDisabled}
+        >
           {i18n.next}
         </Button>
       ) : (

--- a/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
+++ b/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { InlineNotification } from 'carbon-components-react';
+
+import { settings } from '../../../constants/Settings';
+import { childrenPropType } from '../PageWizard';
+import Button from '../../Button/Button';
+
+const { iotPrefix } = settings;
+
+const PageWizardStepPropTypes = {
+  /** Step identifier for controlling which step is active */
+  id: PropTypes.string.isRequired,
+  /** Optional callback function for validation */
+  onValidate: PropTypes.func,
+  /** Children nodes */
+  children: childrenPropType,
+  /** optional error to show for this step */
+  error: PropTypes.node,
+  /** optional callback to clear the error */
+  onClearError: PropTypes.func,
+  /** Internationalized strings */
+  i18n: PropTypes.objectOf(PropTypes.string),
+  /** Optional sticky footer */
+  hasStickyFooter: PropTypes.bool,
+  /** Callback function to close the wizard */
+  onClose: PropTypes.func.isRequired,
+  /** Determines if Cancel or Previous button is rendered */
+  hasPrev: PropTypes.bool,
+  /** Determines if Next or Submit button is rendered */
+  hasNext: PropTypes.bool,
+  /** Callback function when Next button is clicked */
+  onNext: PropTypes.func.isRequired,
+  /** Optionally determines if Next button is disabled */
+  nextDisabled: PropTypes.bool,
+  /** Callback function when Previous button is clicked */
+  onBack: PropTypes.func.isRequired,
+  /** Renders a loading icon in the Next button */
+  sendingData: PropTypes.bool,
+  /** Callback function when Submit button is clicked */
+  onSubmit: PropTypes.func.isRequired,
+};
+
+const PageWizardStepDefaultProps = {
+  children: [],
+  error: null,
+  onClearError: null,
+  onValidate: () => true,
+  hasStickyFooter: false,
+  nextDisabled: false,
+  sendingData: false,
+  i18n: {
+    close: 'Close',
+    cancel: 'Cancel',
+    back: 'Back',
+    next: 'Next',
+    submit: 'Submit',
+  },
+  hasPrev: false,
+  hasNext: false,
+};
+
+const PageWizardStep = ({
+  id,
+  children,
+  onValidate,
+  error,
+  onClearError,
+  i18n,
+  hasStickyFooter,
+  onClose,
+  hasPrev,
+  hasNext,
+  onNext,
+  nextDisabled,
+  onBack,
+  sendingData,
+  onSubmit,
+}) => (
+  <div className={`${iotPrefix}--page-wizard--step`} id={id}>
+    {error ? (
+      <InlineNotification
+        lowContrast
+        title={error}
+        subtitle=""
+        kind="error"
+        onCloseButtonClick={onClearError}
+        iconDescription={i18n.close}
+      />
+    ) : null}
+    {children}
+    <div
+      className={
+        hasStickyFooter
+          ? `${iotPrefix}--page-wizard--content--actions--sticky`
+          : `${iotPrefix}--page-wizard--content--actions`
+      }
+    >
+      {!hasPrev ? (
+        <Button onClick={onClose} kind="secondary">
+          {i18n.cancel}
+        </Button>
+      ) : null}
+      {hasPrev ? (
+        <Button onClick={onBack} kind="secondary">
+          {i18n.back}
+        </Button>
+      ) : null}
+      {hasNext ? (
+        <Button onClick={() => onValidate() && onNext()} disabled={nextDisabled}>
+          {i18n.next}
+        </Button>
+      ) : (
+        <Button
+          onClick={() => onValidate() && onSubmit()}
+          disabled={nextDisabled}
+          loading={sendingData}
+        >
+          {i18n.submit}
+        </Button>
+      )}
+    </div>
+  </div>
+);
+
+PageWizardStep.propTypes = PageWizardStepPropTypes;
+PageWizardStep.defaultProps = PageWizardStepDefaultProps;
+
+export default PageWizardStep;

--- a/src/components/PageWizard/PageWizardStep/PageWizardStepContent.jsx
+++ b/src/components/PageWizard/PageWizardStep/PageWizardStepContent.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { settings } from '../../../constants/Settings';
+import { childrenPropType } from '../PageWizard';
+
+const { iotPrefix } = settings;
+
+const PageWizardStepContent = ({ children }) => (
+  <div className={`${iotPrefix}--page-wizard--step--content`}>{children}</div>
+);
+
+PageWizardStepContent.propTypes = { children: childrenPropType };
+PageWizardStepContent.defaultProps = { children: [] };
+
+export default PageWizardStepContent;

--- a/src/components/PageWizard/PageWizardStep/PageWizardStepDescription.jsx
+++ b/src/components/PageWizard/PageWizardStep/PageWizardStepDescription.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { settings } from '../../../constants/Settings';
+import { childrenPropType } from '../PageWizard';
+
+const { iotPrefix } = settings;
+
+const PageWizardStepDescription = ({ children }) => (
+  <div className={`${iotPrefix}--page-wizard--step--description`}>{children}</div>
+);
+
+PageWizardStepDescription.propTypes = { children: childrenPropType };
+PageWizardStepDescription.defaultProps = { children: [] };
+
+export default PageWizardStepDescription;

--- a/src/components/PageWizard/PageWizardStep/PageWizardStepExtraContent.jsx
+++ b/src/components/PageWizard/PageWizardStep/PageWizardStepExtraContent.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { settings } from '../../../constants/Settings';
+import { childrenPropType } from '../PageWizard';
+
+const { iotPrefix } = settings;
+
+const PageWizardStepExtraContent = ({ children }) => (
+  <div className={`${iotPrefix}--page-wizard--step--extra-content`}>{children}</div>
+);
+
+PageWizardStepExtraContent.propTypes = { children: childrenPropType };
+PageWizardStepExtraContent.defaultProps = { children: [] };
+
+export default PageWizardStepExtraContent;

--- a/src/components/PageWizard/PageWizardStep/PageWizardStepTitle.jsx
+++ b/src/components/PageWizard/PageWizardStep/PageWizardStepTitle.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { settings } from '../../../constants/Settings';
+import { childrenPropType } from '../PageWizard';
+
+const { iotPrefix } = settings;
+
+const PageWizardStepTitle = ({ children }) => (
+  <div className={`${iotPrefix}--page-wizard--step--title`}>{children}</div>
+);
+
+PageWizardStepTitle.propTypes = { children: childrenPropType };
+PageWizardStepTitle.defaultProps = { children: [] };
+
+export default PageWizardStepTitle;

--- a/src/components/PageWizard/StatefulPageWizard.jsx
+++ b/src/components/PageWizard/StatefulPageWizard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { PageWizard, propTypes, defaultProps } from './PageWizard';
+import PageWizard, { PageWizardPropTypes, defaultProps } from './PageWizard';
 
 const StatefulPageWizard = ({
   currentStepId: currentStepIdProp,
@@ -40,6 +40,6 @@ const StatefulPageWizard = ({
   );
 };
 
-StatefulPageWizard.propTypes = propTypes;
+StatefulPageWizard.propTypes = PageWizardPropTypes;
 StatefulPageWizard.defaultProps = defaultProps;
 export default StatefulPageWizard;

--- a/src/components/PageWizard/StatefulPageWizard.jsx
+++ b/src/components/PageWizard/StatefulPageWizard.jsx
@@ -1,6 +1,66 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 
-import PageWizard, { PageWizardPropTypes, defaultProps } from './PageWizard';
+import PageWizard, { childrenPropType } from './PageWizard';
+
+const StatefulPageWizardPropTypes = {
+  children: childrenPropType,
+  /** Id of current step */
+  currentStepId: PropTypes.string,
+  /** action when click next button called with no param */
+  onNext: PropTypes.func,
+  /** action when click back button called with no param */
+  onBack: PropTypes.func,
+  /** action if the inline wizard is closed or canceled */
+  onClose: PropTypes.func.isRequired,
+  /** action triggered if the inline wizard has submitted final step */
+  onSubmit: PropTypes.func.isRequired,
+  i18n: PropTypes.shape({
+    /** label to show on the cancel button */
+    cancel: PropTypes.string,
+    /** label to show on the back button */
+    back: PropTypes.string,
+    /** label to show on the next button */
+    next: PropTypes.string,
+    /** label to show on the submit button */
+    submit: PropTypes.string,
+    /** label to show on the close notification button */
+    close: PropTypes.string,
+  }),
+  /** function to go to step when click ProgressIndicator step. */
+  setStep: PropTypes.func.isRequired,
+  /** next button disabled */
+  nextDisabled: PropTypes.bool,
+  /** show progress indicator on finish button */
+  sendingData: PropTypes.bool,
+  /** Form Error Details */
+  error: PropTypes.string,
+  /** required callback to clear the error */
+  onClearError: PropTypes.func.isRequired,
+  /** use sticky footer to show buttons at the bottom */
+  hasStickyFooter: PropTypes.bool,
+  /** Displays the progress indicator vertically */
+  isProgressIndicatorVertical: PropTypes.bool,
+};
+
+const defaultProps = {
+  children: [],
+  nextDisabled: false,
+  currentStepId: null,
+  i18n: {
+    back: 'Back',
+    next: 'Next',
+    cancel: 'Cancel',
+    submit: 'Submit',
+    close: 'Close',
+  },
+  sendingData: false,
+  error: null,
+  hasStickyFooter: false,
+  isProgressIndicatorVertical: true,
+  onNext: null,
+  onBack: null,
+};
 
 const StatefulPageWizard = ({
   currentStepId: currentStepIdProp,
@@ -17,11 +77,11 @@ const StatefulPageWizard = ({
   const prevStep = currentStepIndex > 0 ? steps[currentStepIndex - 1] : undefined;
   const handleNext = id => {
     setCurrentStepId(id);
-    onNext(id);
+    if (onNext) onNext(id);
   };
   const handleBack = id => {
     setCurrentStepId(id);
-    onBack(id);
+    if (onBack) onBack(id);
   };
 
   return (
@@ -40,6 +100,6 @@ const StatefulPageWizard = ({
   );
 };
 
-StatefulPageWizard.propTypes = PageWizardPropTypes;
+StatefulPageWizard.propTypes = StatefulPageWizardPropTypes;
 StatefulPageWizard.defaultProps = defaultProps;
 export default StatefulPageWizard;

--- a/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
+++ b/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
@@ -1,0 +1,2014 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageWizard With Horizontal ProgressIndicator 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div>
+          <div
+            className="  "
+          >
+            <div
+              className="iot--page-wizard--progress--horizontal"
+            >
+              <ul
+                className="bx--progress"
+                onChange={[Function]}
+              >
+                <li
+                  className="bx--progress-step bx--progress-step--current"
+                >
+                  <div
+                    className="bx--progress-step-button bx--progress-step-button--unclickable"
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={-1}
+                  >
+                    <svg>
+                      <path
+                        d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                      />
+                      <title />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 1
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+                <li
+                  className="bx--progress-step bx--progress-step--incomplete"
+                >
+                  <div
+                    className="bx--progress-step-button"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg>
+                      <title />
+                      <path
+                        d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                      />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 2
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+                <li
+                  className="bx--progress-step bx--progress-step--incomplete"
+                >
+                  <div
+                    className="bx--progress-step-button"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg>
+                      <title />
+                      <path
+                        d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                      />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 3
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div
+              className="iot--page-wizard--content"
+            >
+              <div
+                className="iot--page-wizard--step"
+                id="step1"
+              >
+                <div
+                  className="iot--page-wizard--step--title"
+                >
+                  Step 1: Define the data
+                </div>
+                <div
+                  className="iot--page-wizard--step--description"
+                >
+                  You can create summaries lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est.
+                   
+                  <a
+                    href="www.ibm.com"
+                  >
+                    An embedded link
+                  </a>
+                   is good to have sometimes.
+                </div>
+                <div
+                  className="iot--page-wizard--step--content"
+                >
+                  <h1>
+                    A table could go here
+                  </h1>
+                  <h3>
+                    Some other form items could go here
+                  </h3>
+                  <h4>
+                    And other things here
+                  </h4>
+                </div>
+                <div
+                  className="iot--page-wizard--step--extra-content"
+                >
+                  <h4>
+                    What are time grains?
+                  </h4>
+                  <p>
+                    Time grains are lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est. Duis blandit tellus ultricies justo sagittis, tempus ornare purus tristique. Quisque nisi tortor, semper ac efficitur tincidunt, feugiat vel ligula. Aenean consequat, massa nec rhoncus vulputate, metus ex dictum ante, at posuere erat tellus vitae orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu tempus sem. Vestibulum quis consequat orci. Sed vel ultrices libero, eu malesuada quam.
+                  </p>
+                </div>
+                <div
+                  className="iot--page-wizard--content--actions"
+                >
+                  <button
+                    className="iot--btn bx--btn bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageWizard With Sticky Footer: stateful example w/ validation in PageTitleBar 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div>
+          <div
+            className="page-title-bar"
+          >
+            <div
+              className="page-title-bar-header"
+            >
+              <div>
+                <div
+                  className="page-title-bar-breadcrumb"
+                >
+                  <nav
+                    aria-label="Breadcrumb"
+                  >
+                    <ol
+                      className="bx--breadcrumb"
+                    >
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Home
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something Else
+                        </a>
+                      </li>
+                    </ol>
+                  </nav>
+                </div>
+                <div
+                  className="page-title-bar-title"
+                >
+                  <div
+                    className="page-title-bar-title--text"
+                  >
+                    <h2>
+                      A cool PageWizard!
+                    </h2>
+                    <div
+                      className="bx--tooltip__label"
+                      id="tooltip"
+                    >
+                      
+                      <div
+                        aria-describedby={null}
+                        aria-haspopup="true"
+                        className="bx--tooltip__trigger"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          description={null}
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role={null}
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                          />
+                          <path
+                            d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-content"
+            >
+              <div
+                className="iot--page-wizard  iot--page-wizard__sticky"
+              >
+                <div
+                  className="iot--page-wizard--progress--vertical"
+                >
+                  <ul
+                    className="bx--progress bx--progress--vertical"
+                    onChange={[Function]}
+                  >
+                    <li
+                      className="bx--progress-step bx--progress-step--current"
+                    >
+                      <div
+                        className="bx--progress-step-button bx--progress-step-button--unclickable"
+                        onKeyDown={[Function]}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <svg>
+                          <path
+                            d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                          />
+                          <title />
+                        </svg>
+                        <p
+                          className="bx--progress-label"
+                        >
+                          Step with validation
+                        </p>
+                        <span
+                          className="bx--progress-line"
+                        />
+                      </div>
+                    </li>
+                    <li
+                      className="bx--progress-step bx--progress-step--incomplete"
+                    >
+                      <div
+                        className="bx--progress-step-button"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg>
+                          <title />
+                          <path
+                            d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                          />
+                        </svg>
+                        <p
+                          className="bx--progress-label"
+                        >
+                          Step 2
+                        </p>
+                        <span
+                          className="bx--progress-line"
+                        />
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  className="iot--page-wizard--content"
+                >
+                  <div
+                    className="iot--page-wizard--step"
+                    id="step1"
+                  >
+                    <div
+                      className="iot--page-wizard--step--title"
+                    >
+                      Enter some things
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--description"
+                    >
+                      Make sure you do not try to go to the next step with an empty input! Bad things will happen.
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--content"
+                    >
+                      <form
+                        className="bx--form"
+                      >
+                         
+                        <fieldset
+                          className="bx--fieldset"
+                        >
+                          <legend
+                            className="bx--label"
+                          >
+                            Name
+                          </legend>
+                          <div
+                            className="bx--form-item"
+                          >
+                            <div
+                              className="bx--form-item bx--text-input-wrapper"
+                            >
+                              <label
+                                className="bx--label"
+                                htmlFor="first-name"
+                              >
+                                First name
+                              </label>
+                              <div
+                                className="bx--text-input__field-wrapper"
+                                data-invalid={null}
+                              >
+                                <input
+                                  className="bx--text-input bx--text__input"
+                                  data-testid="first-name"
+                                  disabled={false}
+                                  id="first-name"
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="bx--form-item"
+                          >
+                            <div
+                              className="bx--form-item bx--text-input-wrapper"
+                            >
+                              <label
+                                className="bx--label"
+                                htmlFor="last-name"
+                              >
+                                Last name
+                              </label>
+                              <div
+                                className="bx--text-input__field-wrapper"
+                                data-invalid={null}
+                              >
+                                <input
+                                  className="bx--text-input bx--text__input"
+                                  data-testid="last-name"
+                                  disabled={false}
+                                  id="last-name"
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                         
+                      </form>
+                    </div>
+                    <div
+                      className="iot--page-wizard--content--actions--sticky"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Next
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageWizard only one step, in PageTitleBar 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div>
+          <div
+            className="page-title-bar"
+          >
+            <div
+              className="page-title-bar-header"
+            >
+              <div>
+                <div
+                  className="page-title-bar-breadcrumb"
+                >
+                  <nav
+                    aria-label="Breadcrumb"
+                  >
+                    <ol
+                      className="bx--breadcrumb"
+                    >
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Home
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something Else
+                        </a>
+                      </li>
+                    </ol>
+                  </nav>
+                </div>
+                <div
+                  className="page-title-bar-title"
+                >
+                  <div
+                    className="page-title-bar-title--text"
+                  >
+                    <h2>
+                      A cool PageWizard!
+                    </h2>
+                    <div
+                      className="bx--tooltip__label"
+                      id="tooltip"
+                    >
+                      
+                      <div
+                        aria-describedby={null}
+                        aria-haspopup="true"
+                        className="bx--tooltip__trigger"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          description={null}
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role={null}
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                          />
+                          <path
+                            d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-content"
+            >
+              <div
+                className="iot--page-wizard  "
+              >
+                <div
+                  className="iot--page-wizard--content"
+                >
+                  <div
+                    className="iot--page-wizard--step"
+                    id="step1"
+                  >
+                    <div
+                      className="iot--page-wizard--step--title"
+                    >
+                      Step 1: Define the data
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--description"
+                    >
+                      You can create summaries lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est.
+                       
+                      <a
+                        href="www.ibm.com"
+                      >
+                        An embedded link
+                      </a>
+                       is good to have sometimes.
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--content"
+                    >
+                      <h1>
+                        A table could go here
+                      </h1>
+                      <h3>
+                        Some other form items could go here
+                      </h3>
+                      <h4>
+                        And other things here
+                      </h4>
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--extra-content"
+                    >
+                      <h4>
+                        What are time grains?
+                      </h4>
+                      <p>
+                        Time grains are lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est. Duis blandit tellus ultricies justo sagittis, tempus ornare purus tristique. Quisque nisi tortor, semper ac efficitur tincidunt, feugiat vel ligula. Aenean consequat, massa nec rhoncus vulputate, metus ex dictum ante, at posuere erat tellus vitae orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu tempus sem. Vestibulum quis consequat orci. Sed vel ultrices libero, eu malesuada quam.
+                      </p>
+                    </div>
+                    <div
+                      className="iot--page-wizard--content--actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Submit
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageWizard stateful example 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div>
+          <div
+            className="iot--page-wizard  "
+          >
+            <div
+              className="iot--page-wizard--progress--vertical"
+            >
+              <ul
+                className="bx--progress bx--progress--vertical"
+                onChange={[Function]}
+              >
+                <li
+                  className="bx--progress-step bx--progress-step--current"
+                >
+                  <div
+                    className="bx--progress-step-button bx--progress-step-button--unclickable"
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={-1}
+                  >
+                    <svg>
+                      <path
+                        d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                      />
+                      <title />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 1
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+                <li
+                  className="bx--progress-step bx--progress-step--incomplete"
+                >
+                  <div
+                    className="bx--progress-step-button"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg>
+                      <title />
+                      <path
+                        d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                      />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 2
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+                <li
+                  className="bx--progress-step bx--progress-step--incomplete"
+                >
+                  <div
+                    className="bx--progress-step-button"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg>
+                      <title />
+                      <path
+                        d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                      />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 3
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div
+              className="iot--page-wizard--content"
+            >
+              <div
+                className="iot--page-wizard--step"
+                id="step1"
+              >
+                <div
+                  className="iot--page-wizard--step--title"
+                >
+                  Step 1: Define the data
+                </div>
+                <div
+                  className="iot--page-wizard--step--description"
+                >
+                  You can create summaries lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est.
+                   
+                  <a
+                    href="www.ibm.com"
+                  >
+                    An embedded link
+                  </a>
+                   is good to have sometimes.
+                </div>
+                <div
+                  className="iot--page-wizard--step--content"
+                >
+                  <h1>
+                    A table could go here
+                  </h1>
+                  <h3>
+                    Some other form items could go here
+                  </h3>
+                  <h4>
+                    And other things here
+                  </h4>
+                </div>
+                <div
+                  className="iot--page-wizard--step--extra-content"
+                >
+                  <h4>
+                    What are time grains?
+                  </h4>
+                  <p>
+                    Time grains are lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est. Duis blandit tellus ultricies justo sagittis, tempus ornare purus tristique. Quisque nisi tortor, semper ac efficitur tincidunt, feugiat vel ligula. Aenean consequat, massa nec rhoncus vulputate, metus ex dictum ante, at posuere erat tellus vitae orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu tempus sem. Vestibulum quis consequat orci. Sed vel ultrices libero, eu malesuada quam.
+                  </p>
+                </div>
+                <div
+                  className="iot--page-wizard--content--actions"
+                >
+                  <button
+                    className="iot--btn bx--btn bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageWizard stateful example w/ validation in PageTitleBar 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div>
+          <div
+            className="page-title-bar"
+          >
+            <div
+              className="page-title-bar-header"
+            >
+              <div>
+                <div
+                  className="page-title-bar-breadcrumb"
+                >
+                  <nav
+                    aria-label="Breadcrumb"
+                  >
+                    <ol
+                      className="bx--breadcrumb"
+                    >
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Home
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something Else
+                        </a>
+                      </li>
+                    </ol>
+                  </nav>
+                </div>
+                <div
+                  className="page-title-bar-title"
+                >
+                  <div
+                    className="page-title-bar-title--text"
+                  >
+                    <h2>
+                      A cool PageWizard!
+                    </h2>
+                    <div
+                      className="bx--tooltip__label"
+                      id="tooltip"
+                    >
+                      
+                      <div
+                        aria-describedby={null}
+                        aria-haspopup="true"
+                        className="bx--tooltip__trigger"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          description={null}
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role={null}
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                          />
+                          <path
+                            d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-content"
+            >
+              <div
+                className="iot--page-wizard  "
+              >
+                <div
+                  className="iot--page-wizard--progress--vertical"
+                >
+                  <ul
+                    className="bx--progress bx--progress--vertical"
+                    onChange={[Function]}
+                  >
+                    <li
+                      className="bx--progress-step bx--progress-step--current"
+                    >
+                      <div
+                        className="bx--progress-step-button bx--progress-step-button--unclickable"
+                        onKeyDown={[Function]}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <svg>
+                          <path
+                            d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                          />
+                          <title />
+                        </svg>
+                        <p
+                          className="bx--progress-label"
+                        >
+                          Step with validation
+                        </p>
+                        <span
+                          className="bx--progress-line"
+                        />
+                      </div>
+                    </li>
+                    <li
+                      className="bx--progress-step bx--progress-step--incomplete"
+                    >
+                      <div
+                        className="bx--progress-step-button"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg>
+                          <title />
+                          <path
+                            d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                          />
+                        </svg>
+                        <p
+                          className="bx--progress-label"
+                        >
+                          Step 2
+                        </p>
+                        <span
+                          className="bx--progress-line"
+                        />
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  className="iot--page-wizard--content"
+                >
+                  <div
+                    className="iot--page-wizard--step"
+                    id="step1"
+                  >
+                    <div
+                      className="iot--page-wizard--step--title"
+                    >
+                      Enter some things
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--description"
+                    >
+                      Make sure you do not try to go to the next step with an empty input! Bad things will happen.
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--content"
+                    >
+                      <form
+                        className="bx--form"
+                      >
+                         
+                        <fieldset
+                          className="bx--fieldset"
+                        >
+                          <legend
+                            className="bx--label"
+                          >
+                            Name
+                          </legend>
+                          <div
+                            className="bx--form-item"
+                          >
+                            <div
+                              className="bx--form-item bx--text-input-wrapper"
+                            >
+                              <label
+                                className="bx--label"
+                                htmlFor="first-name"
+                              >
+                                First name
+                              </label>
+                              <div
+                                className="bx--text-input__field-wrapper"
+                                data-invalid={null}
+                              >
+                                <input
+                                  className="bx--text-input bx--text__input"
+                                  data-testid="first-name"
+                                  disabled={false}
+                                  id="first-name"
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            className="bx--form-item"
+                          >
+                            <div
+                              className="bx--form-item bx--text-input-wrapper"
+                            >
+                              <label
+                                className="bx--label"
+                                htmlFor="last-name"
+                              >
+                                Last name
+                              </label>
+                              <div
+                                className="bx--text-input__field-wrapper"
+                                data-invalid={null}
+                              >
+                                <input
+                                  className="bx--text-input bx--text__input"
+                                  data-testid="last-name"
+                                  disabled={false}
+                                  id="last-name"
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                         
+                      </form>
+                    </div>
+                    <div
+                      className="iot--page-wizard--content--actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Next
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageWizard w/ i18n 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div>
+          <div
+            className="iot--page-wizard  "
+          >
+            <div
+              className="iot--page-wizard--progress--vertical"
+            >
+              <ul
+                className="bx--progress bx--progress--vertical"
+                onChange={[Function]}
+              >
+                <li
+                  className="bx--progress-step bx--progress-step--current"
+                >
+                  <div
+                    className="bx--progress-step-button bx--progress-step-button--unclickable"
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={-1}
+                  >
+                    <svg>
+                      <path
+                        d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                      />
+                      <title />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 1
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+                <li
+                  className="bx--progress-step bx--progress-step--incomplete"
+                >
+                  <div
+                    className="bx--progress-step-button"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg>
+                      <title />
+                      <path
+                        d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                      />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 2
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+                <li
+                  className="bx--progress-step bx--progress-step--incomplete"
+                >
+                  <div
+                    className="bx--progress-step-button"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg>
+                      <title />
+                      <path
+                        d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                      />
+                    </svg>
+                    <p
+                      className="bx--progress-label"
+                    >
+                      Step 3
+                    </p>
+                    <span
+                      className="bx--progress-line"
+                    />
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div
+              className="iot--page-wizard--content"
+            >
+              <div
+                className="iot--page-wizard--step"
+                id="step1"
+              >
+                <div
+                  className="iot--page-wizard--step--title"
+                >
+                  Step 1: Define the data
+                </div>
+                <div
+                  className="iot--page-wizard--step--description"
+                >
+                  You can create summaries lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est.
+                   
+                  <a
+                    href="www.ibm.com"
+                  >
+                    An embedded link
+                  </a>
+                   is good to have sometimes.
+                </div>
+                <div
+                  className="iot--page-wizard--step--content"
+                >
+                  <h1>
+                    A table could go here
+                  </h1>
+                  <h3>
+                    Some other form items could go here
+                  </h3>
+                  <h4>
+                    And other things here
+                  </h4>
+                </div>
+                <div
+                  className="iot--page-wizard--step--extra-content"
+                >
+                  <h4>
+                    What are time grains?
+                  </h4>
+                  <p>
+                    Time grains are lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est. Duis blandit tellus ultricies justo sagittis, tempus ornare purus tristique. Quisque nisi tortor, semper ac efficitur tincidunt, feugiat vel ligula. Aenean consequat, massa nec rhoncus vulputate, metus ex dictum ante, at posuere erat tellus vitae orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu tempus sem. Vestibulum quis consequat orci. Sed vel ultrices libero, eu malesuada quam.
+                  </p>
+                </div>
+                <div
+                  className="iot--page-wizard--content--actions"
+                >
+                  <button
+                    className="iot--btn bx--btn bx--btn--secondary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="iot--btn bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageWizard wrapped in PageTitleBar 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div>
+          <div
+            className="page-title-bar"
+          >
+            <div
+              className="page-title-bar-header"
+            >
+              <div>
+                <div
+                  className="page-title-bar-breadcrumb"
+                >
+                  <nav
+                    aria-label="Breadcrumb"
+                  >
+                    <ol
+                      className="bx--breadcrumb"
+                    >
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Home
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something
+                        </a>
+                      </li>
+                      <li
+                        className="bx--breadcrumb-item"
+                      >
+                        <a
+                          className="bx--link bx--link"
+                          to="www.ibm.com"
+                        >
+                          Something Else
+                        </a>
+                      </li>
+                    </ol>
+                  </nav>
+                </div>
+                <div
+                  className="page-title-bar-title"
+                >
+                  <div
+                    className="page-title-bar-title--text"
+                  >
+                    <h2>
+                      A cool PageWizard!
+                    </h2>
+                    <div
+                      className="bx--tooltip__label"
+                      id="tooltip"
+                    >
+                      
+                      <div
+                        aria-describedby={null}
+                        aria-haspopup="true"
+                        className="bx--tooltip__trigger"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          description={null}
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role={null}
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M17 22v-9h-4v2h2v7h-3v2h8v-2h-3zM16 7a1.5 1.5 0 1 0 1.5 1.5A1.5 1.5 0 0 0 16 7z"
+                          />
+                          <path
+                            d="M16 30a14 14 0 1 1 14-14 14 14 0 0 1-14 14zm0-26a12 12 0 1 0 12 12A12 12 0 0 0 16 4z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="page-title-bar-content"
+            >
+              <div
+                className="iot--page-wizard  "
+              >
+                <div
+                  className="iot--page-wizard--progress--vertical"
+                >
+                  <ul
+                    className="bx--progress bx--progress--vertical"
+                    onChange={[Function]}
+                  >
+                    <li
+                      className="bx--progress-step bx--progress-step--current"
+                    >
+                      <div
+                        className="bx--progress-step-button bx--progress-step-button--unclickable"
+                        onKeyDown={[Function]}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <svg>
+                          <path
+                            d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0"
+                          />
+                          <title />
+                        </svg>
+                        <p
+                          className="bx--progress-label"
+                        >
+                          Step 1
+                        </p>
+                        <span
+                          className="bx--progress-line"
+                        />
+                      </div>
+                    </li>
+                    <li
+                      className="bx--progress-step bx--progress-step--incomplete"
+                    >
+                      <div
+                        className="bx--progress-step-button"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg>
+                          <title />
+                          <path
+                            d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                          />
+                        </svg>
+                        <p
+                          className="bx--progress-label"
+                        >
+                          Step 2
+                        </p>
+                        <span
+                          className="bx--progress-line"
+                        />
+                      </div>
+                    </li>
+                    <li
+                      className="bx--progress-step bx--progress-step--incomplete"
+                    >
+                      <div
+                        className="bx--progress-step-button"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <svg>
+                          <title />
+                          <path
+                            d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z"
+                          />
+                        </svg>
+                        <p
+                          className="bx--progress-label"
+                        >
+                          Step 3
+                        </p>
+                        <span
+                          className="bx--progress-line"
+                        />
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+                <div
+                  className="iot--page-wizard--content"
+                >
+                  <div
+                    className="iot--page-wizard--step"
+                    id="step1"
+                  >
+                    <div
+                      className="iot--page-wizard--step--title"
+                    >
+                      Step 1: Define the data
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--description"
+                    >
+                      You can create summaries lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est.
+                       
+                      <a
+                        href="www.ibm.com"
+                      >
+                        An embedded link
+                      </a>
+                       is good to have sometimes.
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--content"
+                    >
+                      <h1>
+                        A table could go here
+                      </h1>
+                      <h3>
+                        Some other form items could go here
+                      </h3>
+                      <h4>
+                        And other things here
+                      </h4>
+                    </div>
+                    <div
+                      className="iot--page-wizard--step--extra-content"
+                    >
+                      <h4>
+                        What are time grains?
+                      </h4>
+                      <p>
+                        Time grains are lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer eros odio, rhoncus et sapien quis, vestibulum bibendum est. Duis blandit tellus ultricies justo sagittis, tempus ornare purus tristique. Quisque nisi tortor, semper ac efficitur tincidunt, feugiat vel ligula. Aenean consequat, massa nec rhoncus vulputate, metus ex dictum ante, at posuere erat tellus vitae orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu tempus sem. Vestibulum quis consequat orci. Sed vel ultrices libero, eu malesuada quam.
+                      </p>
+                    </div>
+                    <div
+                      className="iot--page-wizard--content--actions"
+                    >
+                      <button
+                        className="iot--btn bx--btn bx--btn--secondary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="iot--btn bx--btn bx--btn--primary"
+                        disabled={false}
+                        onClick={[Function]}
+                        tabIndex={0}
+                        type="button"
+                      >
+                        Next
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
+++ b/src/components/PageWizard/__snapshots__/PageWizard.story.storyshot
@@ -41,7 +41,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageW
       >
         <div>
           <div
-            className="  "
+            className=""
           >
             <div
               className="iot--page-wizard--progress--horizontal"
@@ -380,7 +380,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageW
               className="page-title-bar-content"
             >
               <div
-                className="iot--page-wizard  iot--page-wizard__sticky"
+                className="iot--page-wizard iot--page-wizard__sticky"
               >
                 <div
                   className="iot--page-wizard--progress--vertical"
@@ -742,7 +742,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageW
               className="page-title-bar-content"
             >
               <div
-                className="iot--page-wizard  "
+                className="iot--page-wizard"
               >
                 <div
                   className="iot--page-wizard--content"
@@ -889,7 +889,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageW
       >
         <div>
           <div
-            className="iot--page-wizard  "
+            className="iot--page-wizard"
           >
             <div
               className="iot--page-wizard--progress--vertical"
@@ -1228,7 +1228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageW
               className="page-title-bar-content"
             >
               <div
-                className="iot--page-wizard  "
+                className="iot--page-wizard"
               >
                 <div
                   className="iot--page-wizard--progress--vertical"
@@ -1482,7 +1482,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageW
       >
         <div>
           <div
-            className="iot--page-wizard  "
+            className="iot--page-wizard"
           >
             <div
               className="iot--page-wizard--progress--vertical"
@@ -1821,7 +1821,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|PageW
               className="page-title-bar-content"
             >
               <div
-                className="iot--page-wizard  "
+                className="iot--page-wizard"
               >
                 <div
                   className="iot--page-wizard--progress--vertical"

--- a/src/components/PageWizard/_page-wizard.scss
+++ b/src/components/PageWizard/_page-wizard.scss
@@ -1,7 +1,8 @@
 @import '~carbon-components/scss/globals/scss/vars';
 @import '~carbon-components/scss/globals/scss/typography';
+@import '../../globals/vars';
 
-.page-wizard {
+.#{$iot-prefix}--page-wizard {
   display: flex;
 
   &__sticky {
@@ -9,17 +10,26 @@
   }
 
   &--progress {
-    padding-right: $spacing-05;
-    flex: 0 0 12rem;
+    &--vertical {
+      padding-right: $spacing-05;
+      flex: 0 0 12rem;
+    }
+
+    &--horizontal {
+      padding-bottom: $spacing-05;
+    }
+
     .#{$prefix}--progress--vertical {
       li {
         min-height: 4.5rem;
       }
     }
   }
+
   &--step {
     padding-bottom: $spacing-07;
     @include type-style('body-long-01');
+
     &--title {
       @include type-style('productive-heading-02');
       margin-bottom: $spacing-03;
@@ -32,14 +42,18 @@
       display: none; /* TODO: render as sidebar */
     }
   }
+
   &--content {
     flex: 1;
+
     &--actions {
       padding-top: $spacing-07;
+
       .#{$prefix}--btn {
         margin-right: $spacing-05;
       }
     }
+
     &--actions--sticky {
       position: fixed;
       bottom: 0;

--- a/src/index.js
+++ b/src/index.js
@@ -63,14 +63,13 @@ export {
 
 // Experimental
 export ListCard from './components/ListCard/ListCard';
-export {
-  PageWizard,
-  PageWizardStep,
-  PageWizardStepContent,
-  PageWizardStepTitle,
-  PageWizardStepDescription,
-  PageWizardStepExtraContent,
-} from './components/PageWizard/PageWizard';
+
+export PageWizard from './components/PageWizard/PageWizard';
+export PageWizardStep from './components/PageWizard/PageWizardStep/PageWizardStep';
+export PageWizardStepContent from './components/PageWizard/PageWizardStep/PageWizardStepContent';
+export PageWizardStepDescription from './components/PageWizard/PageWizardStep/PageWizardStepDescription';
+export PageWizardStepExtraContent from './components/PageWizard/PageWizardStep/PageWizardStepExtraContent';
+export PageWizardStepTitle from './components/PageWizard/PageWizardStep/PageWizardStepTitle';
 export StatefulPageWizard from './components/PageWizard/StatefulPageWizard';
 
 export TileGallery from './components/TileGallery/TileGallery';


### PR DESCRIPTION
Closes #874

**Summary**

- Added `isProgressIndicatorVertical` boolean to toggle the vertical vs horizontal layouts
- Refactored PageWizardStep into smaller components
- Added comments to props
- Corrected props
- Added tests to get more test coverage
- Added knobs to all applicable stories

![Screen Shot 2020-02-03 at 1 52 46 PM](https://user-images.githubusercontent.com/25177649/73685844-7b868280-468c-11ea-90cd-2a8b17d89d02.png)


**Acceptance Test (how to verify the PR)**

- Check the PageWizard stories and toggle the horizontal layout by using the knob
