### PR TITLE
fix(dashboard): only set loading if a datasource is specified

### DIFF
--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -36,17 +36,20 @@ const CachedCardRenderer = ({
 
 /** Asynchronous reusable function to load Card Data */
 export const loadCardData = async (card, setCard, onFetchData, timeGrain) => {
-  // Set state to loading
-  setCard({ ...card, isLoading: true });
-  const cardWithData = await onFetchData(
-    card,
-    card.type !== CARD_TYPES.IMAGE && card.type !== CARD_TYPES.VALUE
-  );
-  setCard({
-    ...cardWithData,
-    timeGrain: compareGrains(timeGrain, card.timeGrain) < 1 ? card.timeGrain : timeGrain,
-    isLoading: false,
-  });
+  // Only set the card to loading if it has a datasource to support simple cards
+  if (card.dataSource) {
+    // Set state to loading
+    setCard({ ...card, isLoading: true });
+    const cardWithData = await onFetchData(
+      card,
+      card.type !== CARD_TYPES.IMAGE && card.type !== CARD_TYPES.VALUE
+    );
+    setCard({
+      ...cardWithData,
+      timeGrain: compareGrains(timeGrain, card.timeGrain) < 1 ? card.timeGrain : timeGrain,
+      isLoading: false,
+    });
+  }
 };
 
 /**

--- a/src/components/Dashboard/CardRenderer.test.jsx
+++ b/src/components/Dashboard/CardRenderer.test.jsx
@@ -125,6 +125,7 @@ const onClick = jest.fn();
 describe('CardRenderer testcases', () => {
   test('load card data', async () => {
     let state = {
+      dataSource: {},
       hasLoaded: false,
     };
     const setCard = cardObj => {

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -303,7 +303,10 @@ const Dashboard = ({
         if (cardsLoadingRef.current && !cardsLoadingRef.current.includes(card.id)) {
           cardsLoadingRef.current.push(card.id);
           // If the card array count matches the card count, we call setIsLoading to false, and clear the array
-          if (cardsLoadingRef.current.length === cards.length) {
+          if (
+            cardsLoadingRef.current.length ===
+            cards.filter(cardsToLoad => cardsToLoad.dataSource).length
+          ) {
             setIsLoading(false);
             onSetRefresh(Date.now());
           }

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -63,6 +63,15 @@ export const originalCards = [
     },
   },
   {
+    id: 'section-card',
+    size: CARD_SIZES.XSMALLWIDE,
+    type: CARD_TYPES.CUSTOM,
+    availableActions: {
+      delete: true,
+    },
+    content: <h2 style={{ padding: '1rem' }}>Section Header</h2>,
+  },
+  {
     title: 'Utilization',
     id: 'facilitycard-xs2',
     size: CARD_SIZES.XSMALL,
@@ -292,15 +301,16 @@ export const originalCards = [
 const commonDashboardProps = {
   title: text('title', 'Munich Building'),
   cards: originalCards,
-  onFetchData: (card, isTimeseriesData) => {
-    action('onFetchData')(card, isTimeseriesData);
-    return Promise.resolve({ ...card, values: [] });
-  },
   lastUpdated: new Date('2019-10-22T00:00:00').toUTCString(),
   isEditable: boolean('isEditable', false),
   isLoading: boolean('isLoading', false),
   onBreakpointChange: action('onBreakpointChange'),
   onLayoutChange: action('onLayoutChange'),
+  onSetRefresh: action('onSetRefresh'),
+  setIsLoading: action('setIsLoading'),
+  onFetchData: card => {
+    return new Promise(resolve => setTimeout(() => resolve(card), 5000));
+  },
 };
 
 storiesOf('Watson IoT|Dashboard', module)
@@ -309,7 +319,7 @@ storiesOf('Watson IoT|Dashboard', module)
     () => {
       return (
         <FullWidthWrapper>
-          <Dashboard {...commonDashboardProps} />
+          <Dashboard {...commonDashboardProps} isLoading={boolean('isLoading', false)} />
         </FullWidthWrapper>
       );
     },

--- a/src/components/Dashboard/Dashboard.test.jsx
+++ b/src/components/Dashboard/Dashboard.test.jsx
@@ -25,6 +25,7 @@ const cardValues = [
         { label: 'Sev 1', dataSourceId: 'data3', color: COLORS.BLUE },
       ],
     },
+    dataSource: {},
   },
   {
     title: 'Alerts (Section 2)',
@@ -43,6 +44,7 @@ const cardValues = [
         { label: 'Sev 1', value: 32, color: COLORS.BLUE },
       ],
     },
+    dataSource: {},
   },
   {
     title: 'Alerts',
@@ -56,6 +58,7 @@ const cardValues = [
       data: tableData,
       columns: tableColumns,
     },
+    dataSource: {},
   },
   {
     title: 'Floor Map',
@@ -73,6 +76,7 @@ const cardValues = [
       image: 'firstfloor',
       src: imageFile,
     },
+    dataSource: {},
     values: {
       hotspots: [
         {
@@ -118,6 +122,7 @@ const cardValues = [
         { label: 'Sev 1', value: 18, color: COLORS.BLUE },
       ],
     },
+    dataSource: {},
   },
 ];
 

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -306,7 +306,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
-                    id="facilitycard-xs2"
+                    content={
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    }
+                    id="section-card"
                     style={
                       Object {
                         "MozTransform": "translate(490px,16px)",
@@ -316,6 +327,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         "msTransform": "translate(490px,16px)",
                         "position": "absolute",
                         "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="CUSTOM"
+                  >
+                    <div
+                      className="Card__CardContent-v5r71h-1 bVgaXY"
+                    >
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
+                    id="facilitycard-xs2"
+                    style={
+                      Object {
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(648px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(648px,16px)",
                         "width": "142px",
                       }
                     }
@@ -380,13 +422,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,16px)",
-                        "OTransform": "translate(648px,16px)",
-                        "WebkitTransform": "translate(648px,16px)",
+                        "MozTransform": "translate(806px,16px)",
+                        "OTransform": "translate(806px,16px)",
+                        "WebkitTransform": "translate(806px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,16px)",
+                        "msTransform": "translate(806px,16px)",
                         "position": "absolute",
-                        "transform": "translate(648px,16px)",
+                        "transform": "translate(806px,16px)",
                         "width": "142px",
                       }
                     }
@@ -451,13 +493,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -544,13 +586,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -2083,7 +2125,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
-                    id="facilitycard-xs2"
+                    content={
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    }
+                    id="section-card"
                     style={
                       Object {
                         "MozTransform": "translate(490px,16px)",
@@ -2093,6 +2146,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         "msTransform": "translate(490px,16px)",
                         "position": "absolute",
                         "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="CUSTOM"
+                  >
+                    <div
+                      className="Card__CardContent-v5r71h-1 bVgaXY"
+                    >
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
+                    id="facilitycard-xs2"
+                    style={
+                      Object {
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(648px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(648px,16px)",
                         "width": "142px",
                       }
                     }
@@ -2157,13 +2241,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,16px)",
-                        "OTransform": "translate(648px,16px)",
-                        "WebkitTransform": "translate(648px,16px)",
+                        "MozTransform": "translate(806px,16px)",
+                        "OTransform": "translate(806px,16px)",
+                        "WebkitTransform": "translate(806px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,16px)",
+                        "msTransform": "translate(806px,16px)",
                         "position": "absolute",
-                        "transform": "translate(648px,16px)",
+                        "transform": "translate(806px,16px)",
                         "width": "142px",
                       }
                     }
@@ -2228,13 +2312,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -2321,13 +2405,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -3892,7 +3976,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
-                    id="facilitycard-xs2"
+                    content={
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    }
+                    id="section-card"
                     style={
                       Object {
                         "MozTransform": "translate(490px,16px)",
@@ -3902,6 +3997,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         "msTransform": "translate(490px,16px)",
                         "position": "absolute",
                         "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="CUSTOM"
+                  >
+                    <div
+                      className="Card__CardContent-v5r71h-1 bVgaXY"
+                    >
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
+                    id="facilitycard-xs2"
+                    style={
+                      Object {
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(648px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(648px,16px)",
                         "width": "142px",
                       }
                     }
@@ -3966,13 +4092,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,16px)",
-                        "OTransform": "translate(648px,16px)",
-                        "WebkitTransform": "translate(648px,16px)",
+                        "MozTransform": "translate(806px,16px)",
+                        "OTransform": "translate(806px,16px)",
+                        "WebkitTransform": "translate(806px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,16px)",
+                        "msTransform": "translate(806px,16px)",
                         "position": "absolute",
-                        "transform": "translate(648px,16px)",
+                        "transform": "translate(806px,16px)",
                         "width": "142px",
                       }
                     }
@@ -4037,13 +4163,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -4130,13 +4256,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -8032,7 +8158,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
-                    id="facilitycard-xs2"
+                    content={
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    }
+                    id="section-card"
                     style={
                       Object {
                         "MozTransform": "translate(490px,16px)",
@@ -8042,6 +8179,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         "msTransform": "translate(490px,16px)",
                         "position": "absolute",
                         "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="CUSTOM"
+                  >
+                    <div
+                      className="Card__CardContent-v5r71h-1 bVgaXY"
+                    >
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
+                    id="facilitycard-xs2"
+                    style={
+                      Object {
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(648px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(648px,16px)",
                         "width": "142px",
                       }
                     }
@@ -8106,13 +8274,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,16px)",
-                        "OTransform": "translate(648px,16px)",
-                        "WebkitTransform": "translate(648px,16px)",
+                        "MozTransform": "translate(806px,16px)",
+                        "OTransform": "translate(806px,16px)",
+                        "WebkitTransform": "translate(806px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,16px)",
+                        "msTransform": "translate(806px,16px)",
                         "position": "absolute",
-                        "transform": "translate(648px,16px)",
+                        "transform": "translate(806px,16px)",
                         "width": "142px",
                       }
                     }
@@ -8177,13 +8345,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -8270,13 +8438,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -19846,7 +20014,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
-                    id="facilitycard-xs2"
+                    content={
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    }
+                    id="section-card"
                     style={
                       Object {
                         "MozTransform": "translate(490px,16px)",
@@ -19856,6 +20035,37 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         "msTransform": "translate(490px,16px)",
                         "position": "absolute",
                         "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="CUSTOM"
+                  >
+                    <div
+                      className="Card__CardContent-v5r71h-1 bVgaXY"
+                    >
+                      <h2
+                        style={
+                          Object {
+                            "padding": "1rem",
+                          }
+                        }
+                      >
+                        Section Header
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 fbzdtE"
+                    id="facilitycard-xs2"
+                    style={
+                      Object {
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(648px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(648px,16px)",
                         "width": "142px",
                       }
                     }
@@ -19920,13 +20130,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,16px)",
-                        "OTransform": "translate(648px,16px)",
-                        "WebkitTransform": "translate(648px,16px)",
+                        "MozTransform": "translate(806px,16px)",
+                        "OTransform": "translate(806px,16px)",
+                        "WebkitTransform": "translate(806px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,16px)",
+                        "msTransform": "translate(806px,16px)",
                         "position": "absolute",
-                        "transform": "translate(648px,16px)",
+                        "transform": "translate(806px,16px)",
                         "width": "142px",
                       }
                     }
@@ -19991,13 +20201,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -20084,13 +20294,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }


### PR DESCRIPTION
Closes #

**Summary**

- If you specified a card without a datasource, it would hang in the loading state forever (and never be updated)

**Change List (commits, features, bugs, etc)**

- fix(CardRenderer): only cards with dataSources are loaded

**Acceptance Test (how to verify the PR)**

- Flip the new isLoading knobs on the main Dashboard story and notice that the only cards that show loading spinners are the ones with dataSources specified (i.e. the timeseries graph)
