### PR TITLE
feat:GRAPHITE-6186: #AllowHeader-Tooltip-Overflow

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -43,14 +43,9 @@ export const CardHeader = (
 ) => <div className="card--header">{children}</div>;
 
 export const CardTitle = (
-  { children, title, handleTooltip } //eslint-disable-line
+  { children, title } //eslint-disable-line
 ) => (
-  <span
-    className="card--title"
-    title={title}
-    onMouseEnter={() => handleTooltip(true)}
-    onMouseLeave={() => handleTooltip(false)}
-  >
+  <span className="card--title" title={title}>
     {children}
   </span>
 );

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState, createRef } from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 import { Tooltip, SkeletonText } from 'carbon-components-react';
 import styled from 'styled-components';
 import SizeMe from 'react-sizeme';
+import classNames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 import {
@@ -42,9 +43,14 @@ export const CardHeader = (
 ) => <div className="card--header">{children}</div>;
 
 export const CardTitle = (
-  { children, title } //eslint-disable-line
+  { children, title, handleTooltip } //eslint-disable-line
 ) => (
-  <span className="card--title" title={title}>
+  <span
+    className="card--title"
+    title={title}
+    onMouseEnter={() => handleTooltip(true)}
+    onMouseLeave={() => handleTooltip(false)}
+  >
     {children}
   </span>
 );
@@ -198,6 +204,15 @@ const Card = props => {
     return childSize;
   };
 
+  const elmRef = createRef();
+  const [showTooltip, setshowTooltip] = useState(false);
+  const handleTooltip = IsShow => {
+    const element = elmRef.current;
+    if (element && element.offsetWidth < element.scrollWidth) {
+      setshowTooltip(IsShow);
+    }
+  };
+
   const card = (
     <VisibilitySensor partialVisibility offset={{ top: 10 }}>
       {({ isVisible }) => (
@@ -230,8 +245,23 @@ const Card = props => {
               >
                 {!hideHeader && (
                   <CardHeader>
-                    <CardTitle title={title}>
-                      <span>{title}</span>
+                    <CardTitle handleTooltip={handleTooltip}>
+                      <Tooltip
+                        triggerId={`card-tooltip-trigger-${id}`}
+                        tooltipId={`card-tooltip-${id}`}
+                        triggerClassName={classNames(`card--title-tooltip`, {
+                          'card--title-tooltip-icon': tooltip,
+                        })}
+                        triggerText={
+                          <div ref={elmRef} className="card--title-wrapper">
+                            {title}
+                          </div>
+                        }
+                        showIcon={false}
+                        open={showTooltip}
+                      >
+                        {title}
+                      </Tooltip>
                       {tooltip && (
                         <Tooltip
                           triggerId={`card-tooltip-trigger-${id}`}

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useMemo, useState, createRef } from 'react';
+import React, { useCallback, useMemo, useEffect, useState } from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 import { Tooltip, SkeletonText } from 'carbon-components-react';
 import styled from 'styled-components';
 import SizeMe from 'react-sizeme';
-import classNames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 import {
@@ -205,14 +204,16 @@ const Card = props => {
     return childSize;
   };
 
-  const elmRef = createRef();
-  const [showTooltip, setshowTooltip] = useState(false);
-  const handleTooltip = IsShow => {
-    const element = elmRef.current;
-    if (element && element.offsetWidth < element.scrollWidth) {
-      setshowTooltip(IsShow);
+  // Ensure the title text has a tooltip only if the title text is truncated
+  const titleRef = React.createRef();
+  const [hasTitleTooltip, setHasTitleTooltip] = useState(false);
+  useEffect(() => {
+    if (titleRef.current && titleRef.current.clientWidth < titleRef.current.scrollWidth) {
+      setHasTitleTooltip(true);
+    } else {
+      setHasTitleTooltip(false);
     }
-  };
+  });
 
   const card = (
     <VisibilitySensor partialVisibility offset={{ top: 10 }}>
@@ -246,23 +247,21 @@ const Card = props => {
               >
                 {!hideHeader && (
                   <CardHeader>
-                    <CardTitle handleTooltip={handleTooltip}>
-                      <Tooltip
-                        triggerId={`card-tooltip-trigger-${id}`}
-                        tooltipId={`card-tooltip-${id}`}
-                        triggerClassName={classNames(`card--title-tooltip`, {
-                          'card--title-tooltip-icon': tooltip,
-                        })}
-                        triggerText={
-                          <div ref={elmRef} className="card--title-wrapper">
-                            {title}
-                          </div>
-                        }
-                        showIcon={false}
-                        open={showTooltip}
-                      >
-                        {title}
-                      </Tooltip>
+                    <CardTitle title={title}>
+                      {hasTitleTooltip ? (
+                        <Tooltip
+                          ref={titleRef}
+                          showIcon={false}
+                          triggerClassName="title--text"
+                          triggerText={title}
+                        >
+                          {title}
+                        </Tooltip>
+                      ) : (
+                        <div ref={titleRef} className="title--text">
+                          {title}
+                        </div>
+                      )}
                       {tooltip && (
                         <Tooltip
                           triggerId={`card-tooltip-trigger-${id}`}

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -29,6 +29,28 @@ storiesOf('Watson IoT|Card', module)
       </div>
     );
   })
+  .add('with ellipsed title and tooltip', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <Card
+          title={text(
+            'title',
+            'Card Title that is really long and should be truncated and have a tooltip'
+          )}
+          id="facilitycard-basic"
+          size={size}
+          isLoading={boolean('isLoading', false)}
+          isEmpty={boolean('isEmpty', false)}
+          isEditable={boolean('isEditable', false)}
+          isExpanded={boolean('isExpanded', false)}
+          breakpoint="lg"
+          availableActions={{ range: true, expand: true }}
+          onCardAction={action('onCardAction')}
+        />
+      </div>
+    );
+  })
   .add('basic with render prop', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -56,11 +56,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -233,11 +237,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card with render prop"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card with render prop
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -416,11 +424,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -522,11 +534,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -923,11 +939,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1078,11 +1098,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1210,11 +1234,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1251,11 +1279,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1341,11 +1373,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1431,11 +1467,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1521,11 +1561,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1611,11 +1655,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1701,11 +1749,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1791,11 +1843,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1890,6 +1946,187 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card with ellipsed title and tooltip 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "520px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 SYfLr"
+            id="facilitycard-basic"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                title="Card Title that is really long and should be truncated and have a tooltip"
+              >
+                <div
+                  className="title--text"
+                >
+                  Card Title that is really long and should be truncated and have a tooltip
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              >
+                <div
+                  className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    aria-label="Menu"
+                    className="card--toolbar-action bx--overflow-menu"
+                    onClick={[Function]}
+                    onClose={[Function]}
+                    onKeyDown={[Function]}
+                    open={false}
+                    tabIndex={0}
+                    title="Open and close list of options"
+                  >
+                    <svg
+                      aria-label="open and close list of options"
+                      className="bx--overflow-menu__icon"
+                      focusable="false"
+                      height={20}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                      />
+                      <path
+                        d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                      />
+                      <path
+                        d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                      />
+                      <title>
+                        open and close list of options
+                      </title>
+                    </svg>
+                  </button>
+                </div>
+                <button
+                  className="card--toolbar-action CardToolbar__ToolbarSVGWrapper-sc-1ekh8ti-0 eapGUf"
+                  onClick={[Function]}
+                >
+                  <svg
+                    description="Expand to fullscreen"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    title="Expand to fullscreen"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                    />
+                    <path
+                      d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ioQZbN"
+            />
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card with empty state 1`] = `
 <div
   style={
@@ -1946,11 +2183,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2101,11 +2342,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2232,11 +2477,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Card Title"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Card Title
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -56,8 +56,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -237,8 +235,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card with render prop"
               >
                 <div
@@ -424,8 +420,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -534,8 +528,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -939,8 +931,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1098,8 +1088,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1234,8 +1222,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1279,8 +1265,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1373,8 +1357,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1467,8 +1449,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1561,8 +1541,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1655,8 +1633,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1749,8 +1725,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -1843,8 +1817,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -2002,8 +1974,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title that is really long and should be truncated and have a tooltip"
               >
                 <div
@@ -2183,8 +2153,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -2342,8 +2310,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div
@@ -2477,8 +2443,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Card Title"
               >
                 <div

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -3,19 +3,18 @@
 
 .card {
   &--title {
-    width: 100%;
-    padding-right: $spacing-05;
-    &-wrapper {
+    flex: 1;
+    // min-width value is required to ensure flex child with text properly truncates
+    // https://css-tricks.com/flexbox-truncated-text/
+    min-width: 0;
+    display: flex;
+
+    .title--text {
       @include type-style('productive-heading-01');
+      display: block;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-    }
-    &-tooltip {
-      max-width: 100%;
-      &-icon {
-        max-width: 86%;
-      }
     }
 
     & + * {

--- a/src/components/Card/_card.scss
+++ b/src/components/Card/_card.scss
@@ -3,11 +3,20 @@
 
 .card {
   &--title {
-    display: flex;
-    @include type-style('productive-heading-01');
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    width: 100%;
+    padding-right: $spacing-05;
+    &-wrapper {
+      @include type-style('productive-heading-01');
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    &-tooltip {
+      max-width: 100%;
+      &-icon {
+        max-width: 86%;
+      }
+    }
 
     & + * {
       margin-left: $spacing-05;

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -17,7 +17,8 @@ import Dashboard from './Dashboard';
 
 export const originalCards = [
   {
-    title: 'Facility Metrics',
+    title:
+      'Facility Metrics with a very long title that should be truncated and have a tooltip for the full text ',
     id: 'facilitycard',
     size: CARD_SIZES.SMALL,
     type: CARD_TYPES.VALUE,
@@ -240,7 +241,8 @@ export const originalCards = [
     values: { health: 'Healthy' },
   },
   {
-    title: 'Temperature',
+    title:
+      'Temperature with a very long title that should be truncated and have a tooltip for the full text ',
     id: 'facility-temperature-timeseries',
     size: CARD_SIZES.MEDIUM,
     type: CARD_TYPES.TIMESERIES,

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -63,6 +63,31 @@ export const originalCards = [
     },
   },
   {
+    title: 'Show tooltip when the card title has ellipsis ',
+    id: 'facilitycard-tooltip',
+    size: CARD_SIZES.XSMALL,
+    type: CARD_TYPES.VALUE,
+    availableActions: {
+      delete: true,
+    },
+    content: {
+      attributes: [
+        {
+          dataSourceId: 'humidity',
+          unit: '%',
+          thresholds: [
+            { comparison: '<', value: '40', color: 'red' },
+            { comparison: '<', value: '70', color: 'green' },
+            { comparison: '>=', value: '70', color: 'red' },
+          ],
+        },
+      ],
+    },
+    values: {
+      humidity: 62.1,
+    },
+  },
+  {
     id: 'section-card',
     size: CARD_SIZES.XSMALLWIDE,
     type: CARD_TYPES.CUSTOM,

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -109,8 +109,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -263,8 +261,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
                         <div
@@ -336,8 +332,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Show tooltip when the card title has ellipsis "
                       >
                         <div
@@ -451,8 +445,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
                         <div
@@ -527,8 +519,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
                         <div
@@ -603,8 +593,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
                         <div
@@ -701,8 +689,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
                         <div
@@ -774,8 +760,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -939,8 +923,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -1037,8 +1019,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -1645,8 +1625,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Environment"
                       >
                         <div
@@ -1777,8 +1755,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
                         <div
@@ -2222,8 +2198,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -2376,8 +2350,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
                         <div
@@ -2449,8 +2421,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Show tooltip when the card title has ellipsis "
                       >
                         <div
@@ -2564,8 +2534,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
                         <div
@@ -2640,8 +2608,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
                         <div
@@ -2716,8 +2682,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
                         <div
@@ -2814,8 +2778,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
                         <div
@@ -2887,8 +2849,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -3052,8 +3012,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -3150,8 +3108,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -3758,8 +3714,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Environment"
                       >
                         <div
@@ -3890,8 +3844,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
                         <div
@@ -4367,8 +4319,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -4521,8 +4471,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
                         <div
@@ -4594,8 +4542,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Show tooltip when the card title has ellipsis "
                       >
                         <div
@@ -4709,8 +4655,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
                         <div
@@ -4785,8 +4729,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
                         <div
@@ -4861,8 +4803,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
                         <div
@@ -4959,8 +4899,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
                         <div
@@ -5032,8 +4970,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -5197,8 +5133,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -5295,8 +5229,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -5903,8 +5835,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Environment"
                       >
                         <div
@@ -6035,8 +5965,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
                         <div
@@ -6480,8 +6408,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   >
                     <span
                       className="card--title"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
                       title="Expanded card"
                     >
                       <div
@@ -6692,8 +6618,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Expanded card"
                       >
                         <div
@@ -6980,8 +6904,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   >
                     <span
                       className="card--title"
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
                       title="Expanded card"
                     >
                       <div
@@ -9064,8 +8986,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -9218,8 +9138,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
                         <div
@@ -9291,8 +9209,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Show tooltip when the card title has ellipsis "
                       >
                         <div
@@ -9406,8 +9322,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
                         <div
@@ -9482,8 +9396,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
                         <div
@@ -9558,8 +9470,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
                         <div
@@ -9656,8 +9566,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
                         <div
@@ -9729,8 +9637,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -9894,8 +9800,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -9992,8 +9896,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -10598,8 +10500,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Environment"
                       >
                         <div
@@ -10730,8 +10630,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
                         <div
@@ -11183,8 +11081,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
                           <div
@@ -11256,8 +11152,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
                           <div
@@ -11329,8 +11223,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
                           <div
@@ -11402,8 +11294,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
                           <div
@@ -11475,8 +11365,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
                           <div
@@ -11548,8 +11436,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: false "
                         >
                           <div
@@ -11625,8 +11511,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: true "
                         >
                           <div
@@ -11767,8 +11651,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
                           <div
@@ -11840,8 +11722,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
                           <div
@@ -11913,8 +11793,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
                           <div
@@ -11986,8 +11864,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
                           <div
@@ -12059,8 +11935,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
                           <div
@@ -12132,8 +12006,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: false "
                         >
                           <div
@@ -12209,8 +12081,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: true "
                         >
                           <div
@@ -12351,8 +12221,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -12424,8 +12292,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -12500,8 +12366,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -12573,8 +12437,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -12714,8 +12576,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -12787,8 +12647,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -12863,8 +12721,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -12936,8 +12792,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -13077,8 +12931,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13175,8 +13027,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13273,8 +13123,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13371,8 +13219,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13534,8 +13380,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13632,8 +13476,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13730,8 +13572,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13828,8 +13668,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -13991,8 +13829,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14064,8 +13900,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14137,8 +13971,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14210,8 +14042,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14283,8 +14113,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14421,8 +14249,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14494,8 +14320,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14567,8 +14391,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14640,8 +14462,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14713,8 +14533,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -14851,8 +14669,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
                           <div
@@ -14924,8 +14740,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
                           <div
@@ -14997,8 +14811,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
                           <div
@@ -15070,8 +14882,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
                           <div
@@ -15143,8 +14953,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
                           <div
@@ -15216,8 +15024,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: false "
                         >
                           <div
@@ -15293,8 +15099,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: true "
                         >
                           <div
@@ -15370,8 +15174,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -15443,8 +15245,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -15519,8 +15319,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -15592,8 +15390,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -15668,8 +15464,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -15766,8 +15560,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -15864,8 +15656,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -15962,8 +15752,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -16060,8 +15848,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -16133,8 +15919,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -16206,8 +15990,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -16279,8 +16061,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -16352,8 +16132,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -16490,8 +16268,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
                           <div
@@ -16563,8 +16339,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
                           <div
@@ -16636,8 +16410,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
                           <div
@@ -16709,8 +16481,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
                           <div
@@ -16782,8 +16552,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
                           <div
@@ -16855,8 +16623,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: false "
                         >
                           <div
@@ -16932,8 +16698,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="value: true "
                         >
                           <div
@@ -17009,8 +16773,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -17082,8 +16844,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -17158,8 +16918,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -17231,8 +16989,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
                           <div
@@ -17307,8 +17063,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -17405,8 +17159,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -17503,8 +17255,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -17601,8 +17351,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -17699,8 +17447,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -17772,8 +17518,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -17845,8 +17589,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -17918,8 +17660,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -17991,8 +17731,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -18129,8 +17867,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
                           <div
@@ -18236,8 +17972,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -18343,8 +18077,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -18515,8 +18247,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
                           <div
@@ -18622,8 +18352,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -18729,8 +18457,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -18901,8 +18627,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
                           <div
@@ -19008,8 +18732,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -19115,8 +18837,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -19287,8 +19007,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
                           <div
@@ -19394,8 +19112,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -19501,8 +19217,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
                           <div
@@ -19673,8 +19387,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -19830,8 +19542,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -20052,8 +19762,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -20209,8 +19917,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -20431,8 +20137,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -20585,8 +20289,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -20739,8 +20441,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -21033,8 +20733,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
                           <div
@@ -21187,8 +20885,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -21341,8 +21037,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
                           <div
@@ -21724,8 +21418,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -21878,8 +21570,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
                         <div
@@ -21951,8 +21641,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Show tooltip when the card title has ellipsis "
                       >
                         <div
@@ -22066,8 +21754,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
                         <div
@@ -22142,8 +21828,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
                         <div
@@ -22218,8 +21902,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
                         <div
@@ -22316,8 +21998,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
                         <div
@@ -22389,8 +22069,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -22554,8 +22232,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Health"
                       >
                         <div
@@ -22652,8 +22328,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
                         <div
@@ -23260,8 +22934,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Environment"
                       >
                         <div
@@ -23392,8 +23064,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        onMouseEnter={[Function]}
-                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
                         <div
@@ -24389,8 +24059,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Tutorials"
                         >
                           <div
@@ -24573,8 +24241,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
                           title="Announcements"
                         >
                           <div

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -109,11 +109,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Facility Metrics"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Facility Metrics
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -259,11 +263,88 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Humidity
-                        </span>
+                        </div>
+                      </span>
+                      <div
+                        className="card--toolbar"
+                      />
+                    </div>
+                    <div
+                      className="Card__CardContent-v5r71h-1 cZyqBY"
+                    >
+                      <div
+                        className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+                      >
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="XSMALL"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                            label={null}
+                            size="XSMALL"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
+                              color="green"
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                                size="XSMALL"
+                                title="62.1 %"
+                                value={62.1}
+                              >
+                                62
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                            size="XSMALL"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 HsjmT"
+                    id="facilitycard-tooltip"
+                    style={
+                      Object {
+                        "MozTransform": "translate(490px,16px)",
+                        "OTransform": "translate(490px,16px)",
+                        "WebkitTransform": "translate(490px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(490px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="VALUE"
+                  >
+                    <div
+                      className="card--header"
+                    >
+                      <span
+                        className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Show tooltip when the card title has ellipsis "
+                      >
+                        <div
+                          className="title--text"
+                        >
+                          Show tooltip when the card title has ellipsis 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -322,13 +403,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="section-card"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,16px)",
-                        "OTransform": "translate(490px,16px)",
-                        "WebkitTransform": "translate(490px,16px)",
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,16px)",
+                        "msTransform": "translate(648px,16px)",
                         "position": "absolute",
-                        "transform": "translate(490px,16px)",
+                        "transform": "translate(648px,16px)",
                         "width": "300px",
                       }
                     }
@@ -353,13 +434,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs2"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -370,11 +451,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Utilization
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -425,13 +510,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -442,11 +527,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Alert Count
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -497,13 +586,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(1122px,16px)",
-                        "OTransform": "translate(1122px,16px)",
-                        "WebkitTransform": "translate(1122px,16px)",
+                        "MozTransform": "translate(332px,160px)",
+                        "OTransform": "translate(332px,160px)",
+                        "WebkitTransform": "translate(332px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(1122px,16px)",
+                        "msTransform": "translate(332px,160px)",
                         "position": "absolute",
-                        "transform": "translate(1122px,16px)",
+                        "transform": "translate(332px,160px)",
                         "width": "142px",
                       }
                     }
@@ -514,11 +603,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Comfort Level
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -591,13 +684,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(332px,160px)",
-                        "OTransform": "translate(332px,160px)",
-                        "WebkitTransform": "translate(332px,160px)",
+                        "MozTransform": "translate(490px,160px)",
+                        "OTransform": "translate(490px,160px)",
+                        "WebkitTransform": "translate(490px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(332px,160px)",
+                        "msTransform": "translate(490px,160px)",
                         "position": "absolute",
-                        "transform": "translate(332px,160px)",
+                        "transform": "translate(490px,160px)",
                         "width": "142px",
                       }
                     }
@@ -608,11 +701,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Foot Traffic
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -660,13 +757,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="GaugeCard"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,160px)",
-                        "OTransform": "translate(490px,160px)",
-                        "WebkitTransform": "translate(490px,160px)",
+                        "MozTransform": "translate(648px,160px)",
+                        "OTransform": "translate(648px,160px)",
+                        "WebkitTransform": "translate(648px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,160px)",
+                        "msTransform": "translate(648px,160px)",
                         "position": "absolute",
-                        "transform": "translate(490px,160px)",
+                        "transform": "translate(648px,160px)",
                         "width": "142px",
                       }
                     }
@@ -677,11 +774,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                         <div
                           className="bx--tooltip__label"
                           id="card-tooltip-trigger-GaugeCard"
@@ -821,13 +922,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-health"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,160px)",
-                        "OTransform": "translate(648px,160px)",
-                        "WebkitTransform": "translate(648px,160px)",
+                        "MozTransform": "translate(806px,160px)",
+                        "OTransform": "translate(806px,160px)",
+                        "WebkitTransform": "translate(806px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,160px)",
+                        "msTransform": "translate(806px,160px)",
                         "position": "absolute",
-                        "transform": "translate(648px,160px)",
+                        "transform": "translate(806px,160px)",
                         "width": "300px",
                       }
                     }
@@ -838,11 +939,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -932,11 +1037,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Temperature"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Temperature
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Temperature with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -1536,11 +1645,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Environment"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Environment
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -1664,11 +1777,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Floor Map
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2105,11 +2222,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Facility Metrics"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Facility Metrics
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2255,11 +2376,88 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Humidity
-                        </span>
+                        </div>
+                      </span>
+                      <div
+                        className="card--toolbar"
+                      />
+                    </div>
+                    <div
+                      className="Card__CardContent-v5r71h-1 cZyqBY"
+                    >
+                      <div
+                        className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+                      >
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="XSMALL"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                            label={null}
+                            size="XSMALL"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
+                              color="green"
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                                size="XSMALL"
+                                title="62.1 %"
+                                value={62.1}
+                              >
+                                62
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                            size="XSMALL"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 HsjmT"
+                    id="facilitycard-tooltip"
+                    style={
+                      Object {
+                        "MozTransform": "translate(490px,16px)",
+                        "OTransform": "translate(490px,16px)",
+                        "WebkitTransform": "translate(490px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(490px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="VALUE"
+                  >
+                    <div
+                      className="card--header"
+                    >
+                      <span
+                        className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Show tooltip when the card title has ellipsis "
+                      >
+                        <div
+                          className="title--text"
+                        >
+                          Show tooltip when the card title has ellipsis 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2318,13 +2516,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="section-card"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,16px)",
-                        "OTransform": "translate(490px,16px)",
-                        "WebkitTransform": "translate(490px,16px)",
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,16px)",
+                        "msTransform": "translate(648px,16px)",
                         "position": "absolute",
-                        "transform": "translate(490px,16px)",
+                        "transform": "translate(648px,16px)",
                         "width": "300px",
                       }
                     }
@@ -2349,13 +2547,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs2"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -2366,11 +2564,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Utilization
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2421,13 +2623,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -2438,11 +2640,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Alert Count
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2493,13 +2699,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(1122px,16px)",
-                        "OTransform": "translate(1122px,16px)",
-                        "WebkitTransform": "translate(1122px,16px)",
+                        "MozTransform": "translate(332px,160px)",
+                        "OTransform": "translate(332px,160px)",
+                        "WebkitTransform": "translate(332px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(1122px,16px)",
+                        "msTransform": "translate(332px,160px)",
                         "position": "absolute",
-                        "transform": "translate(1122px,16px)",
+                        "transform": "translate(332px,160px)",
                         "width": "142px",
                       }
                     }
@@ -2510,11 +2716,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Comfort Level
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2587,13 +2797,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(332px,160px)",
-                        "OTransform": "translate(332px,160px)",
-                        "WebkitTransform": "translate(332px,160px)",
+                        "MozTransform": "translate(490px,160px)",
+                        "OTransform": "translate(490px,160px)",
+                        "WebkitTransform": "translate(490px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(332px,160px)",
+                        "msTransform": "translate(490px,160px)",
                         "position": "absolute",
-                        "transform": "translate(332px,160px)",
+                        "transform": "translate(490px,160px)",
                         "width": "142px",
                       }
                     }
@@ -2604,11 +2814,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Foot Traffic
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2656,13 +2870,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="GaugeCard"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,160px)",
-                        "OTransform": "translate(490px,160px)",
-                        "WebkitTransform": "translate(490px,160px)",
+                        "MozTransform": "translate(648px,160px)",
+                        "OTransform": "translate(648px,160px)",
+                        "WebkitTransform": "translate(648px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,160px)",
+                        "msTransform": "translate(648px,160px)",
                         "position": "absolute",
-                        "transform": "translate(490px,160px)",
+                        "transform": "translate(648px,160px)",
                         "width": "142px",
                       }
                     }
@@ -2673,11 +2887,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                         <div
                           className="bx--tooltip__label"
                           id="card-tooltip-trigger-GaugeCard"
@@ -2817,13 +3035,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-health"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,160px)",
-                        "OTransform": "translate(648px,160px)",
-                        "WebkitTransform": "translate(648px,160px)",
+                        "MozTransform": "translate(806px,160px)",
+                        "OTransform": "translate(806px,160px)",
+                        "WebkitTransform": "translate(806px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,160px)",
+                        "msTransform": "translate(806px,160px)",
                         "position": "absolute",
-                        "transform": "translate(648px,160px)",
+                        "transform": "translate(806px,160px)",
                         "width": "300px",
                       }
                     }
@@ -2834,11 +3052,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -2928,11 +3150,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Temperature"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Temperature
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Temperature with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -3532,11 +3758,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Environment"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Environment
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -3660,11 +3890,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Floor Map
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4133,11 +4367,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Facility Metrics"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Facility Metrics
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4283,11 +4521,88 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Humidity
-                        </span>
+                        </div>
+                      </span>
+                      <div
+                        className="card--toolbar"
+                      />
+                    </div>
+                    <div
+                      className="Card__CardContent-v5r71h-1 cZyqBY"
+                    >
+                      <div
+                        className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+                      >
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="XSMALL"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                            label={null}
+                            size="XSMALL"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
+                              color="green"
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                                size="XSMALL"
+                                title="62.1 %"
+                                value={62.1}
+                              >
+                                62
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                            size="XSMALL"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 HsjmT"
+                    id="facilitycard-tooltip"
+                    style={
+                      Object {
+                        "MozTransform": "translate(490px,16px)",
+                        "OTransform": "translate(490px,16px)",
+                        "WebkitTransform": "translate(490px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(490px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="VALUE"
+                  >
+                    <div
+                      className="card--header"
+                    >
+                      <span
+                        className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Show tooltip when the card title has ellipsis "
+                      >
+                        <div
+                          className="title--text"
+                        >
+                          Show tooltip when the card title has ellipsis 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4346,13 +4661,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="section-card"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,16px)",
-                        "OTransform": "translate(490px,16px)",
-                        "WebkitTransform": "translate(490px,16px)",
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,16px)",
+                        "msTransform": "translate(648px,16px)",
                         "position": "absolute",
-                        "transform": "translate(490px,16px)",
+                        "transform": "translate(648px,16px)",
                         "width": "300px",
                       }
                     }
@@ -4377,13 +4692,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs2"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -4394,11 +4709,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Utilization
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4449,13 +4768,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -4466,11 +4785,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Alert Count
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4521,13 +4844,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(1122px,16px)",
-                        "OTransform": "translate(1122px,16px)",
-                        "WebkitTransform": "translate(1122px,16px)",
+                        "MozTransform": "translate(332px,160px)",
+                        "OTransform": "translate(332px,160px)",
+                        "WebkitTransform": "translate(332px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(1122px,16px)",
+                        "msTransform": "translate(332px,160px)",
                         "position": "absolute",
-                        "transform": "translate(1122px,16px)",
+                        "transform": "translate(332px,160px)",
                         "width": "142px",
                       }
                     }
@@ -4538,11 +4861,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Comfort Level
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4615,13 +4942,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(332px,160px)",
-                        "OTransform": "translate(332px,160px)",
-                        "WebkitTransform": "translate(332px,160px)",
+                        "MozTransform": "translate(490px,160px)",
+                        "OTransform": "translate(490px,160px)",
+                        "WebkitTransform": "translate(490px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(332px,160px)",
+                        "msTransform": "translate(490px,160px)",
                         "position": "absolute",
-                        "transform": "translate(332px,160px)",
+                        "transform": "translate(490px,160px)",
                         "width": "142px",
                       }
                     }
@@ -4632,11 +4959,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Foot Traffic
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4684,13 +5015,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="GaugeCard"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,160px)",
-                        "OTransform": "translate(490px,160px)",
-                        "WebkitTransform": "translate(490px,160px)",
+                        "MozTransform": "translate(648px,160px)",
+                        "OTransform": "translate(648px,160px)",
+                        "WebkitTransform": "translate(648px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,160px)",
+                        "msTransform": "translate(648px,160px)",
                         "position": "absolute",
-                        "transform": "translate(490px,160px)",
+                        "transform": "translate(648px,160px)",
                         "width": "142px",
                       }
                     }
@@ -4701,11 +5032,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                         <div
                           className="bx--tooltip__label"
                           id="card-tooltip-trigger-GaugeCard"
@@ -4845,13 +5180,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-health"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,160px)",
-                        "OTransform": "translate(648px,160px)",
-                        "WebkitTransform": "translate(648px,160px)",
+                        "MozTransform": "translate(806px,160px)",
+                        "OTransform": "translate(806px,160px)",
+                        "WebkitTransform": "translate(806px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,160px)",
+                        "msTransform": "translate(806px,160px)",
                         "position": "absolute",
-                        "transform": "translate(648px,160px)",
+                        "transform": "translate(806px,160px)",
                         "width": "300px",
                       }
                     }
@@ -4862,11 +5197,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -4956,11 +5295,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Temperature"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Temperature
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Temperature with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -5560,11 +5903,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Environment"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Environment
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -5688,11 +6035,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Floor Map
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -6129,11 +6480,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   >
                     <span
                       className="card--title"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       title="Expanded card"
                     >
-                      <span>
+                      <div
+                        className="title--text"
+                      >
                         Expanded card
-                      </span>
+                      </div>
                     </span>
                     <div
                       className="card--toolbar"
@@ -6337,11 +6692,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Expanded card"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Expanded card
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -6621,11 +6980,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   >
                     <span
                       className="card--title"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                       title="Expanded card"
                     >
-                      <span>
+                      <div
+                        className="title--text"
+                      >
                         Expanded card
-                      </span>
+                      </div>
                     </span>
                     <div
                       className="card--toolbar"
@@ -8701,11 +9064,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Facility Metrics"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Facility Metrics
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -8851,11 +9218,88 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Humidity
-                        </span>
+                        </div>
+                      </span>
+                      <div
+                        className="card--toolbar"
+                      />
+                    </div>
+                    <div
+                      className="Card__CardContent-v5r71h-1 cZyqBY"
+                    >
+                      <div
+                        className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+                      >
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="XSMALL"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                            label={null}
+                            size="XSMALL"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
+                              color="green"
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                                size="XSMALL"
+                                title="62.1 %"
+                                value={62.1}
+                              >
+                                62
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                            size="XSMALL"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 HsjmT"
+                    id="facilitycard-tooltip"
+                    style={
+                      Object {
+                        "MozTransform": "translate(490px,16px)",
+                        "OTransform": "translate(490px,16px)",
+                        "WebkitTransform": "translate(490px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(490px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="VALUE"
+                  >
+                    <div
+                      className="card--header"
+                    >
+                      <span
+                        className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Show tooltip when the card title has ellipsis "
+                      >
+                        <div
+                          className="title--text"
+                        >
+                          Show tooltip when the card title has ellipsis 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -8914,13 +9358,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="section-card"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,16px)",
-                        "OTransform": "translate(490px,16px)",
-                        "WebkitTransform": "translate(490px,16px)",
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,16px)",
+                        "msTransform": "translate(648px,16px)",
                         "position": "absolute",
-                        "transform": "translate(490px,16px)",
+                        "transform": "translate(648px,16px)",
                         "width": "300px",
                       }
                     }
@@ -8945,13 +9389,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs2"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -8962,11 +9406,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Utilization
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -9017,13 +9465,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -9034,11 +9482,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Alert Count
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -9089,13 +9541,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(1122px,16px)",
-                        "OTransform": "translate(1122px,16px)",
-                        "WebkitTransform": "translate(1122px,16px)",
+                        "MozTransform": "translate(332px,160px)",
+                        "OTransform": "translate(332px,160px)",
+                        "WebkitTransform": "translate(332px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(1122px,16px)",
+                        "msTransform": "translate(332px,160px)",
                         "position": "absolute",
-                        "transform": "translate(1122px,16px)",
+                        "transform": "translate(332px,160px)",
                         "width": "142px",
                       }
                     }
@@ -9106,11 +9558,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Comfort Level
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -9183,13 +9639,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(332px,160px)",
-                        "OTransform": "translate(332px,160px)",
-                        "WebkitTransform": "translate(332px,160px)",
+                        "MozTransform": "translate(490px,160px)",
+                        "OTransform": "translate(490px,160px)",
+                        "WebkitTransform": "translate(490px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(332px,160px)",
+                        "msTransform": "translate(490px,160px)",
                         "position": "absolute",
-                        "transform": "translate(332px,160px)",
+                        "transform": "translate(490px,160px)",
                         "width": "142px",
                       }
                     }
@@ -9200,11 +9656,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Foot Traffic
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -9252,13 +9712,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="GaugeCard"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,160px)",
-                        "OTransform": "translate(490px,160px)",
-                        "WebkitTransform": "translate(490px,160px)",
+                        "MozTransform": "translate(648px,160px)",
+                        "OTransform": "translate(648px,160px)",
+                        "WebkitTransform": "translate(648px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,160px)",
+                        "msTransform": "translate(648px,160px)",
                         "position": "absolute",
-                        "transform": "translate(490px,160px)",
+                        "transform": "translate(648px,160px)",
                         "width": "142px",
                       }
                     }
@@ -9269,11 +9729,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                         <div
                           className="bx--tooltip__label"
                           id="card-tooltip-trigger-GaugeCard"
@@ -9413,13 +9877,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-health"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,160px)",
-                        "OTransform": "translate(648px,160px)",
-                        "WebkitTransform": "translate(648px,160px)",
+                        "MozTransform": "translate(806px,160px)",
+                        "OTransform": "translate(806px,160px)",
+                        "WebkitTransform": "translate(806px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,160px)",
+                        "msTransform": "translate(806px,160px)",
                         "position": "absolute",
-                        "transform": "translate(648px,160px)",
+                        "transform": "translate(806px,160px)",
                         "width": "300px",
                       }
                     }
@@ -9430,11 +9894,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -9524,11 +9992,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Temperature"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Temperature
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Temperature with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -10126,11 +10598,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Environment"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Environment
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -10254,11 +10730,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Floor Map
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -10703,11 +11183,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 13 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -10772,11 +11256,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1352 steps
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -10841,11 +11329,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 103.2 ˚F
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -10910,11 +11402,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 107324.3 kJ
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -10979,11 +11475,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1709384.1 people
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11048,11 +11548,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: false "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: false 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11121,11 +11625,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: true "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: true 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11259,11 +11767,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 13 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11328,11 +11840,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1352 steps
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11397,11 +11913,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 103.2 ˚F
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11466,11 +11986,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 107324.3 kJ
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11535,11 +12059,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1709384.1 people
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11604,11 +12132,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: false "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: false 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11677,11 +12209,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: true "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: true 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11815,11 +12351,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11884,11 +12424,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -11956,11 +12500,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12025,11 +12573,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12162,11 +12714,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12231,11 +12787,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12303,11 +12863,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12372,11 +12936,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12509,11 +13077,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12603,11 +13175,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12697,11 +13273,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12791,11 +13371,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -12950,11 +13534,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13044,11 +13632,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13138,11 +13730,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13232,11 +13828,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13391,11 +13991,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13460,11 +14064,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13529,11 +14137,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13598,11 +14210,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13667,11 +14283,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13801,11 +14421,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13870,11 +14494,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -13939,11 +14567,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14008,11 +14640,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14077,11 +14713,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14211,11 +14851,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 13 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14280,11 +14924,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1352 steps
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14349,11 +14997,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 103.2 ˚F
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14418,11 +15070,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 107324.3 kJ
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14487,11 +15143,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1709384.1 people
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14556,11 +15216,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: false "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: false 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14629,11 +15293,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: true "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: true 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14702,11 +15370,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14771,11 +15443,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14843,11 +15519,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14912,11 +15592,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -14984,11 +15668,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15078,11 +15766,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15172,11 +15864,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15266,11 +15962,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15360,11 +16060,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15429,11 +16133,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15498,11 +16206,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15567,11 +16279,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15636,11 +16352,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15770,11 +16490,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 13 "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 13 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15839,11 +16563,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1352 steps"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1352 steps
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15908,11 +16636,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 103.2 ˚F"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 103.2 ˚F
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -15977,11 +16709,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 107324.3 kJ"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 107324.3 kJ
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16046,11 +16782,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: 1709384.1 people"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: 1709384.1 people
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16115,11 +16855,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: false "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: false 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16188,11 +16932,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="value: true "
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             value: true 
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16261,11 +17009,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16330,11 +17082,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16402,11 +17158,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16471,11 +17231,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Temperature"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Temperature
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16543,11 +17307,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16637,11 +17405,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16731,11 +17503,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16825,11 +17601,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16919,11 +17699,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -16988,11 +17772,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17057,11 +17845,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17126,11 +17918,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17195,11 +17991,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17329,11 +18129,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 89.2%, 76 mb
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17432,11 +18236,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17535,11 +18343,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17703,11 +18515,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 89.2%, 76 mb
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17806,11 +18622,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -17909,11 +18729,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18077,11 +18901,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 89.2%, 76 mb
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18180,11 +19008,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18283,11 +19115,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18451,11 +19287,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 89.2%, 76 mb"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 89.2%, 76 mb
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18554,11 +19394,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18657,11 +19501,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="values: 88.3˚F, Elevated"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             values: 88.3˚F, Elevated
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18825,11 +19673,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -18978,11 +19830,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -19196,11 +20052,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -19349,11 +20209,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -19567,11 +20431,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -19717,11 +20585,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -19867,11 +20739,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -20157,11 +21033,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Humidity"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Humidity
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -20307,11 +21187,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -20457,11 +21341,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Danger Level"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Danger Level
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -20836,11 +21724,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Facility Metrics"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Facility Metrics with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Facility Metrics
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Facility Metrics with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -20986,11 +21878,88 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Humidity"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Humidity
-                        </span>
+                        </div>
+                      </span>
+                      <div
+                        className="card--toolbar"
+                      />
+                    </div>
+                    <div
+                      className="Card__CardContent-v5r71h-1 cZyqBY"
+                    >
+                      <div
+                        className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+                      >
+                        <div
+                          className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                          size="XSMALL"
+                        >
+                          <div
+                            className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                            label={null}
+                            size="XSMALL"
+                          >
+                            <div
+                              className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
+                              color="green"
+                            >
+                              <span
+                                className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                                size="XSMALL"
+                                title="62.1 %"
+                                value={62.1}
+                              >
+                                62
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                            size="XSMALL"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 HsjmT"
+                    id="facilitycard-tooltip"
+                    style={
+                      Object {
+                        "MozTransform": "translate(490px,16px)",
+                        "OTransform": "translate(490px,16px)",
+                        "WebkitTransform": "translate(490px,16px)",
+                        "height": "128px",
+                        "msTransform": "translate(490px,16px)",
+                        "position": "absolute",
+                        "transform": "translate(490px,16px)",
+                        "width": "142px",
+                      }
+                    }
+                    type="VALUE"
+                  >
+                    <div
+                      className="card--header"
+                    >
+                      <span
+                        className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Show tooltip when the card title has ellipsis "
+                      >
+                        <div
+                          className="title--text"
+                        >
+                          Show tooltip when the card title has ellipsis 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -21049,13 +22018,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="section-card"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,16px)",
-                        "OTransform": "translate(490px,16px)",
-                        "WebkitTransform": "translate(490px,16px)",
+                        "MozTransform": "translate(648px,16px)",
+                        "OTransform": "translate(648px,16px)",
+                        "WebkitTransform": "translate(648px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,16px)",
+                        "msTransform": "translate(648px,16px)",
                         "position": "absolute",
-                        "transform": "translate(490px,16px)",
+                        "transform": "translate(648px,16px)",
                         "width": "300px",
                       }
                     }
@@ -21080,13 +22049,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs2"
                     style={
                       Object {
-                        "MozTransform": "translate(806px,16px)",
-                        "OTransform": "translate(806px,16px)",
-                        "WebkitTransform": "translate(806px,16px)",
+                        "MozTransform": "translate(964px,16px)",
+                        "OTransform": "translate(964px,16px)",
+                        "WebkitTransform": "translate(964px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(806px,16px)",
+                        "msTransform": "translate(964px,16px)",
                         "position": "absolute",
-                        "transform": "translate(806px,16px)",
+                        "transform": "translate(964px,16px)",
                         "width": "142px",
                       }
                     }
@@ -21097,11 +22066,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Utilization"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Utilization
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -21152,13 +22125,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs3"
                     style={
                       Object {
-                        "MozTransform": "translate(964px,16px)",
-                        "OTransform": "translate(964px,16px)",
-                        "WebkitTransform": "translate(964px,16px)",
+                        "MozTransform": "translate(1122px,16px)",
+                        "OTransform": "translate(1122px,16px)",
+                        "WebkitTransform": "translate(1122px,16px)",
                         "height": "128px",
-                        "msTransform": "translate(964px,16px)",
+                        "msTransform": "translate(1122px,16px)",
                         "position": "absolute",
-                        "transform": "translate(964px,16px)",
+                        "transform": "translate(1122px,16px)",
                         "width": "142px",
                       }
                     }
@@ -21169,11 +22142,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Alert Count"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Alert Count
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -21224,13 +22201,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-comfort-level"
                     style={
                       Object {
-                        "MozTransform": "translate(1122px,16px)",
-                        "OTransform": "translate(1122px,16px)",
-                        "WebkitTransform": "translate(1122px,16px)",
+                        "MozTransform": "translate(332px,160px)",
+                        "OTransform": "translate(332px,160px)",
+                        "WebkitTransform": "translate(332px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(1122px,16px)",
+                        "msTransform": "translate(332px,160px)",
                         "position": "absolute",
-                        "transform": "translate(1122px,16px)",
+                        "transform": "translate(332px,160px)",
                         "width": "142px",
                       }
                     }
@@ -21241,11 +22218,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Comfort Level"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Comfort Level
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -21318,13 +22299,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-xs4"
                     style={
                       Object {
-                        "MozTransform": "translate(332px,160px)",
-                        "OTransform": "translate(332px,160px)",
-                        "WebkitTransform": "translate(332px,160px)",
+                        "MozTransform": "translate(490px,160px)",
+                        "OTransform": "translate(490px,160px)",
+                        "WebkitTransform": "translate(490px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(332px,160px)",
+                        "msTransform": "translate(490px,160px)",
                         "position": "absolute",
-                        "transform": "translate(332px,160px)",
+                        "transform": "translate(490px,160px)",
                         "width": "142px",
                       }
                     }
@@ -21335,11 +22316,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Foot Traffic"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Foot Traffic
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -21387,13 +22372,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="GaugeCard"
                     style={
                       Object {
-                        "MozTransform": "translate(490px,160px)",
-                        "OTransform": "translate(490px,160px)",
-                        "WebkitTransform": "translate(490px,160px)",
+                        "MozTransform": "translate(648px,160px)",
+                        "OTransform": "translate(648px,160px)",
+                        "WebkitTransform": "translate(648px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(490px,160px)",
+                        "msTransform": "translate(648px,160px)",
                         "position": "absolute",
-                        "transform": "translate(490px,160px)",
+                        "transform": "translate(648px,160px)",
                         "width": "142px",
                       }
                     }
@@ -21404,11 +22389,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                         <div
                           className="bx--tooltip__label"
                           id="card-tooltip-trigger-GaugeCard"
@@ -21548,13 +22537,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     id="facilitycard-health"
                     style={
                       Object {
-                        "MozTransform": "translate(648px,160px)",
-                        "OTransform": "translate(648px,160px)",
-                        "WebkitTransform": "translate(648px,160px)",
+                        "MozTransform": "translate(806px,160px)",
+                        "OTransform": "translate(806px,160px)",
+                        "WebkitTransform": "translate(806px,160px)",
                         "height": "128px",
-                        "msTransform": "translate(648px,160px)",
+                        "msTransform": "translate(806px,160px)",
                         "position": "absolute",
-                        "transform": "translate(648px,160px)",
+                        "transform": "translate(806px,160px)",
                         "width": "300px",
                       }
                     }
@@ -21565,11 +22554,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Health"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Health
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -21659,11 +22652,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
-                        title="Temperature"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        title="Temperature with a very long title that should be truncated and have a tooltip for the full text "
                       >
-                        <span>
-                          Temperature
-                        </span>
+                        <div
+                          className="title--text"
+                        >
+                          Temperature with a very long title that should be truncated and have a tooltip for the full text 
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -22263,11 +23260,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Environment"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Environment
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -22391,11 +23392,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     >
                       <span
                         className="card--title"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
                         title="Floor Map"
                       >
-                        <span>
+                        <div
+                          className="title--text"
+                        >
                           Floor Map
-                        </span>
+                        </div>
                       </span>
                       <div
                         className="card--toolbar"
@@ -23384,11 +24389,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Tutorials"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Tutorials
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"
@@ -23564,11 +24573,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <span
                           className="card--title"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
                           title="Announcements"
                         >
-                          <span>
+                          <div
+                            className="title--text"
+                          >
                             Announcements
-                          </span>
+                          </div>
                         </span>
                         <div
                           className="card--toolbar"

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -85,8 +85,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Facility Metrics"
                   >
                     <div
@@ -126,8 +124,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Humidity"
                   >
                     <div
@@ -167,8 +163,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Utilization"
                   >
                     <div
@@ -302,8 +296,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Facility Metrics"
                   >
                     <div
@@ -343,8 +335,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Humidity"
                   >
                     <div
@@ -384,8 +374,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Utilization"
                   >
                     <div
@@ -524,8 +512,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Facility Metrics"
                   >
                     <div
@@ -570,8 +556,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Humidity"
                   >
                     <div
@@ -616,8 +600,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
                     title="Utilization"
                   >
                     <div

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -85,11 +85,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Facility Metrics"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Facility Metrics
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -122,11 +126,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Humidity"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Humidity
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -159,11 +167,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Utilization"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Utilization
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -290,11 +302,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Facility Metrics"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Facility Metrics
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -327,11 +343,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Humidity"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Humidity
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -364,11 +384,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Utilization"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Utilization
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -500,11 +524,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Facility Metrics"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Facility Metrics
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -542,11 +570,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Humidity"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Humidity
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"
@@ -584,11 +616,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                 >
                   <span
                     className="card--title"
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                     title="Utilization"
                   >
-                    <span>
+                    <div
+                      className="title--text"
+                    >
                       Utilization
-                    </span>
+                    </div>
                   </span>
                   <div
                     className="card--toolbar"

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -56,11 +56,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Image"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Image
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -433,11 +437,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Image"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Image
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -824,11 +832,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Image"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Image
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -959,11 +971,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Image"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Image
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1094,11 +1110,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Image"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Image
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1355,11 +1375,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Image"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Image
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"

--- a/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
+++ b/src/components/ImageCard/__snapshots__/ImageCard.story.storyshot
@@ -56,8 +56,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Image"
               >
                 <div
@@ -437,8 +435,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Image"
               >
                 <div
@@ -832,8 +828,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Image"
               >
                 <div
@@ -971,8 +965,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Image"
               >
                 <div
@@ -1110,8 +1102,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Image"
               >
                 <div
@@ -1375,8 +1365,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Image
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Image"
               >
                 <div

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -56,11 +56,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -165,11 +169,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -274,11 +282,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -383,11 +395,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -489,11 +505,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -598,11 +618,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -707,11 +731,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -816,11 +844,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -925,11 +957,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1034,11 +1070,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1143,11 +1183,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1252,11 +1296,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1361,11 +1409,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1470,11 +1522,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Pressure"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Pressure
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1579,11 +1635,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1688,11 +1748,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1797,11 +1861,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1906,11 +1974,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2015,11 +2087,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2124,11 +2200,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2233,11 +2313,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2342,11 +2426,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2451,11 +2539,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2560,11 +2652,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2669,11 +2765,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2778,11 +2878,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2887,11 +2991,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2996,11 +3104,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3105,11 +3217,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3214,11 +3330,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3323,11 +3443,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3432,11 +3556,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3541,11 +3669,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3650,11 +3782,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3759,11 +3895,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3868,11 +4008,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -4032,11 +4176,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Temperature"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Temperature
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -56,8 +56,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -169,8 +167,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -282,8 +278,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -395,8 +389,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -505,8 +497,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -618,8 +608,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -731,8 +719,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -844,8 +830,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -957,8 +941,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1070,8 +1052,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1183,8 +1163,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1296,8 +1274,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1409,8 +1385,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1522,8 +1496,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Pressure"
               >
                 <div
@@ -1635,8 +1607,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1748,8 +1718,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1861,8 +1829,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -1974,8 +1940,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2087,8 +2051,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2200,8 +2162,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2313,8 +2273,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2426,8 +2384,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2539,8 +2495,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2652,8 +2606,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2765,8 +2717,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2878,8 +2828,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -2991,8 +2939,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3104,8 +3050,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3217,8 +3161,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3330,8 +3272,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3443,8 +3383,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3556,8 +3494,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3669,8 +3605,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3782,8 +3716,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -3895,8 +3827,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -4008,8 +3938,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div
@@ -4176,8 +4104,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Temperature"
               >
                 <div

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -56,11 +56,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions per device"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions per device
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -231,11 +235,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Really really really long card title?"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Really really really long card title?
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -406,11 +414,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -512,11 +524,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -804,11 +820,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Really long card title?"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Really long card title?
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -940,11 +960,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Really really really long card title?"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Really really really long card title?
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1115,11 +1139,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1329,11 +1357,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1504,11 +1536,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1679,11 +1715,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -1943,11 +1983,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2157,11 +2201,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2293,11 +2341,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2663,11 +2715,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Facility Conditions
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -2877,11 +2933,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Uncomfortable?"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Uncomfortable?
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3017,11 +3077,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Occupancy"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Occupancy
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3150,11 +3214,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Occupancy"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Occupancy
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3283,11 +3351,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Alert Count"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Alert Count
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3449,11 +3521,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Alert Count"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Alert Count
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3607,11 +3683,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Alert Count"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Alert Count
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3740,11 +3820,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Foot Traffic"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Foot Traffic
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -3876,11 +3960,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Foot Traffic"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Foot Traffic
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -4009,11 +4097,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Alert Count"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Alert Count
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -4142,11 +4234,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Occupancy"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Occupancy
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -4275,11 +4371,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Status"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Status
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -4442,11 +4542,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Status"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Status
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"
@@ -4600,11 +4704,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 title="Status"
               >
-                <span>
+                <div
+                  className="title--text"
+                >
                   Status
-                </span>
+                </div>
               </span>
               <div
                 className="card--toolbar"

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -56,8 +56,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions per device"
               >
                 <div
@@ -235,8 +233,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Really really really long card title?"
               >
                 <div
@@ -414,8 +410,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -524,8 +518,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -820,8 +812,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Really long card title?"
               >
                 <div
@@ -960,8 +950,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Really really really long card title?"
               >
                 <div
@@ -1139,8 +1127,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -1357,8 +1343,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -1536,8 +1520,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -1715,8 +1697,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -1983,8 +1963,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -2201,8 +2179,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -2341,8 +2317,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -2715,8 +2689,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Facility Conditions"
               >
                 <div
@@ -2933,8 +2905,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Uncomfortable?"
               >
                 <div
@@ -3077,8 +3047,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Occupancy"
               >
                 <div
@@ -3214,8 +3182,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Occupancy"
               >
                 <div
@@ -3351,8 +3317,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Alert Count"
               >
                 <div
@@ -3521,8 +3485,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Alert Count"
               >
                 <div
@@ -3683,8 +3645,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Alert Count"
               >
                 <div
@@ -3820,8 +3780,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Foot Traffic"
               >
                 <div
@@ -3960,8 +3918,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Foot Traffic"
               >
                 <div
@@ -4097,8 +4053,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Alert Count"
               >
                 <div
@@ -4234,8 +4188,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Occupancy"
               >
                 <div
@@ -4371,8 +4323,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Status"
               >
                 <div
@@ -4542,8 +4492,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Status"
               >
                 <div
@@ -4704,8 +4652,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
             >
               <span
                 className="card--title"
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
                 title="Status"
               >
                 <div


### PR DESCRIPTION
Closes #

**Summary**

Allow to showing tooltip on mouse hover when the card title has ellipsis

**Change List (commits, features, bugs, etc)**

src/components/Card/Card.jsx
src/components/Card/_card.scss
src/components/Dashboard/Dashboard.story.jsx


**Acceptance Test (how to verify the PR)**

Showing tooltip when the card title has text overflow has ellipsis
