### PR TITLE
fix(dashboardgrid): 6277-Dashboard-Grid-Tile-Jump

### DIFF
--- a/src/components/Dashboard/DashboardGrid.jsx
+++ b/src/components/Dashboard/DashboardGrid.jsx
@@ -163,11 +163,14 @@ const DashboardGrid = ({
   );
 
   const [animationState, setAnimationState] = useState(false);
-  useEffect(() => {
-    setTimeout(() => {
-      setAnimationState(true);
-    }, 1000);
-  }, []);
+  useEffect(
+    () => {
+      requestAnimationFrame(() => {
+        setAnimationState(isEditable);
+      });
+    },
+    [isEditable]
+  );
 
   return (
     <div style={{ flex: 1 }}>

--- a/src/components/Dashboard/DashboardGrid.jsx
+++ b/src/components/Dashboard/DashboardGrid.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Responsive, WidthProvider } from 'react-grid-layout';
 import styled from 'styled-components';
@@ -162,6 +162,13 @@ const DashboardGrid = ({
     [childrenArray]
   );
 
+  const [animationState, setAnimationState] = useState(false);
+  useEffect(() => {
+    setTimeout(() => {
+      setAnimationState(true);
+    }, 1000);
+  }, []);
+
   return (
     <div style={{ flex: 1 }}>
       <StyledGridLayout
@@ -173,7 +180,7 @@ const DashboardGrid = ({
         rowHeight={ROW_HEIGHT[breakpoint]}
         preventCollision={false}
         // Stop the initial animation unless we need to support editing drag-and-drop
-        shouldAnimate={isEditable}
+        shouldAnimate={animationState}
         onLayoutChange={handleLayoutChange}
         onBreakpointChange={onBreakpointChange}
         isResizable={false}

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -465,7 +465,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
             }
           >
             <div
-              className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 fKgkDF"
+              className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 hTrCDO"
               style={
                 Object {
                   "height": "304px",


### PR DESCRIPTION
Closes #780 

**Summary**

Dashboard Grid (dashboard,isEditable) : Tiles on dashboard grid is jump (animated) while rending the page.

**Change List (commits, features, bugs, etc)**

src/components/Dashboard/DashboardGrid.jsx
src/components/Dashboard/snapshots/DashboardGrid.story.storyshot

**Acceptance Test (how to verify the PR)**

Click on Dashboard (dashboard,isEditable) link, Dashboard tiles should be rendering static without animation
