### PR TITLE
fix(tableCard): add size validation

### DIFF
--- a/src/components/Card/CardToolbar.jsx
+++ b/src/components/Card/CardToolbar.jsx
@@ -11,6 +11,7 @@ import CardRangePicker, { CardRangePickerPropTypes } from './CardRangePicker';
 
 export const ToolbarSVGWrapper = styled.button`
   &&& {
+    align-items: center;
     background: transparent;
     border: none;
     display: flex;

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -16,6 +16,12 @@ import { generateTableSampleValues } from '../TimeSeriesCard/timeSeriesUtils';
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import CardToolbar from '../Card/CardToolbar';
 
+const ContentWrapper = styled.div`
+  height: 100%;
+  max-height: 100%;
+  padding: 0 16px 16px 16px;
+`;
+
 const StyledOverflowMenu = styled(OverflowMenu)`
   &&& {
     margin-left: 10px;
@@ -689,6 +695,12 @@ const TableCard = ({
     ? columnsToRender.find(item => item.priority === 1)
     : columnStartSortDefined;
 
+  const supportedSizes = [
+    CARD_SIZES.LARGE,
+    CARD_SIZES.XLARGE,
+  ];
+  const supportedSize = supportedSizes.includes(size);
+
   const cardToolbar = (
     <CardToolbar
       availableActions={{ expand: isExpandable, range: true }}
@@ -711,8 +723,9 @@ const TableCard = ({
       i18n={i18n}
       hideHeader
       {...others}
-    >
-      {({ height }) => {
+    > 
+      {supportedSize ?
+      ({ height }) => {
         const numberOfRowsPerPage = !isNil(height) ? Math.floor((height - 48 * 3) / 48) : 10;
         return (
           <StyledStatefulTable
@@ -771,7 +784,10 @@ const TableCard = ({
             i18n={i18n} // TODO: add Card defaultprops ?
           />
         );
-      }}
+      } :
+      <ContentWrapper>
+        <p>Size not supported.</p>
+      </ContentWrapper>}
     </Card>
   );
 };


### PR DESCRIPTION
Closes #755 

**Summary**

Added a size validation to not allow card sizes smaller than 'LARGE'.

Here is the 'TALL' size:
<img width="1144" alt="TableCardTall" src="https://user-images.githubusercontent.com/53092833/74273044-5b327580-4cd5-11ea-8965-588ba690f96e.png">

Here is 'TALL' size after size validation:
<img width="1461" alt="TableCardSizeNotSupported" src="https://user-images.githubusercontent.com/53092833/74273185-a187d480-4cd5-11ea-9ea0-d14a7479b009.png">

**Change List (commits, features, bugs, etc)**

src/components/Card/CardToolbar.jsx
src/components/TableCard/TableCard.jsx

**Acceptance Test (how to verify the PR)**

Test any size other than the supported 'LARGE' and 'XLARGE'
