### PR TITLE
fix(timeseries): generate sample values needs to use dataFilter

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -55,7 +55,7 @@ export const CardContent = styled.div`
   position: relative;
   height: ${props => props.dimensions.y - CARD_TITLE_HEIGHT}px;
   overflow-x: visible;
-  overflow-y: visible;
+  overflow-y: ${props => (!props.isExpanded ? 'visible' : 'auto')};
 `;
 
 export const SkeletonWrapper = styled.div`
@@ -246,7 +246,7 @@ const Card = props => {
                     {cardToolbar}
                   </CardHeader>
                 )}
-                <CardContent dimensions={dimensions}>
+                <CardContent dimensions={dimensions} isExpanded={isExpanded}>
                   {!isVisible && isLazyLoading ? ( // if not visible don't show anything
                     ''
                   ) : isLoading ? (

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -1145,6 +1145,7 @@ storiesOf('Watson IoT|TimeSeriesCard', module)
           title={text('title', 'Temperature')}
           key="dataFilter"
           id="facility-temperature"
+          isEditable={boolean('isEditable', false)}
           isLoading={boolean('isLoading', false)}
           content={object('content', {
             series: [
@@ -1169,7 +1170,6 @@ storiesOf('Watson IoT|TimeSeriesCard', module)
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature'),
             timeDataSourceId: 'timestamp',
-            chartType: TIME_SERIES_TYPES.BAR,
           })}
           values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100).reduce(
             (acc, dataPoint) => {

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -51,6 +51,20 @@ describe('timeSeriesUtils', () => {
     expect(sampleValues[0].temperature).toBeDefined();
     expect(sampleValues[0].pressure).toBeDefined();
   });
+  test('generateSampleValues with data Filters', () => {
+    const sampleValues = generateSampleValues(
+      [
+        { dataSourceId: 'temperature', dataFilter: { severity: 5 } },
+        { dataSourceId: 'temperature', dataFilter: { severity: 3 } },
+      ],
+      'timestamp'
+    );
+    expect(sampleValues).toHaveLength(14);
+    expect(sampleValues[0].temperature).toBeDefined();
+    expect(sampleValues[0].severity).toEqual(5);
+    expect(sampleValues[7].temperature).toBeDefined();
+    expect(sampleValues[7].severity).toEqual(3);
+  });
   test('generateSampleValues hour', () => {
     const sampleValues = generateSampleValues(
       [{ dataSourceId: 'temperature' }, { dataSourceId: 'pressure' }],
@@ -86,7 +100,7 @@ describe('timeSeriesUtils', () => {
     const sampleValues5 = generateSampleValues(
       [{ dataSourceId: 'temperature' }, { dataSourceId: 'pressure' }],
       'timestamp',
-      'other'
+      'day'
     );
     expect(sampleValues5).toHaveLength(7);
   });


### PR DESCRIPTION
Closes #

**Summary**

- Now that we support dataFilters being attached to each line, we need to generate extra data to match each dataFilter

**Change List (commits, features, bugs, etc)**

- fix(timeSeriesUtils): need to generate a row of data for each unique dataFilter.  If they leave off the dataFilter, than find the existing row and update it.

**Acceptance Test (how to verify the PR)**

- I added a new isEditable bit to the dataFilter TimeSeriesCard story so you could test this.  It used to be when you set the card to isEditable, the card would show empty because no data would match it's filters.  Now it is showing sample data correctly

![image](https://user-images.githubusercontent.com/6663002/74288855-29300c00-4cf3-11ea-86e0-f398528dae3d.png)


