### PR TITLE
feat(timeseriescard): allow multiple alerts to match the same timeseries datapoint

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -55,7 +55,7 @@ export const CardContent = styled.div`
   position: relative;
   height: ${props => props.dimensions.y - CARD_TITLE_HEIGHT}px;
   overflow-x: visible;
-  overflow-y: visible;
+  overflow-y: ${props => (!props.isExpanded ? 'visible' : 'auto')};
 `;
 
 export const SkeletonWrapper = styled.div`
@@ -246,7 +246,7 @@ const Card = props => {
                     {cardToolbar}
                   </CardHeader>
                 )}
-                <CardContent dimensions={dimensions}>
+                <CardContent dimensions={dimensions} isExpanded={isExpanded}>
                   {!isVisible && isLazyLoading ? ( // if not visible don't show anything
                     ''
                   ) : isLoading ? (

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1029,7 +1029,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="MEDIUM"
                       >
                         <div
@@ -1633,7 +1633,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="LARGE"
                       >
                         <div
@@ -3025,7 +3025,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="MEDIUM"
                       >
                         <div
@@ -3629,7 +3629,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="LARGE"
                       >
                         <div
@@ -5053,7 +5053,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="MEDIUM"
                       >
                         <div
@@ -5657,7 +5657,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="LARGE"
                       >
                         <div
@@ -6172,7 +6172,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     className="Card__CardContent-v5r71h-1 eebKIM"
                   >
                     <div
-                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                       size="LARGE"
                     >
                       <div
@@ -6664,7 +6664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     className="Card__CardContent-v5r71h-1 eebKIM"
                   >
                     <div
-                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                       size="LARGE"
                     >
                       <div
@@ -9621,7 +9621,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="MEDIUM"
                       >
                         <div
@@ -10223,7 +10223,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="LARGE"
                       >
                         <div
@@ -21756,7 +21756,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="MEDIUM"
                       >
                         <div
@@ -22360,7 +22360,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                         size="LARGE"
                       >
                         <div

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1112,7 +1112,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="MEDIUM"
                       >
                         <div
@@ -1737,7 +1737,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="LARGE"
                       >
                         <div
@@ -3214,7 +3214,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="MEDIUM"
                       >
                         <div
@@ -3839,7 +3839,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="LARGE"
                       >
                         <div
@@ -5348,7 +5348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="MEDIUM"
                       >
                         <div
@@ -5973,7 +5973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="LARGE"
                       >
                         <div
@@ -6492,7 +6492,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     className="Card__CardContent-v5r71h-1 eebKIM"
                   >
                     <div
-                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                       size="LARGE"
                     >
                       <div
@@ -6988,7 +6988,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     className="Card__CardContent-v5r71h-1 eebKIM"
                   >
                     <div
-                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                      className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                       size="LARGE"
                     >
                       <div
@@ -10006,7 +10006,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="MEDIUM"
                       >
                         <div
@@ -10629,7 +10629,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="LARGE"
                       >
                         <div
@@ -22451,7 +22451,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 bfMykM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="MEDIUM"
                       >
                         <div
@@ -23076,7 +23076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       className="Card__CardContent-v5r71h-1 eebKIM"
                     >
                       <div
-                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                        className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                         size="LARGE"
                       >
                         <div

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -13,7 +13,7 @@ import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
-import { CARD_SIZES, TIME_SERIES_TYPES } from '../../constants/LayoutConstants';
+import { CARD_SIZES, TIME_SERIES_TYPES, DISABLED_COLORS } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
 import StatefulTable from '../Table/StatefulTable';
 
@@ -57,7 +57,6 @@ const LineChartWrapper = styled.div`
       width: 100%;
       height: 100%;
       circle.dot.unfilled {
-        stroke-opacity: ${props => (props.isEditable ? '1' : '')};
         opacity: ${props => (props.numberOfPoints > 50 ? '0' : '1')};
       }
     }
@@ -252,7 +251,11 @@ const TimeSeriesCard = ({
   );
 
   const lines = useMemo(
-    () => series.map(line => ({ ...line, color: !isEditable ? line.color : 'gray' })),
+    () =>
+      series.map((line, index) => ({
+        ...line,
+        color: !isEditable ? line.color : DISABLED_COLORS[index % DISABLED_COLORS.length],
+      })),
     [isEditable, series]
   );
 
@@ -265,12 +268,13 @@ const TimeSeriesCard = ({
   };
 
   const handleFillColor = (datasetLabel, label, data, originalFillColor) => {
+    // If it's editable don't fill the dot
     const defaultFillColor = !isEditable ? originalFillColor : '#f3f3f3';
     if (!isNil(data)) {
       const matchingAlertRange = findMatchingAlertRange(alertRanges, data);
       return matchingAlertRange?.length > 0 ? matchingAlertRange[0].color : defaultFillColor;
     }
-    // If it's editable don't fill the dot
+
     return defaultFillColor;
   };
 

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -58,8 +58,6 @@ const LineChartWrapper = styled.div`
       height: 100%;
       circle.dot.unfilled {
         stroke-opacity: ${props => (props.isEditable ? '1' : '')};
-      }
-      circle.dot.unfilled {
         opacity: ${props => (props.numberOfPoints > 50 ? '0' : '1')};
       }
     }
@@ -157,21 +155,28 @@ export const handleTooltip = (dataOrHoveredElement, defaultTooltip, alertRanges,
         'L HH:mm:ss'
       )}</p></li>`
     : '';
-  const matchingAlertRange = findMatchingAlertRange(alertRanges, data);
-  const matchingAlertLabel = matchingAlertRange
-    ? `<li class='datapoint-tooltip'><p class='label'>${alertDetected} ${
-        matchingAlertRange.details
-      }</p></li>`
+  const matchingAlertRanges = findMatchingAlertRange(alertRanges, data);
+  const matchingAlertLabels = Array.isArray(matchingAlertRanges)
+    ? matchingAlertRanges
+        .map(
+          matchingAlertRange =>
+            `<li class='datapoint-tooltip'><a style="background-color:${
+              matchingAlertRange.color
+            }" class="tooltip-color"></a><p class='label'>${alertDetected} ${
+              matchingAlertRange.details
+            }</p></li>`
+        )
+        .join('')
     : '';
   let updatedTooltip = defaultTooltip;
   if (Array.isArray(data)) {
     // prepend the date inside the existing multi tooltip
     updatedTooltip = defaultTooltip
       .replace('<li', `${dateLabel}<li`)
-      .replace('</ul', `${matchingAlertLabel}</ul`);
+      .replace('</ul', `${matchingAlertLabels}</ul`);
   } else {
     // wrap to make single a multi-tooltip
-    updatedTooltip = `<ul class='multi-tooltip'>${dateLabel}<li>${defaultTooltip}</li>${matchingAlertLabel}</ul>`;
+    updatedTooltip = `<ul class='multi-tooltip'>${dateLabel}<li>${defaultTooltip}</li>${matchingAlertLabels}</ul>`;
   }
   return updatedTooltip;
 };
@@ -254,7 +259,7 @@ const TimeSeriesCard = ({
   const handleStrokeColor = (datasetLabel, label, data, originalStrokeColor) => {
     if (!isNil(data)) {
       const matchingAlertRange = findMatchingAlertRange(alertRanges, data);
-      return matchingAlertRange ? matchingAlertRange.color : originalStrokeColor;
+      return matchingAlertRange?.length > 0 ? matchingAlertRange[0].color : originalStrokeColor;
     }
     return originalStrokeColor;
   };
@@ -263,7 +268,7 @@ const TimeSeriesCard = ({
     const defaultFillColor = !isEditable ? originalFillColor : '#f3f3f3';
     if (!isNil(data)) {
       const matchingAlertRange = findMatchingAlertRange(alertRanges, data);
-      return matchingAlertRange ? matchingAlertRange.color : defaultFillColor;
+      return matchingAlertRange?.length > 0 ? matchingAlertRange[0].color : defaultFillColor;
     }
     // If it's editable don't fill the dot
     return defaultFillColor;
@@ -272,7 +277,7 @@ const TimeSeriesCard = ({
   const handleIsFilled = (datasetLabel, label, data, isFilled) => {
     if (!isNil(data)) {
       const matchingAlertRange = findMatchingAlertRange(alertRanges, data);
-      return matchingAlertRange ? true : isFilled;
+      return matchingAlertRange?.length > 0 ? true : isFilled;
     }
 
     return isFilled;

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -993,7 +993,7 @@ storiesOf('Watson IoT|TimeSeriesCard', module)
                 details: 'Alert name',
               },
               {
-                startTimestamp: 1572804320000,
+                startTimestamp: 1572313622000,
                 endTimestamp: 1572824320000,
                 color: '#FFFF00',
                 details: 'Less severe',

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -70,7 +70,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="XLARGE"
               >
                 <div
@@ -179,7 +179,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -288,7 +288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -503,7 +503,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -612,7 +612,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -721,7 +721,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 esQSiJ"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 jHYuJR"
                 size="LARGE"
               >
                 <div
@@ -830,7 +830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -939,7 +939,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1048,7 +1048,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1157,7 +1157,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1266,7 +1266,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1375,7 +1375,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1484,7 +1484,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1593,7 +1593,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1702,7 +1702,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1811,7 +1811,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -1920,7 +1920,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -2029,7 +2029,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -2138,7 +2138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -2247,7 +2247,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -2356,7 +2356,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="LARGE"
               >
                 <div
@@ -2465,7 +2465,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -2574,7 +2574,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -2683,7 +2683,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -2792,7 +2792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -2901,7 +2901,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3010,7 +3010,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3119,7 +3119,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3228,7 +3228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3337,7 +3337,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3446,7 +3446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3555,7 +3555,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3664,7 +3664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3773,7 +3773,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -3937,7 +3937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div
@@ -4046,7 +4046,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 kupEJX"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
                 size="MEDIUM"
               >
                 <div

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -72,7 +72,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="XLARGE"
               >
                 <div
@@ -183,7 +183,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -294,7 +294,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -513,7 +513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -624,7 +624,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -735,7 +735,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 jHYuJR"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 bJyHEu"
                 size="LARGE"
               >
                 <div
@@ -846,7 +846,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -957,7 +957,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1068,7 +1068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1179,7 +1179,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1290,7 +1290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1401,7 +1401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1512,7 +1512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1623,7 +1623,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1734,7 +1734,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1845,7 +1845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -1956,7 +1956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -2067,7 +2067,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -2178,7 +2178,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -2289,7 +2289,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -2400,7 +2400,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 eebKIM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
               >
                 <div
@@ -2511,7 +2511,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -2622,7 +2622,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -2733,7 +2733,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -2844,7 +2844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -2955,7 +2955,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3066,7 +3066,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3177,7 +3177,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3288,7 +3288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3399,7 +3399,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3510,7 +3510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3621,7 +3621,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3732,7 +3732,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -3843,7 +3843,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -4009,7 +4009,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div
@@ -4120,7 +4120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               className="Card__CardContent-v5r71h-1 bfMykM"
             >
               <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 cCqfBS"
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="MEDIUM"
               >
                 <div

--- a/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -101,6 +101,7 @@ export const formatGraphTick = (
   const currentTimestamp = moment.unix(timestamp / 1000);
 
   const sameDay = moment(previousTickTimestamp).isSame(currentTimestamp, 'day');
+  const sameMonth = moment(previousTickTimestamp).isSame(currentTimestamp, 'month');
   const sameYear = moment(previousTickTimestamp).isSame(currentTimestamp, 'year');
 
   // This works around a bug in moment where some Chinese languages are missing the day indicator
@@ -116,18 +117,22 @@ export const formatGraphTick = (
     ? currentTimestamp.format(dailyFormat)
     : interval === 'hour'
     ? currentTimestamp.format('HH:mm')
-    : interval === 'day' && index === 0
+    : (interval === 'day' || interval === 'week') && sameDay
+    ? '' // if we're on the day and week and the same day then skip
+    : (interval === 'day' || interval === 'week') && index === 0
     ? currentTimestamp.format(dailyFormat)
-    : interval === 'day' && index !== 0
+    : (interval === 'day' || interval === 'week') && index !== 0
     ? currentTimestamp.format(dailyFormat)
+    : interval === 'month' && sameMonth // don't repeat same month
+    ? ''
     : interval === 'month' && !sameYear
     ? currentTimestamp.format('MMM YYYY')
     : interval === 'month' && sameYear && index === 0
     ? currentTimestamp.format('MMM YYYY')
     : interval === 'month' && sameYear
     ? currentTimestamp.format('MMM')
-    : interval === 'year' && sameYear && index !== 0
-    ? currentTimestamp.format('MMM') // if we're on the year boundary and the same year, then don't repeat
+    : interval === 'year' && sameYear
+    ? '' // if we're on the year boundary and the same year, then don't repeat
     : interval === 'year' && (!sameYear || index === 0)
     ? currentTimestamp.format('YYYY')
     : interval === 'minute'

--- a/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -140,7 +140,7 @@ export const findMatchingAlertRange = (alertRanges, data) => {
   const currentDatapointTimestamp = data && data.date && data.date.valueOf();
   return (
     Array.isArray(alertRanges) &&
-    alertRanges.find(
+    alertRanges.filter(
       alert =>
         currentDatapointTimestamp <= alert.endTimestamp &&
         currentDatapointTimestamp >= alert.startTimestamp

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -148,7 +148,7 @@ describe('timeSeriesUtils', () => {
       },
     ];
     const matchingAlertRange = findMatchingAlertRange(alertRange, data);
-    expect(matchingAlertRange).toHaveLength();
+    expect(matchingAlertRange).toHaveLength(1);
     expect(matchingAlertRange[0].color).toEqual('#FF0000');
     expect(matchingAlertRange[0].details).toEqual('Alert details');
   });

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -148,7 +148,8 @@ describe('timeSeriesUtils', () => {
       },
     ];
     const matchingAlertRange = findMatchingAlertRange(alertRange, data);
-    expect(matchingAlertRange.color).toEqual('#FF0000');
-    expect(matchingAlertRange.details).toEqual('Alert details');
+    expect(matchingAlertRange).toHaveLength();
+    expect(matchingAlertRange[0].color).toEqual('#FF0000');
+    expect(matchingAlertRange[0].details).toEqual('Alert details');
   });
 });

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -126,6 +126,10 @@ describe('timeSeriesUtils', () => {
     expect(
       formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'hour', 'en', 1572933600000)
     ).toContain('00:00');
+    // day same day should skip
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'day', 'en', 1572933600000)
+    ).toEqual('');
     // month different year
     expect(
       formatGraphTick(1546322400000, 1, [1, 2, 3, 4, 5, 6], 'month', 'en', 1522558800000)
@@ -134,6 +138,25 @@ describe('timeSeriesUtils', () => {
     expect(
       formatGraphTick(1561957200000, 1, [1, 2, 3, 4, 5, 6], 'month', 'en', 1572584400000)
     ).toContain('Jul');
+    // week shouldn't show year
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'week', 'en', 1572912000000)
+    ).toContain('Nov 05');
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'week', 'en', 1572912000000)
+    ).not.toContain('Nov 05 2019');
+    // same year should not repeat
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'year', 'en', 1572933600000)
+    ).toEqual('');
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'year', 'en', 872912000000)
+    ).toContain('2019');
+
+    // same month should not repeat
+    expect(
+      formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'month', 'en', 1572933600000)
+    ).toEqual('');
   });
   test('findMatchingAlertRange', () => {
     const data = {

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -8,6 +8,8 @@ export const COLORS = {
   CYAN: '#0072C3',
 };
 
+export const DISABLED_COLORS = ['#e0e0e0', '#cacaca', '#a8a8a8', '#8d8d8d', '#6f6f6f'];
+
 export const CARD_SIZES = {
   XSMALL: 'XSMALL',
   XSMALLWIDE: 'XSMALLWIDE',


### PR DESCRIPTION
Closes #

**Summary**

Improve the tooltip and markup to allow multiple alert ranges to match a given datapoint for a TimeSeriesCard
![image](https://user-images.githubusercontent.com/6663002/74363670-a9587f00-4d90-11ea-8c83-14e8095451f3.png)


**Change List (commits, features, bugs, etc)**

- fix(timeseriescard): fix style lint issue with the style
- feat(TimeSeriesCard): add support for multiple matching alert ranges for one datapoint
- feat(timeSeriesUtils): add support for matching multiple alert ranges

**Acceptance Test (how to verify the PR)**

- tests here
