### PR TITLE
test(table): add story for sticky header and tooltip positioning

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -8,6 +8,7 @@ import Arrow from '@carbon/icons-react/lib/arrow--right/20';
 import Add from '@carbon/icons-react/lib/add/20';
 import Delete from '@carbon/icons-react/lib/delete/20';
 import { Add20 } from '@carbon/icons-react';
+import { Tooltip } from 'carbon-components-react';
 
 import { getSortedData, csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import FullWidthWrapper from '../../internal/FullWidthWrapper';
@@ -1648,6 +1649,66 @@ storiesOf('Watson IoT|Table', module)
         `,
         propTables: [Table],
         propTablesExclude: [StatefulTable],
+      },
+    }
+  )
+  .add(
+    'with sticky header and cell tooltip calculation',
+    () => {
+      const renderDataFunction = ({ value }) => (
+        <div style={{ position: 'relative' }} data-floating-menu-container>
+          {value}
+          <Tooltip
+            direction="right"
+            tabIndex={0}
+            tooltipId="table-tooltip"
+            triggerId="table-tooltip-trigger"
+            triggerText=""
+            menuOffset={menuBody => {
+              const container = menuBody.closest('[data-floating-menu-container]');
+              return {
+                top: -container.getBoundingClientRect().y - window.pageYOffset + 4,
+                left: -container.getBoundingClientRect().x - window.pageXOffset + 10,
+              };
+            }}
+          >
+            <p>This scroll with the table body</p>
+          </Tooltip>
+        </div>
+      );
+      return (
+        <div>
+          <Table
+            columns={tableColumns.map(i => ({
+              ...i,
+              renderDataFunction,
+            }))}
+            data={tableData}
+            actions={actions}
+            stickyHeader
+            options={{
+              hasFilter: true,
+              hasPagination: true,
+              hasRowSelection: 'multi',
+            }}
+            view={{
+              filters: [],
+              table: {
+                ordering: defaultOrdering,
+                sort: {
+                  columnId: 'string',
+                  direction: 'ASC',
+                },
+              },
+            }}
+          />
+        </div>
+      );
+    },
+    {
+      centered: { disable: true },
+      info: {
+        text: `To properly render a tooltip in a table with sticky headers you need to pass a menuOffset or menuOffsetFlip calculation to <Tooltip>`,
       },
     }
   );

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -1169,8 +1169,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-28"
-                      id="bx-pagination-select-28-count-label"
+                      htmlFor="bx-pagination-select-29"
+                      id="bx-pagination-select-29-count-label"
                     >
                       Items per page:
                     </label>
@@ -1189,7 +1189,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-28"
+                              id="bx-pagination-select-29"
                               onChange={[Function]}
                               value={10}
                             >
@@ -1258,7 +1258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-30"
+                          htmlFor="bx-pagination-select-31"
                         >
                           Page number, of 1 pages
                         </label>
@@ -1271,7 +1271,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-30"
+                              id="bx-pagination-select-31"
                               onChange={[Function]}
                               value={1}
                             >
@@ -2932,8 +2932,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-29"
-                      id="bx-pagination-select-29-count-label"
+                      htmlFor="bx-pagination-select-30"
+                      id="bx-pagination-select-30-count-label"
                     >
                       Items per page:
                     </label>
@@ -2952,7 +2952,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-29"
+                              id="bx-pagination-select-30"
                               onChange={[Function]}
                               value={10}
                             >
@@ -3021,7 +3021,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-31"
+                          htmlFor="bx-pagination-select-32"
                         >
                           Page number, of 1 pages
                         </label>
@@ -3034,7 +3034,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-31"
+                              id="bx-pagination-select-32"
                               onChange={[Function]}
                               value={1}
                             >
@@ -6015,8 +6015,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-31"
-                      id="bx-pagination-select-31-count-label"
+                      htmlFor="bx-pagination-select-32"
+                      id="bx-pagination-select-32-count-label"
                     >
                       Items per page:
                     </label>
@@ -6035,7 +6035,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-31"
+                              id="bx-pagination-select-32"
                               onChange={[Function]}
                               value={10}
                             >
@@ -6104,7 +6104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-33"
+                          htmlFor="bx-pagination-select-34"
                         >
                           Page number, of 2 pages
                         </label>
@@ -6117,7 +6117,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-33"
+                              id="bx-pagination-select-34"
                               onChange={[Function]}
                               value={1}
                             >
@@ -7395,8 +7395,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-27"
-                      id="bx-pagination-select-27-count-label"
+                      htmlFor="bx-pagination-select-28"
+                      id="bx-pagination-select-28-count-label"
                     >
                       Items per page:
                     </label>
@@ -7415,7 +7415,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-27"
+                              id="bx-pagination-select-28"
                               onChange={[Function]}
                               value={10}
                             >
@@ -7484,7 +7484,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-29"
+                          htmlFor="bx-pagination-select-30"
                         >
                           Page number, of 2 pages
                         </label>
@@ -7497,7 +7497,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-29"
+                              id="bx-pagination-select-30"
                               onChange={[Function]}
                               value={1}
                             >
@@ -8775,8 +8775,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-17"
-                      id="bx-pagination-select-17-count-label"
+                      htmlFor="bx-pagination-select-18"
+                      id="bx-pagination-select-18-count-label"
                     >
                       Items per page:
                     </label>
@@ -8795,7 +8795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-17"
+                              id="bx-pagination-select-18"
                               onChange={[Function]}
                               value={10}
                             >
@@ -8864,7 +8864,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-19"
+                          htmlFor="bx-pagination-select-20"
                         >
                           Page number, of 2 pages
                         </label>
@@ -8877,7 +8877,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-19"
+                              id="bx-pagination-select-20"
                               onChange={[Function]}
                               value={1}
                             >
@@ -10376,8 +10376,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-18"
-                      id="bx-pagination-select-18-count-label"
+                      htmlFor="bx-pagination-select-19"
+                      id="bx-pagination-select-19-count-label"
                     >
                       Items per page:
                     </label>
@@ -10396,7 +10396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-18"
+                              id="bx-pagination-select-19"
                               onChange={[Function]}
                               value={10}
                             >
@@ -10465,7 +10465,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-20"
+                          htmlFor="bx-pagination-select-21"
                         >
                           Page number, of 2 pages
                         </label>
@@ -10478,7 +10478,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-20"
+                              id="bx-pagination-select-21"
                               onChange={[Function]}
                               value={1}
                             >
@@ -11977,8 +11977,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-24"
-                      id="bx-pagination-select-24-count-label"
+                      htmlFor="bx-pagination-select-25"
+                      id="bx-pagination-select-25-count-label"
                     >
                       Items per page:
                     </label>
@@ -11997,7 +11997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-24"
+                              id="bx-pagination-select-25"
                               onChange={[Function]}
                               value={10}
                             >
@@ -12066,7 +12066,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-26"
+                          htmlFor="bx-pagination-select-27"
                         >
                           Page number, of 2 pages
                         </label>
@@ -12079,7 +12079,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-26"
+                              id="bx-pagination-select-27"
                               onChange={[Function]}
                               value={1}
                             >
@@ -13357,8 +13357,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-25"
-                      id="bx-pagination-select-25-count-label"
+                      htmlFor="bx-pagination-select-26"
+                      id="bx-pagination-select-26-count-label"
                     >
                       Items per page:
                     </label>
@@ -13377,7 +13377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-25"
+                              id="bx-pagination-select-26"
                               onChange={[Function]}
                               value={10}
                             >
@@ -13446,7 +13446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-27"
+                          htmlFor="bx-pagination-select-28"
                         >
                           Page number, of 2 pages
                         </label>
@@ -13459,7 +13459,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-27"
+                              id="bx-pagination-select-28"
                               onChange={[Function]}
                               value={1}
                             >
@@ -15330,8 +15330,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-19"
-                      id="bx-pagination-select-19-count-label"
+                      htmlFor="bx-pagination-select-20"
+                      id="bx-pagination-select-20-count-label"
                     >
                       Items per page:
                     </label>
@@ -15350,7 +15350,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-19"
+                              id="bx-pagination-select-20"
                               onChange={[Function]}
                               value={10}
                             >
@@ -15419,7 +15419,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-21"
+                          htmlFor="bx-pagination-select-22"
                         >
                           Page number, of 2 pages
                         </label>
@@ -15432,7 +15432,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-21"
+                              id="bx-pagination-select-22"
                               onChange={[Function]}
                               value={1}
                             >
@@ -17074,8 +17074,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-26"
-                      id="bx-pagination-select-26-count-label"
+                      htmlFor="bx-pagination-select-27"
+                      id="bx-pagination-select-27-count-label"
                     >
                       Items per page:
                     </label>
@@ -17094,7 +17094,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-26"
+                              id="bx-pagination-select-27"
                               onChange={[Function]}
                               value={10}
                             >
@@ -17163,7 +17163,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-28"
+                          htmlFor="bx-pagination-select-29"
                         >
                           Page number, of 2 pages
                         </label>
@@ -17176,7 +17176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-28"
+                              id="bx-pagination-select-29"
                               onChange={[Function]}
                               value={1}
                             >
@@ -18777,8 +18777,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-20"
-                      id="bx-pagination-select-20-count-label"
+                      htmlFor="bx-pagination-select-21"
+                      id="bx-pagination-select-21-count-label"
                     >
                       Items per page:
                     </label>
@@ -18797,7 +18797,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-20"
+                              id="bx-pagination-select-21"
                               onChange={[Function]}
                               value={10}
                             >
@@ -18866,7 +18866,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-22"
+                          htmlFor="bx-pagination-select-23"
                         >
                           Page number, of 2 pages
                         </label>
@@ -18879,7 +18879,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-22"
+                              id="bx-pagination-select-23"
                               onChange={[Function]}
                               value={1}
                             >
@@ -21216,8 +21216,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-22"
-                      id="bx-pagination-select-22-count-label"
+                      htmlFor="bx-pagination-select-23"
+                      id="bx-pagination-select-23-count-label"
                     >
                       Items per page:
                     </label>
@@ -21236,7 +21236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-22"
+                              id="bx-pagination-select-23"
                               onChange={[Function]}
                               value={10}
                             >
@@ -21305,7 +21305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-24"
+                          htmlFor="bx-pagination-select-25"
                         >
                           Page number, of 2 pages
                         </label>
@@ -21318,7 +21318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-24"
+                              id="bx-pagination-select-25"
                               onChange={[Function]}
                               value={1}
                             >
@@ -22617,8 +22617,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-23"
-                      id="bx-pagination-select-23-count-label"
+                      htmlFor="bx-pagination-select-24"
+                      id="bx-pagination-select-24-count-label"
                     >
                       Items per page:
                     </label>
@@ -22637,7 +22637,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-23"
+                              id="bx-pagination-select-24"
                               onChange={[Function]}
                               value={10}
                             >
@@ -22706,7 +22706,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-25"
+                          htmlFor="bx-pagination-select-26"
                         >
                           Page number, of 1 pages
                         </label>
@@ -22719,7 +22719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-25"
+                              id="bx-pagination-select-26"
                               onChange={[Function]}
                               value={1}
                             >
@@ -25412,8 +25412,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-21"
-                      id="bx-pagination-select-21-count-label"
+                      htmlFor="bx-pagination-select-22"
+                      id="bx-pagination-select-22-count-label"
                     >
                       Items per page:
                     </label>
@@ -25432,7 +25432,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-21"
+                              id="bx-pagination-select-22"
                               onChange={[Function]}
                               value={10}
                             >
@@ -25501,7 +25501,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-23"
+                          htmlFor="bx-pagination-select-24"
                         >
                           Page number, of 2 pages
                         </label>
@@ -25514,7 +25514,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-23"
+                              id="bx-pagination-select-24"
                               onChange={[Function]}
                               value={1}
                             >
@@ -27756,8 +27756,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--pagination__text"
-                      htmlFor="bx-pagination-select-30"
-                      id="bx-pagination-select-30-count-label"
+                      htmlFor="bx-pagination-select-31"
+                      id="bx-pagination-select-31-count-label"
                     >
                       Items per page:
                     </label>
@@ -27776,7 +27776,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-30"
+                              id="bx-pagination-select-31"
                               onChange={[Function]}
                               value={10}
                             >
@@ -27845,7 +27845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <label
                           className="bx--label bx--visually-hidden"
-                          htmlFor="bx-pagination-select-32"
+                          htmlFor="bx-pagination-select-33"
                         >
                           Page number, of 2 pages
                         </label>
@@ -27858,7 +27858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           >
                             <select
                               className="bx--select-input"
-                              id="bx-pagination-select-32"
+                              id="bx-pagination-select-33"
                               onChange={[Function]}
                               value={1}
                             >


### PR DESCRIPTION
Closes #818

**Summary**

The positioning calculation of anything that uses in Carbon (Tooltip, Dropdown, etc) has some serious limitations (and it's [known and on the roadmap](https://github.com/carbon-design-system/carbon/issues/2907)).
This is especially true when needed inside a table with sticky header.
As a workaround, one can use `menuOffset` as explained [here](https://github.com/carbon-design-system/carbon/issues/4755#issuecomment-558131945)

**Acceptance Test (how to verify the PR)**

A new story has been added: ?path=/story/watson-iot-table--with-sticky-header-and-cell-tooltip-calculation
