### PR TITLE
fix(simple-pagination): navigation doesnt activate on the left most or right most page

### DIFF
--- a/src/components/SimplePagination/SimplePagination.jsx
+++ b/src/components/SimplePagination/SimplePagination.jsx
@@ -25,18 +25,22 @@ const StyledPageLabel = styled.span`
 `;
 
 const StyledButton = styled.div`
-  ${props =>
-    props.onClick
-      ? `` // If the item isn't clickable remove the focus outline
-      : `&:focus {
-          outline: none;
-          border: 1px solid ${COLORS.blue};
-        }
-        cursor: default;
-  `}
+  && {
+    ${props =>
+      props.onClick
+        ? `` // If the item isnt clickable remove the focus outline
+        : `&:focus {
+            outline: none;
+          }
+          &:hover {
+            background-color: ${COLORS.gray10};
+          }
+          cursor: default;
+    `}
 
-  svg path {
-    fill: ${COLORS.gray100};
+    svg path {
+      fill: ${COLORS.gray100};
+    }
   }
 `;
 

--- a/src/components/SimplePagination/__snapshots__/SimplePagination.story.storyshot
+++ b/src/components/SimplePagination/__snapshots__/SimplePagination.story.storyshot
@@ -51,7 +51,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Simpl
               Page 1 of 4
             </span>
             <div
-              className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 bxiYjR"
+              className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 iBEASq"
               role="button"
               tabIndex={-1}
             >
@@ -76,7 +76,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Simpl
               </svg>
             </div>
             <div
-              className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 gxHBrs"
+              className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 hEeyee"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="button"

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -4558,107 +4558,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={5}
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-pressure"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -4790,6 +4689,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={5}
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-pressure"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -5249,6 +5249,205 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count < 5"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <circle
+                                      cx="8"
+                                      cy="8"
+                                      fill="#FDD13A"
+                                      id="background-color"
+                                      r="7"
+                                    />
+                                    <path
+                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                      fill="#FFFFFF"
+                                      id="symbol-color"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Low
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={3}
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-pressure"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="pressure >= 10"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -5633,205 +5832,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count < 5"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <circle
-                                      cx="8"
-                                      cy="8"
-                                      fill="#FDD13A"
-                                      id="background-color"
-                                      r="7"
-                                    />
-                                    <path
-                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                      fill="#FFFFFF"
-                                      id="symbol-color"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Low
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={3}
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-pressure"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="pressure >= 10"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -6861,62 +6861,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -6956,6 +6900,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -7141,6 +7141,68 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -7298,68 +7360,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -8255,62 +8255,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -8350,6 +8294,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -8535,6 +8535,68 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -8692,68 +8754,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -9684,81 +9684,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={5}
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -9817,6 +9742,81 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={5}
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -10059,6 +10059,87 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={3}
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -10273,87 +10354,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={3}
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -11610,81 +11610,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={5}
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -11743,6 +11668,81 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-4-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={5}
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -12887,62 +12887,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hhRrti"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width="250px"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hhRrti"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width="250px"
@@ -12982,6 +12926,62 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hhRrti"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width="250px"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -13167,6 +13167,68 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hhRrti"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width="250px"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hhRrti"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width="250px"
@@ -13324,68 +13386,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hhRrti"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width="250px"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -14298,7 +14298,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
+                          id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
                         >
@@ -14317,7 +14317,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-11-hour"
+                          id="cell-Table-row-10-hour"
                           offset={0}
                           width=""
                         >
@@ -14336,7 +14336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-11-pressure"
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                           width=""
                         >
@@ -14349,7 +14349,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
                           data-column="actionColumn"
                           data-offset={0}
-                          id="cell-Table-row-11-actionColumn"
+                          id="cell-Table-row-10-actionColumn"
                           offset={0}
                           width="60px"
                         >
@@ -14412,7 +14412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
+                          id="cell-Table-row-11-alert"
                           offset={0}
                           width=""
                         >
@@ -14431,7 +14431,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-10-hour"
+                          id="cell-Table-row-11-hour"
                           offset={0}
                           width=""
                         >
@@ -14450,7 +14450,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-10-pressure"
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -14463,7 +14463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
                           data-column="actionColumn"
                           data-offset={0}
-                          id="cell-Table-row-10-actionColumn"
+                          id="cell-Table-row-11-actionColumn"
                           offset={0}
                           width="60px"
                         >
@@ -14868,6 +14868,126 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
+                          data-column="actionColumn"
+                          data-offset={0}
+                          id="cell-Table-row-3-actionColumn"
+                          offset={0}
+                          width="60px"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              aria-label="Menu"
+                              className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                              floatingMenu={true}
+                              onClick={[Function]}
+                              onClose={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="#5a6872"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                style={
+                                  Object {
+                                    "willChange": "transform",
+                                  }
+                                }
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="16"
+                                  cy="6"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="16"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="26"
+                                  r="2"
+                                />
+                              </svg>
+                            </button>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -15148,126 +15268,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="actionColumn"
                           data-offset={0}
                           id="cell-Table-row-9-actionColumn"
-                          offset={0}
-                          width="60px"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <button
-                              aria-expanded={false}
-                              aria-haspopup={true}
-                              aria-label="Menu"
-                              className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                              floatingMenu={true}
-                              onClick={[Function]}
-                              onClose={[Function]}
-                              onKeyDown={[Function]}
-                              open={false}
-                              tabIndex={0}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="#5a6872"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                style={
-                                  Object {
-                                    "willChange": "transform",
-                                  }
-                                }
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <circle
-                                  cx="16"
-                                  cy="6"
-                                  r="2"
-                                />
-                                <circle
-                                  cx="16"
-                                  cy="16"
-                                  r="2"
-                                />
-                                <circle
-                                  cx="16"
-                                  cy="26"
-                                  r="2"
-                                />
-                              </svg>
-                            </button>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
-                          data-column="actionColumn"
-                          data-offset={0}
-                          id="cell-Table-row-3-actionColumn"
                           offset={0}
                           width="60px"
                         >
@@ -16311,7 +16311,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
+                          id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
                         >
@@ -16330,7 +16330,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-11-hour"
+                          id="cell-Table-row-10-hour"
                           offset={0}
                           width=""
                         >
@@ -16349,7 +16349,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-11-pressure"
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                           width=""
                         >
@@ -16403,7 +16403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
+                          id="cell-Table-row-11-alert"
                           offset={0}
                           width=""
                         >
@@ -16422,7 +16422,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-10-hour"
+                          id="cell-Table-row-11-hour"
                           offset={0}
                           width=""
                         >
@@ -16441,7 +16441,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-10-pressure"
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -16771,6 +16771,104 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -17000,104 +17098,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -18046,93 +18046,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
-                          data-column="actionColumn"
-                          data-offset={0}
-                          id="cell-Table-row-11-actionColumn"
-                          offset={0}
-                          width="60px"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <svg
-                              aria-label="open"
-                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                              fillRule="evenodd"
-                              height="16"
-                              onClick={[Function]}
-                              role="img"
-                              viewBox="0 0 16 16"
-                              width="16"
-                            >
-                              <title>
-                                open
-                              </title>
-                              <path
-                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                              />
-                            </svg>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -18185,6 +18098,93 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="actionColumn"
                           data-offset={0}
                           id="cell-Table-row-10-actionColumn"
+                          offset={0}
+                          width="60px"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <svg
+                              aria-label="open"
+                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                              fillRule="evenodd"
+                              height="16"
+                              onClick={[Function]}
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                            >
+                              <title>
+                                open
+                              </title>
+                              <path
+                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                              />
+                            </svg>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
+                          data-column="actionColumn"
+                          data-offset={0}
+                          id="cell-Table-row-11-actionColumn"
                           offset={0}
                           width="60px"
                         >
@@ -18481,6 +18481,99 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
+                          data-column="actionColumn"
+                          data-offset={0}
+                          id="cell-Table-row-3-actionColumn"
+                          offset={0}
+                          width="60px"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <svg
+                              aria-label="open"
+                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                              fillRule="evenodd"
+                              height="16"
+                              onClick={[Function]}
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                            >
+                              <title>
+                                open
+                              </title>
+                              <path
+                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                              />
+                            </svg>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -18707,99 +18800,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="actionColumn"
                           data-offset={0}
                           id="cell-Table-row-9-actionColumn"
-                          offset={0}
-                          width="60px"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <svg
-                              aria-label="open"
-                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                              fillRule="evenodd"
-                              height="16"
-                              onClick={[Function]}
-                              role="img"
-                              viewBox="0 0 16 16"
-                              width="16"
-                            >
-                              <title>
-                                open
-                              </title>
-                              <path
-                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                              />
-                            </svg>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 ibyjnp"
-                          data-column="actionColumn"
-                          data-offset={0}
-                          id="cell-Table-row-3-actionColumn"
                           offset={0}
                           width="60px"
                         >
@@ -19913,107 +19913,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={5}
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-pressure"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -20145,6 +20044,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={5}
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-pressure"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -20604,6 +20604,205 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count < 5"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <circle
+                                      cx="8"
+                                      cy="8"
+                                      fill="#FDD13A"
+                                      id="background-color"
+                                      r="7"
+                                    />
+                                    <path
+                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                      fill="#FFFFFF"
+                                      id="symbol-color"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Low
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={3}
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-pressure"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="pressure >= 10"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -20988,205 +21187,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count < 5"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <circle
-                                      cx="8"
-                                      cy="8"
-                                      fill="#FDD13A"
-                                      id="background-color"
-                                      r="7"
-                                    />
-                                    <path
-                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                      fill="#FFFFFF"
-                                      id="symbol-color"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Low
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={3}
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-pressure"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="pressure >= 10"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -23793,143 +23793,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="5"
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-pressure"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -24061,6 +23924,143 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="5"
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-pressure"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -24664,6 +24664,241 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count < 5"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <circle
+                                      cx="8"
+                                      cy="8"
+                                      fill="#FDD13A"
+                                      id="background-color"
+                                      r="7"
+                                    />
+                                    <path
+                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                      fill="#FFFFFF"
+                                      id="symbol-color"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Low
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="3"
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-pressure"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="pressure >= 10"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -25120,241 +25355,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count < 5"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <circle
-                                      cx="8"
-                                      cy="8"
-                                      fill="#FDD13A"
-                                      id="background-color"
-                                      r="7"
-                                    />
-                                    <path
-                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                      fill="#FFFFFF"
-                                      id="symbol-color"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Low
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="3"
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-pressure"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="pressure >= 10"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr
@@ -26524,156 +26524,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count > 2"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                           width=""
@@ -26773,6 +26623,156 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count > 2"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                           width=""
                         >
@@ -27280,6 +27280,162 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                          width="200pxpx"
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count > 2"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                          width=""
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                           width=""
@@ -27638,162 +27794,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 hSNyaF"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                          width="200pxpx"
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count > 2"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 lhMdXS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                          width=""
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
                         </td>
                       </tr>
                       <tr

--- a/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
+++ b/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
@@ -2655,7 +2655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileC
               Page 1 of 2
             </span>
             <div
-              className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 bxiYjR"
+              className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 iBEASq"
               role="button"
               tabIndex={-1}
             >
@@ -2680,7 +2680,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileC
               </svg>
             </div>
             <div
-              className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 gxHBrs"
+              className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 hEeyee"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="button"
@@ -3449,7 +3449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileC
               Page 1 of 2
             </span>
             <div
-              className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 bxiYjR"
+              className="bx--pagination__button bx--pagination__button--backward SimplePagination__StyledButton-l7ezj3-2 iBEASq"
               role="button"
               tabIndex={-1}
             >
@@ -3474,7 +3474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TileC
               </svg>
             </div>
             <div
-              className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 gxHBrs"
+              className="bx--pagination__button bx--pagination__button--forward SimplePagination__StyledButton-l7ezj3-2 hEeyee"
               onClick={[Function]}
               onKeyDown={[Function]}
               role="button"


### PR DESCRIPTION
Closes #

**Summary**

Fixes an issue where the left arrow button would activate on page 1, and the right arrow button would activate on the last page. 
This fix causes the buttons to be unresponsive unless there is another page in its respective direction.

**Change List (commits, features, bugs, etc)**

src/components/SimplePagination/SimplePagination.jsx

**Acceptance Test (how to verify the PR)**

On the SimplePagination component, from page 1 click the left arrow, and from page 4 (or the last page) click the right arrow.
<img width="847" alt="PaginationNavFix" src="https://user-images.githubusercontent.com/53092833/74484158-ab4c3c00-4e7d-11ea-963b-c42e89e6e2a5.png">

