### PR TITLE
fix(ci): reconfigure coveralls to not swallow error exit codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
   - yarn lint
-  - travis_wait yarn test --ci --maxWorkers=2 --verbose --coverage --coverageReporters=text-lcov | yarn run coveralls # report coveralls status
+  - travis_wait yarn test --ci --maxWorkers=2 --verbose --coverage && cat ./coverage/lcov.info | yarn run coveralls && rm -rf ./coverage # report coveralls status
 
 after_success:
   - yarn publish-npm

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   collectCoverageFrom: ['src/components/**/*.js?(x)', '!src/**/*.story.js?(x)'],
   coveragePathIgnorePatterns: ['/node_modules/', '/lib/', '/coverage/'],
-  coverageReporters: ['html', 'text-summary'],
+  coverageReporters: ['html', 'text-summary', 'lcov'],
   coverageThreshold: {
     global: {
       statements: 80,

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -4589,6 +4589,101 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={5}
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                         >
@@ -4715,101 +4810,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={5}
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
                           offset={0}
                         >
                           <span
@@ -5250,199 +5250,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count < 5"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <circle
-                                      cx="8"
-                                      cy="8"
-                                      fill="#FDD13A"
-                                      id="background-color"
-                                      r="7"
-                                    />
-                                    <path
-                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                      fill="#FFFFFF"
-                                      id="symbol-color"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Low
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={3}
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="pressure >= 10"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -5809,6 +5616,199 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count < 5"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <circle
+                                      cx="8"
+                                      cy="8"
+                                      fill="#FDD13A"
+                                      id="background-color"
+                                      r="7"
+                                    />
+                                    <path
+                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                      fill="#FFFFFF"
+                                      id="symbol-color"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Low
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={3}
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="pressure >= 10"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -6851,59 +6851,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-10-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-11-alert"
                           offset={0}
                         >
@@ -6941,6 +6888,59 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-10-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-10-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                         >
                           <span
@@ -7116,65 +7116,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -7323,6 +7264,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -8233,59 +8233,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-10-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-11-alert"
                           offset={0}
                         >
@@ -8323,6 +8270,59 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-10-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-10-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                         >
                           <span
@@ -8498,65 +8498,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -8705,6 +8646,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -9656,77 +9656,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-10-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={2}
-                            >
-                              2
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-10-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-11-alert"
                           offset={0}
                         >
@@ -9782,6 +9711,77 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-10-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-10-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={2}
+                            >
+                              2
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-10-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                         >
                           <span
@@ -10011,83 +10011,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={3}
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -10290,6 +10213,83 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={3}
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -11549,77 +11549,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-4-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-4-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={5}
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-4-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-4-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-11-alert"
                           offset={0}
                         >
@@ -11675,6 +11604,77 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-4-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-4-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={5}
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-4-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-4-pressure"
                           offset={0}
                         >
                           <span
@@ -12821,59 +12821,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-10-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-11-alert"
                           offset={0}
                         >
@@ -12911,6 +12858,59 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-10-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-10-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                         >
                           <span
@@ -13086,65 +13086,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -13293,6 +13234,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -14226,7 +14226,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
+                          id="cell-Table-row-11-alert"
                           offset={0}
                         >
                           <span
@@ -14244,7 +14244,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-10-hour"
+                          id="cell-Table-row-11-hour"
                           offset={0}
                         >
                           <span
@@ -14262,7 +14262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-10-pressure"
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                         >
                           <span
@@ -14274,7 +14274,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="actionColumn"
                           data-offset={0}
-                          id="cell-Table-row-10-actionColumn"
+                          id="cell-Table-row-11-actionColumn"
                           offset={0}
                         >
                           <span
@@ -14336,7 +14336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
+                          id="cell-Table-row-10-alert"
                           offset={0}
                         >
                           <span
@@ -14354,7 +14354,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-11-hour"
+                          id="cell-Table-row-10-hour"
                           offset={0}
                         >
                           <span
@@ -14372,7 +14372,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-11-pressure"
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                         >
                           <span
@@ -14384,7 +14384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="actionColumn"
                           data-offset={0}
-                          id="cell-Table-row-11-actionColumn"
+                          id="cell-Table-row-10-actionColumn"
                           offset={0}
                         >
                           <span
@@ -14776,122 +14776,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="actionColumn"
-                          data-offset={0}
-                          id="cell-Table-row-3-actionColumn"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <button
-                              aria-expanded={false}
-                              aria-haspopup={true}
-                              aria-label="Menu"
-                              className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                              floatingMenu={true}
-                              onClick={[Function]}
-                              onClose={[Function]}
-                              onKeyDown={[Function]}
-                              open={false}
-                              tabIndex={0}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                fill="#5a6872"
-                                focusable="false"
-                                height={20}
-                                preserveAspectRatio="xMidYMid meet"
-                                style={
-                                  Object {
-                                    "willChange": "transform",
-                                  }
-                                }
-                                viewBox="0 0 32 32"
-                                width={20}
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <circle
-                                  cx="16"
-                                  cy="6"
-                                  r="2"
-                                />
-                                <circle
-                                  cx="16"
-                                  cy="16"
-                                  r="2"
-                                />
-                                <circle
-                                  cx="16"
-                                  cy="26"
-                                  r="2"
-                                />
-                              </svg>
-                            </button>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -15161,6 +15045,122 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="actionColumn"
                           data-offset={0}
                           id="cell-Table-row-9-actionColumn"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              aria-label="Menu"
+                              className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                              floatingMenu={true}
+                              onClick={[Function]}
+                              onClose={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="#5a6872"
+                                focusable="false"
+                                height={20}
+                                preserveAspectRatio="xMidYMid meet"
+                                style={
+                                  Object {
+                                    "willChange": "transform",
+                                  }
+                                }
+                                viewBox="0 0 32 32"
+                                width={20}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="16"
+                                  cy="6"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="16"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="26"
+                                  r="2"
+                                />
+                              </svg>
+                            </button>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="actionColumn"
+                          data-offset={0}
+                          id="cell-Table-row-3-actionColumn"
                           offset={0}
                         >
                           <span
@@ -16218,7 +16218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
+                          id="cell-Table-row-11-alert"
                           offset={0}
                         >
                           <span
@@ -16236,7 +16236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-10-hour"
+                          id="cell-Table-row-11-hour"
                           offset={0}
                         >
                           <span
@@ -16254,7 +16254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-10-pressure"
+                          id="cell-Table-row-11-pressure"
                           offset={0}
                         >
                           <span
@@ -16307,7 +16307,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-11-alert"
+                          id="cell-Table-row-10-alert"
                           offset={0}
                         >
                           <span
@@ -16325,7 +16325,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="hour"
                           data-offset={0}
-                          id="cell-Table-row-11-hour"
+                          id="cell-Table-row-10-hour"
                           offset={0}
                         >
                           <span
@@ -16343,7 +16343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="pressure"
                           data-offset={0}
-                          id="cell-Table-row-11-pressure"
+                          id="cell-Table-row-10-pressure"
                           offset={0}
                         >
                           <span
@@ -16663,101 +16663,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -16978,6 +16883,101 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -17947,89 +17947,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-10-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-10-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="actionColumn"
-                          data-offset={0}
-                          id="cell-Table-row-10-actionColumn"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <svg
-                              aria-label="open"
-                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                              fillRule="evenodd"
-                              height="16"
-                              onClick={[Function]}
-                              role="img"
-                              viewBox="0 0 16 16"
-                              width="16"
-                            >
-                              <title>
-                                open
-                              </title>
-                              <path
-                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                              />
-                            </svg>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-11-alert"
                           offset={0}
                         >
@@ -18079,6 +17996,89 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="actionColumn"
                           data-offset={0}
                           id="cell-Table-row-11-actionColumn"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <svg
+                              aria-label="open"
+                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                              fillRule="evenodd"
+                              height="16"
+                              onClick={[Function]}
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                            >
+                              <title>
+                                open
+                              </title>
+                              <path
+                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                              />
+                            </svg>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-10-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-10-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-10-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="actionColumn"
+                          data-offset={0}
+                          id="cell-Table-row-10-actionColumn"
                           offset={0}
                         >
                           <span
@@ -18362,95 +18362,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="actionColumn"
-                          data-offset={0}
-                          id="cell-Table-row-3-actionColumn"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <svg
-                              aria-label="open"
-                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                              fillRule="evenodd"
-                              height="16"
-                              onClick={[Function]}
-                              role="img"
-                              viewBox="0 0 16 16"
-                              width="16"
-                            >
-                              <title>
-                                open
-                              </title>
-                              <path
-                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                              />
-                            </svg>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -18666,6 +18577,95 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="actionColumn"
                           data-offset={0}
                           id="cell-Table-row-9-actionColumn"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <svg
+                              aria-label="open"
+                              className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                              fillRule="evenodd"
+                              height="16"
+                              onClick={[Function]}
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                            >
+                              <title>
+                                open
+                              </title>
+                              <path
+                                d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                              />
+                            </svg>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="actionColumn"
+                          data-offset={0}
+                          id="cell-Table-row-3-actionColumn"
                           offset={0}
                         >
                           <span
@@ -19808,6 +19808,101 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={5}
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                         >
@@ -19934,101 +20029,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={5}
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
                           offset={0}
                         >
                           <span
@@ -20469,199 +20469,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count < 5"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <circle
-                                      cx="8"
-                                      cy="8"
-                                      fill="#FDD13A"
-                                      id="background-color"
-                                      r="7"
-                                    />
-                                    <path
-                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                      fill="#FFFFFF"
-                                      id="symbol-color"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Low
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={3}
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="pressure >= 10"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                        onClick={[Function]}
-                      >
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -21028,6 +20835,199 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                        onClick={[Function]}
+                      >
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count < 5"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <circle
+                                      cx="8"
+                                      cy="8"
+                                      fill="#FDD13A"
+                                      id="background-color"
+                                      r="7"
+                                    />
+                                    <path
+                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                      fill="#FFFFFF"
+                                      id="symbol-color"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Low
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={3}
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="pressure >= 10"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -23684,6 +23684,137 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-11-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="5"
+                            >
+                              5
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                         >
@@ -23810,137 +23941,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-11-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="5"
-                            >
-                              5
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
                           offset={0}
                         >
                           <span
@@ -24525,235 +24525,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count < 5"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <circle
-                                      cx="8"
-                                      cy="8"
-                                      fill="#FDD13A"
-                                      id="background-color"
-                                      r="7"
-                                    />
-                                    <path
-                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                      fill="#FFFFFF"
-                                      id="symbol-color"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Low
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="count"
-                          data-offset={0}
-                          id="cell-Table-row-3-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="3"
-                            >
-                              3
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="pressure >= 10"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -25192,6 +24963,235 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count < 5"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <circle
+                                      cx="8"
+                                      cy="8"
+                                      fill="#FDD13A"
+                                      id="background-color"
+                                      r="7"
+                                    />
+                                    <path
+                                      d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                      fill="#FFFFFF"
+                                      id="symbol-color"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Low
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="count"
+                          data-offset={0}
+                          id="cell-Table-row-3-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="3"
+                            >
+                              3
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="pressure >= 10"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr
@@ -26379,6 +26379,152 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
+                          id="cell-Table-row-11-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI010 proccess need to optimize adjust Y variables"
+                            >
+                              AHI010 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-11-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count > 2"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-11-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-11-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          />
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
                           id="cell-Table-row-10-alert"
                           offset={0}
                         >
@@ -26475,152 +26621,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           data-column="pressure"
                           data-offset={0}
                           id="cell-Table-row-10-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          />
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
-                          id="cell-Table-row-11-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI010 proccess need to optimize adjust Y variables"
-                            >
-                              AHI010 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-11-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count > 2"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-11-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-11-pressure"
                           offset={0}
                         >
                           <span
@@ -27115,158 +27115,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                           data-column="alert"
                           data-offset={0}
-                          id="cell-Table-row-3-alert"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="AHI001 proccess need to optimize adjust Y variables"
-                            >
-                              AHI001 proccess need to optimize adjust Y variables
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="iconColumn-count"
-                          data-offset={0}
-                          id="cell-Table-row-3-iconColumn-count"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <div
-                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
-                              title="count > 2"
-                            >
-                              <svg
-                                height="16px"
-                                version="1.1"
-                                viewBox="0 0 16 16"
-                                width="16px"
-                              >
-                                <g
-                                  fill="none"
-                                  fillRule="evenodd"
-                                  id="Artboard-Copy-2"
-                                  stroke="none"
-                                  strokeWidth="1"
-                                >
-                                  <g
-                                    id="Group"
-                                  >
-                                    <path
-                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                      fill="#FFFFFF"
-                                      id="outline-color"
-                                    />
-                                    <path
-                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                      fill="#DA1E28"
-                                      id="background-color"
-                                    />
-                                    <polygon
-                                      fill="#FFFFFF"
-                                      id="icon-color"
-                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                    />
-                                  </g>
-                                </g>
-                              </svg>
-                              <span
-                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
-                              >
-                                Critical
-                              </span>
-                            </div>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="hour"
-                          data-offset={0}
-                          id="cell-Table-row-3-hour"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title="10/28/2018 07:34"
-                            >
-                              10/28/2018 07:34
-                            </span>
-                          </span>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="pressure"
-                          data-offset={0}
-                          id="cell-Table-row-3-pressure"
-                          offset={0}
-                        >
-                          <span
-                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                          >
-                            <span
-                              title={10}
-                            >
-                              10
-                            </span>
-                          </span>
-                        </td>
-                      </tr>
-                      <tr
-                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                        data-child-count={0}
-                        data-nesting-offset={0}
-                        data-parent-row={true}
-                        data-row-nesting={false}
-                        onClick={[Function]}
-                      >
-                        <td
-                          className="bx--table-expand"
-                          headers="expand"
-                        >
-                          <button
-                            aria-label="Click to expand content"
-                            className="bx--table-expand__button"
-                            onClick={[Function]}
-                            title="Click to expand content"
-                          >
-                            <svg
-                              aria-label="Click to expand content"
-                              className="bx--table-expand__svg"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              role="img"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                              />
-                            </svg>
-                          </button>
-                        </td>
-                        <td
-                          align="start"
-                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                          data-column="alert"
-                          data-offset={0}
                           id="cell-Table-row-4-alert"
                           offset={0}
                         >
@@ -27613,6 +27461,158 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                           <span
                             className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                           />
+                        </td>
+                      </tr>
+                      <tr
+                        className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                        data-child-count={0}
+                        data-nesting-offset={0}
+                        data-parent-row={true}
+                        data-row-nesting={false}
+                        onClick={[Function]}
+                      >
+                        <td
+                          className="bx--table-expand"
+                          headers="expand"
+                        >
+                          <button
+                            aria-label="Click to expand content"
+                            className="bx--table-expand__button"
+                            onClick={[Function]}
+                            title="Click to expand content"
+                          >
+                            <svg
+                              aria-label="Click to expand content"
+                              className="bx--table-expand__svg"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
+                              }
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                              />
+                            </svg>
+                          </button>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="alert"
+                          data-offset={0}
+                          id="cell-Table-row-3-alert"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="AHI001 proccess need to optimize adjust Y variables"
+                            >
+                              AHI001 proccess need to optimize adjust Y variables
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="iconColumn-count"
+                          data-offset={0}
+                          id="cell-Table-row-3-iconColumn-count"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <div
+                              className="TableCard__StyledIconDiv-q9l5bz-4 fFnvlh"
+                              title="count > 2"
+                            >
+                              <svg
+                                height="16px"
+                                version="1.1"
+                                viewBox="0 0 16 16"
+                                width="16px"
+                              >
+                                <g
+                                  fill="none"
+                                  fillRule="evenodd"
+                                  id="Artboard-Copy-2"
+                                  stroke="none"
+                                  strokeWidth="1"
+                                >
+                                  <g
+                                    id="Group"
+                                  >
+                                    <path
+                                      d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                      fill="#FFFFFF"
+                                      id="outline-color"
+                                    />
+                                    <path
+                                      d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                      fill="#DA1E28"
+                                      id="background-color"
+                                    />
+                                    <polygon
+                                      fill="#FFFFFF"
+                                      id="icon-color"
+                                      points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                    />
+                                  </g>
+                                </g>
+                              </svg>
+                              <span
+                                className="TableCard__StyledSpan-q9l5bz-5 bPtSrU"
+                              >
+                                Critical
+                              </span>
+                            </div>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="hour"
+                          data-offset={0}
+                          id="cell-Table-row-3-hour"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title="10/28/2018 07:34"
+                            >
+                              10/28/2018 07:34
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          align="start"
+                          className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                          data-column="pressure"
+                          data-offset={0}
+                          id="cell-Table-row-3-pressure"
+                          offset={0}
+                        >
+                          <span
+                            className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                          >
+                            <span
+                              title={10}
+                            >
+                              10
+                            </span>
+                          </span>
                         </td>
                       </tr>
                       <tr


### PR DESCRIPTION
Related to #904 , #898 

**Summary**

- In #898 the testing thresholds weren't being met, yet CI didn't catch this. #904 updated the thresholds to get the build passing locally. 
- I suspect that CI builds passed while local builds failed because the testing script ran by travis piped the text results of `jest` directly to `yarn run coveralls`. Due to this, error codes from `jest` were being swallowed and not causing build failures when coverage thresholds were not met.

**Change List (commits, features, bugs, etc)**

- Modify jest config to output lcov coverage reporter file
- Modify travis script to pipe the lcov coverage reporter file to coveralls, instead of directly piping lcov text output from jest.
