### PR TITLE
feat(modal): add new isPrimaryButtonDisabled property

### DIFF
--- a/src/components/ComposedModal/ComposedModal.jsx
+++ b/src/components/ComposedModal/ComposedModal.jsx
@@ -106,6 +106,8 @@ export const ComposedModalPropTypes = {
       secondaryButtonLabel: PropTypes.node,
       /** should the primary button be hidden (i.e. only show Cancel) */
       isPrimaryButtonHidden: PropTypes.bool,
+      /** should the primary button be disabled */
+      isPrimaryButtonDisabled: PropTypes.bool,
     }),
   ]),
   /** NEW PROP: Type of dialog, affects colors, styles of dialog */

--- a/src/components/ComposedModal/ComposedModal.jsx
+++ b/src/components/ComposedModal/ComposedModal.jsx
@@ -261,6 +261,7 @@ class ComposedModal extends React.Component {
                 </Button>
                 {!footer?.isPrimaryButtonHidden ? (
                   <Button
+                    disabled={footer?.isPrimaryButtonDisabled}
                     kind={type === 'warn' ? 'danger' : 'primary'}
                     loading={
                       (typeof sendingData === 'boolean' && sendingData) ||

--- a/src/components/ComposedModal/ComposedModal.jsx
+++ b/src/components/ComposedModal/ComposedModal.jsx
@@ -11,6 +11,7 @@ import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import styled from 'styled-components';
 import { rem } from 'polished';
+import warning from 'warning';
 
 import { PADDING } from '../../styles/styles';
 import { scrollErrorIntoView } from '../../utils/componentUtilityFunctions';
@@ -133,6 +134,8 @@ export const ComposedModalPropTypes = {
   invalid: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
   /** Callback to submit the dialog/form */
   onSubmit: PropTypes.func,
+  /** Hide the footer */
+  passiveModal: PropTypes.bool,
 };
 
 /**
@@ -166,6 +169,7 @@ class ComposedModal extends React.Component {
     children: null,
     header: {},
     iconDescription: 'Close',
+    passiveModal: false,
   };
 
   componentDidUpdate(prevProps) {
@@ -203,10 +207,18 @@ class ComposedModal extends React.Component {
       onClearError,
       submitFailed,
       invalid,
+      passiveModal,
       ...props
     } = this.props;
     const { label, title, helpText } = header;
     // First check for dataErrors as they are worse than form errors
+
+    if (__DEV__ && passiveModal && (footer || onSubmit)) {
+      warning(
+        false,
+        'You have set passiveModal to true, but also passed a footer or onSubmit handler.  Your footer will not be rendered.'
+      );
+    }
 
     return isFetchingData ? (
       <Loading />
@@ -238,7 +250,7 @@ class ComposedModal extends React.Component {
             onCloseButtonClick={this.handleClearError}
           />
         ) : null}
-        {footer || onSubmit ? (
+        {!passiveModal ? (
           <StyledModalFooter>
             {React.isValidElement(footer) ? (
               footer

--- a/src/components/ComposedModal/ComposedModal.story.jsx
+++ b/src/components/ComposedModal/ComposedModal.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, object } from '@storybook/addon-knobs';
 import styled from 'styled-components';
 
 import ComposedModal from './ComposedModal';
@@ -100,12 +100,11 @@ REDUXFORM or REDUXDIALOG`,
   ))
   .add('primary button is hidden', () => (
     <ComposedModal
-      sendingData
       header={{
         label: 'Custom footer',
         title: 'Custom footer element',
       }}
-      footer={{ isPrimaryButtonHidden: true }}
+      footer={object('footer', { isPrimaryButtonHidden: true, isPrimaryButtonDisabled: false })}
       onClose={action('close')}
     />
   ))

--- a/src/components/ComposedModal/ComposedModal.story.jsx
+++ b/src/components/ComposedModal/ComposedModal.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
 import styled from 'styled-components';
 
 import ComposedModal from './ComposedModal';
@@ -77,11 +78,12 @@ REDUXFORM or REDUXDIALOG`,
   ))
   .add('no footer', () => (
     <ComposedModal
-      sendingData
       header={{
         label: 'No footer',
         title: 'Dialog without footer',
       }}
+      passiveModal={boolean('passiveModal', true)}
+      onSubmit={action('onSubmit')}
       onClose={action('close')}
     />
   ))


### PR DESCRIPTION
**Summary**

- Allows dialog users to disable the primary button with a new isPrimaryButtonDisabled property

**Change List (commits, features, bugs, etc)**

- 

**Acceptance Test (how to verify the PR)**

- Test out the primary button hidden story and see that the isPrimaryButtonDisabled can be set to disable the button
