### PR TITLE
[HierarchyList] re-render on prop change and fix styling

### DIFF
--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 import { caseInsensitiveSearch } from '../../../utils/componentUtilityFunctions';
 import List from '../List';
@@ -128,6 +129,13 @@ const HierarchyList = ({
   const [currentPageNumber, setCurrentPageNumber] = useState(1);
   const [selectedIds, setSelectedIds] = useState([]);
   const [selectedId, setSelectedId] = useState(defaultSelectedId);
+
+  useDeepCompareEffect(
+    () => {
+      setFilteredItems(items);
+    },
+    [items]
+  );
 
   const selectedItemRef = useCallback(node => {
     if (node) {

--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -179,8 +179,8 @@ const ListItem = ({
               {secondaryValue ? (
                 <div
                   title={secondaryValue}
-                  className={`${iotPrefix}--list-item--content--values--secondary
-                   ${iotPrefix}--list-item--content--values--secondary__large`}
+                  className={`${iotPrefix}--list-item--content--values--value
+                   ${iotPrefix}--list-item--content--values--value__large`}
                 >
                   {secondaryValue}
                 </div>
@@ -200,7 +200,7 @@ const ListItem = ({
                 {secondaryValue ? (
                   <div
                     title={secondaryValue}
-                    className={`${iotPrefix}--list-item--content--values--secondary`}
+                    className={`${iotPrefix}--list-item--content--values--value`}
                   >
                     {secondaryValue}
                   </div>

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -63,6 +63,7 @@
       flex: 1;
       max-width: 100%;
       &--main {
+        flex: 1;
         display: flex;
         max-width: 100%;
         align-items: center;
@@ -74,17 +75,10 @@
       }
       &--value {
         flex: 1;
-        margin-right: $spacing-04;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
-      &--secondary {
-        flex: 1;
-        margin-right: $spacing-04;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        padding-right: $spacing-05;
         &__large {
           color: $text-05;
           white-space: wrap;


### PR DESCRIPTION
Closes #927 

**Summary**

- Fixed prop re-render comparison bug
- Fixed spacing issue

**Change List (commits, features, bugs, etc)**

- Added `useDeepCompareEffect` with the `items` dependency to properly re-render
- Changed listItem style to use `padding-right` vs `margin-right` as the node was being moved when the text was too wide

**Acceptance Test (how to verify the PR)**

- Open HierarchyList story in local dev environment
- Change one of the item prop values
- See that the element re-renders
- Proper testing needs a full implementation such as in Monitor
