### PR TITLE
fix(listitem): flex width is corrected

### DIFF
--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -111,7 +111,14 @@ const ListItem = ({
   const handleExpansionClick = () => isExpandable && onExpand(id);
 
   const renderNestingOffset = () =>
-    nestingLevel > 0 ? <div style={{ width: `${nestingLevel * 30}px` }}>&nbsp;</div> : null;
+    nestingLevel > 0 ? (
+      <div
+        className={`${iotPrefix}--list-item--nesting-offset`}
+        style={{ width: `${nestingLevel * 30}px` }}
+      >
+        &nbsp;
+      </div>
+    ) : null;
 
   const renderExpander = () =>
     isExpandable ? (

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -94,7 +94,7 @@
       display: flex;
     }
   }
-  &--list-item--nesting-offset {
+  &--nesting-offset {
     flex-grow: 0;
     flex-shrink: 0;
   }

--- a/src/components/List/ListItem/_list-item.scss
+++ b/src/components/List/ListItem/_list-item.scss
@@ -94,4 +94,8 @@
       display: flex;
     }
   }
+  &--list-item--nesting-offset {
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
 }


### PR DESCRIPTION
Closes #931 

**Summary**

- Added `flex-grow: 0, flex-shrink: 0` to ListItem to fix broken width

**Acceptance Test (how to verify the PR)**

- Add a nested item to List that is wider than the list width and see that the spacing is correct
- Can also verify by inspecting the &nbsp div is set at 30px (it was not before)
