### PR TITLE
fix(tablehead): column resizing bug when columns initially empty

### DIFF
--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -759,8 +759,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
                   title={null}
                 >
                   <thead
-                    onMouseMove={[Function]}
-                    onMouseUp={[Function]}
+                    onMouseMove={null}
+                    onMouseUp={null}
                   >
                     <tr>
                       <th

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1360,8 +1360,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             title={null}
                           >
                             <thead
-                              onMouseMove={[Function]}
-                              onMouseUp={[Function]}
+                              onMouseMove={null}
+                              onMouseUp={null}
                             >
                               <tr>
                                 <th
@@ -3462,8 +3462,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             title={null}
                           >
                             <thead
-                              onMouseMove={[Function]}
-                              onMouseUp={[Function]}
+                              onMouseMove={null}
+                              onMouseUp={null}
                             >
                               <tr>
                                 <th
@@ -5596,8 +5596,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             title={null}
                           >
                             <thead
-                              onMouseMove={[Function]}
-                              onMouseUp={[Function]}
+                              onMouseMove={null}
+                              onMouseUp={null}
                             >
                               <tr>
                                 <th
@@ -7366,8 +7366,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             title={null}
                           >
                             <thead
-                              onMouseMove={[Function]}
-                              onMouseUp={[Function]}
+                              onMouseMove={null}
+                              onMouseUp={null}
                             >
                               <tr>
                                 <th
@@ -10252,8 +10252,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             title={null}
                           >
                             <thead
-                              onMouseMove={[Function]}
-                              onMouseUp={[Function]}
+                              onMouseMove={null}
+                              onMouseUp={null}
                             >
                               <tr>
                                 <th
@@ -22699,8 +22699,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             title={null}
                           >
                             <thead
-                              onMouseMove={[Function]}
-                              onMouseUp={[Function]}
+                              onMouseMove={null}
+                              onMouseUp={null}
                             >
                               <tr>
                                 <th

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useLayoutEffect } from 'react';
 // import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -1401,6 +1401,23 @@ storiesOf('Watson IoT|Table', module)
         propTables: false,
       },
     }
+  )
+  .add('with resize and no initial columns', () =>
+    React.createElement(() => {
+      // Initial render is an empty columns array, which is updated after the first render
+      const [columns, setColumns] = useState([]);
+      useLayoutEffect(() => {
+        setColumns(
+          tableColumns.map((i, idx) => ({
+            width: idx % 2 === 0 ? '100px' : '100px',
+            ...i,
+          }))
+        );
+      }, []);
+      return (
+        <Table options={{ hasResize: true }} columns={columns} data={tableData} actions={actions} />
+      );
+    })
   )
   .add(
     'with custom row height',

--- a/src/components/Table/TableHead/TableHead.test.jsx
+++ b/src/components/Table/TableHead/TableHead.test.jsx
@@ -120,4 +120,36 @@ describe('TableHead', () => {
     const tableHeaders = wrapper.find(TableHeader);
     expect(tableHeaders).toHaveLength(2);
   });
+
+  test('header renders with resizing columns when columns are empty on initial render', () => {
+    const wrapper = mount(
+      <TableHead
+        columns={[]}
+        tableState={{
+          filters: [],
+          expandedIds: [],
+          isSelectAllSelected: false,
+          selectedIds: [],
+          rowActions: [],
+          sort: {},
+          ordering: [],
+          loadingState: { rowCount: 5 },
+          selection: { isSelectAllSelected: false },
+        }}
+        actions={{ onColumnResize: jest.fn() }}
+        options={{ hasResize: true }}
+      />
+    );
+    const tableHeaders = wrapper.find(TableHeader);
+    expect(tableHeaders).toHaveLength(0);
+    // trigger a re-render with non-empty columns
+    wrapper.setProps({ ...commonTableHeadProps, options: { hasResize: true } });
+    // sync enzyme component tree with the updated dom
+    wrapper.update();
+    const tableHeaderResizeHandles = wrapper.find(`div.${iotPrefix}--column-resize-handle`);
+    tableHeaderResizeHandles.first().simulate('mouseDown');
+    tableHeaderResizeHandles.first().simulate('mouseMove');
+    tableHeaderResizeHandles.first().simulate('mouseUp');
+    expect(tableHeaderResizeHandles).toHaveLength(2);
+  });
 });

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -346,8 +346,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -1747,8 +1747,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -3533,8 +3533,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -4157,8 +4157,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -6626,8 +6626,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -8008,8 +8008,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -9362,8 +9362,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -10965,8 +10965,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -12596,8 +12596,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -13978,8 +13978,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -15953,8 +15953,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -17699,8 +17699,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -19376,8 +19376,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -21817,8 +21817,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -23212,8 +23212,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th
@@ -26045,8 +26045,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     title={null}
                   >
                     <thead
-                      onMouseMove={[Function]}
-                      onMouseUp={[Function]}
+                      onMouseMove={null}
+                      onMouseUp={null}
                     >
                       <tr>
                         <th


### PR DESCRIPTION
Closes #933

**Summary**

- Fixes a bug where if the columns array was initially empty, and then subsequently updated with new data - I was able to write a unit test against this bug
- Also refactored a bit while I was in there

**Change List (commits, features, bugs, etc)**

- combination of some null checks and adding appropriate dependencies to the dependency array of a few hooks
- refactor a couple functions to useCallback, since they have dependencies and can be memoized without affecting functionality
- conditionally apply mouse event handlers for only when `useResize=true`
- refactor an abstracted function that was only used in `useLayoutEffect` to be inline there

**Acceptance Test (how to verify the PR)**

- Check out the `with resize and no initial columns` story
