### PR TITLE
fix(list): hide header when no title or buttons are present

### DIFF
--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -22,7 +22,7 @@ export const itemPropTypes = {
 
 const propTypes = {
   /** list title */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   /** search bar call back function and search value */
   search: PropTypes.shape({
     onChange: PropTypes.func,
@@ -59,6 +59,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  title: null,
   search: null,
   buttons: [],
   isFullHeight: false,

--- a/src/components/List/ListHeader/ListHeader.jsx
+++ b/src/components/List/ListHeader/ListHeader.jsx
@@ -29,10 +29,12 @@ const defaultProps = {
 const ListHeader = ({ title, buttons, search, i18n }) => {
   return (
     <div className={`${iotPrefix}--list-header-container`}>
-      <div className={`${iotPrefix}--list-header`}>
-        <div className={`${iotPrefix}--list-header--title`}>{title}</div>
-        <div className={`${iotPrefix}--list-header--btn-container`}>{buttons}</div>
-      </div>
+      {title || (buttons && buttons.length > 0) ? (
+        <div className={`${iotPrefix}--list-header`}>
+          <div className={`${iotPrefix}--list-header--title`}>{title}</div>
+          <div className={`${iotPrefix}--list-header--btn-container`}>{buttons}</div>
+        </div>
+      ) : null}
       {search && (
         <div className={`${iotPrefix}--list-header--search`}>
           <Search

--- a/src/components/List/ListHeader/ListHeader.test.jsx
+++ b/src/components/List/ListHeader/ListHeader.test.jsx
@@ -5,12 +5,17 @@ import ListHeader from './ListHeader';
 
 describe('ListHeader tests', () => {
   test('ListHeader gets rendered', () => {
-    const { getByText } = render(<ListHeader title="List Header" i18n="" />);
+    const { getByText } = render(<ListHeader title="List Header" i18n={{}} />);
     expect(getByText('List Header')).toBeTruthy();
   });
 
   test('ListHeader with defaultProps onChange function', () => {
     expect(ListHeader.defaultProps.search.onChange).toBeDefined();
     ListHeader.defaultProps.search.onChange();
+  });
+
+  test('ListHeader with no title', () => {
+    const { queryByText } = render(<ListHeader i18n={{}} />);
+    expect(queryByText('List Header')).toBeNull();
   });
 });


### PR DESCRIPTION
**Summary**

- When title is `null` (or empty string) and no buttons are provided, hide the header.  This is needed to use List for navigation in some scenarios.

![image](https://user-images.githubusercontent.com/2175647/75066634-d7d10b00-54b0-11ea-94cf-f3c52cf3b696.png)

**Change List (commits, features, bugs, etc)**

- fix(list): hide header when no title or search is present <-- note: I meant to say "buttons" instead of search here... search is rendered below the title/buttons section

**Acceptance Test (how to verify the PR)**

- In the **basic (single column)** story, set the title to an empty string and verify the header is hidden.
