### PR TITLE
fix(accordionitem): change onClick to onHeaderClick

### DIFF
--- a/src/components/Accordion/AccordionItem.jsx
+++ b/src/components/Accordion/AccordionItem.jsx
@@ -15,15 +15,11 @@ const AccordionItem = ({ children, ...props }) => {
     [open]
   );
   const handleToggle = event => {
-    props.onClick(event);
+    props.onHeadingClick(event);
     setOpenState(!openState);
   };
   return (
-    <CarbonAccordionItem
-      data-testid="accordion-item"
-      {...props}
-      onClick={event => handleToggle(event)}
-    >
+    <CarbonAccordionItem data-testid="accordion-item" {...props} onHeadingClick={handleToggle}>
       {openState && children}
     </CarbonAccordionItem>
   );

--- a/src/components/Accordion/AccordionItem.test.jsx
+++ b/src/components/Accordion/AccordionItem.test.jsx
@@ -7,7 +7,7 @@ import { Accordion } from '.';
 
 describe('AccordionItem', () => {
   test('that it conditionally loads', () => {
-    const { getByTestId } = render(
+    const { container, getByTestId } = render(
       <Accordion>
         <AccordionItem id="a" title="Title one">
           <p>This content</p>
@@ -15,7 +15,10 @@ describe('AccordionItem', () => {
       </Accordion>
     );
     expect(getByTestId('accordion-item').lastElementChild.childElementCount).toEqual(0);
-    fireEvent.click(getByTestId('accordion-item'));
+    fireEvent.click(container.querySelector('.bx--accordion__heading'));
+    expect(getByTestId('accordion-item').lastElementChild.childElementCount).toEqual(1);
+    // test that content will not close accordion
+    fireEvent.click(container.querySelector('.bx--accordion__content'));
     expect(getByTestId('accordion-item').lastElementChild.childElementCount).toEqual(1);
   });
 });


### PR DESCRIPTION
Closes #950 

**Summary**

onClick handler should have been onHeaderClick which is the prop Carbon accordion uses to trigger.

**Change List (commits, features, bugs, etc)**

- Switched onClick to onHeaderClick in AccordionItem

**Acceptance Test (how to verify the PR)**

- Open accordion story and try clicking on the content of the accordion. 
