### PR TITLE
fix(table): allow default values to be set

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1144,61 +1144,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         className="bx--toolbar-content iot--table-toolbar-content"
                       >
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
+                          className="iot--table-toolbar-search"
                           onClick={[Function]}
-                          onFocus={[Function]}
-                          role="search"
-                          tabIndex="0"
                         >
                           <div
-                            className="bx--search bx--search--sm table-toolbar-search"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="search"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              autoComplete="off"
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              role="searchbox"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm table-toolbar-search"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -1212,10 +1174,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                autoComplete="off"
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                placeholder="Search"
+                                role="searchbox"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
                         </div>
                         <div
@@ -3203,61 +3209,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         className="bx--toolbar-content iot--table-toolbar-content"
                       >
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
+                          className="iot--table-toolbar-search"
                           onClick={[Function]}
-                          onFocus={[Function]}
-                          role="search"
-                          tabIndex="0"
                         >
                           <div
-                            className="bx--search bx--search--sm table-toolbar-search"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="search"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              autoComplete="off"
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              role="searchbox"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm table-toolbar-search"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -3271,10 +3239,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                autoComplete="off"
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                placeholder="Search"
+                                role="searchbox"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
                         </div>
                         <div
@@ -5294,61 +5306,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         className="bx--toolbar-content iot--table-toolbar-content"
                       >
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
+                          className="iot--table-toolbar-search"
                           onClick={[Function]}
-                          onFocus={[Function]}
-                          role="search"
-                          tabIndex="0"
                         >
                           <div
-                            className="bx--search bx--search--sm table-toolbar-search"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="search"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              autoComplete="off"
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              role="searchbox"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm table-toolbar-search"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -5362,10 +5336,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                autoComplete="off"
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                placeholder="Search"
+                                role="searchbox"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
                         </div>
                         <div
@@ -6969,60 +6987,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         className="bx--toolbar-content iot--table-toolbar-content"
                       >
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
+                          className="iot--table-toolbar-search"
                           onClick={[Function]}
-                          onFocus={[Function]}
-                          role="search"
-                          tabIndex="0"
                         >
                           <div
-                            className="bx--search bx--search--sm table-toolbar-search"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="search"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              autoComplete="off"
-                              className="bx--search-input"
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              role="searchbox"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm table-toolbar-search"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -7036,10 +7017,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                autoComplete="off"
+                                className="bx--search-input"
+                                id="Table-toolbar-search"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                placeholder="Search"
+                                role="searchbox"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
                         </div>
                         <div
@@ -9811,61 +9835,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         className="bx--toolbar-content iot--table-toolbar-content"
                       >
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
+                          className="iot--table-toolbar-search"
                           onClick={[Function]}
-                          onFocus={[Function]}
-                          role="search"
-                          tabIndex="0"
                         >
                           <div
-                            className="bx--search bx--search--sm table-toolbar-search"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="search"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              autoComplete="off"
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              role="searchbox"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm table-toolbar-search"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -9879,10 +9865,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                autoComplete="off"
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                placeholder="Search"
+                                role="searchbox"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
                         </div>
                         <div
@@ -22087,61 +22117,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         className="bx--toolbar-content iot--table-toolbar-content"
                       >
                         <div
-                          className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                          onBlur={[Function]}
+                          className="iot--table-toolbar-search"
                           onClick={[Function]}
-                          onFocus={[Function]}
-                          role="search"
-                          tabIndex="0"
                         >
                           <div
-                            className="bx--search bx--search--sm table-toolbar-search"
+                            className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            role="search"
+                            tabIndex="0"
                           >
-                            <svg
-                              aria-hidden={true}
-                              className="bx--search-magnifier"
-                              focusable="false"
-                              height={16}
-                              preserveAspectRatio="xMidYMid meet"
-                              style={
-                                Object {
-                                  "willChange": "transform",
-                                }
-                              }
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                              />
-                            </svg>
-                            <label
-                              className="bx--label"
-                              htmlFor="Table-toolbar-search"
-                            >
-                              Search
-                            </label>
-                            <input
-                              aria-hidden={true}
-                              autoComplete="off"
-                              className="bx--search-input"
-                              disabled={false}
-                              id="Table-toolbar-search"
-                              onChange={[Function]}
-                              placeholder="Search"
-                              role="searchbox"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              aria-label="Clear search input"
-                              className="bx--search-close bx--search-close--hidden"
-                              onClick={[Function]}
-                              type="button"
+                            <div
+                              className="bx--search bx--search--sm table-toolbar-search"
                             >
                               <svg
                                 aria-hidden={true}
+                                className="bx--search-magnifier"
                                 focusable="false"
                                 height={16}
                                 preserveAspectRatio="xMidYMid meet"
@@ -22155,10 +22147,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                                 xmlns="http://www.w3.org/2000/svg"
                               >
                                 <path
-                                  d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                                 />
                               </svg>
-                            </button>
+                              <label
+                                className="bx--label"
+                                htmlFor="Table-toolbar-search"
+                              >
+                                Search
+                              </label>
+                              <input
+                                aria-hidden={true}
+                                autoComplete="off"
+                                className="bx--search-input"
+                                disabled={false}
+                                id="Table-toolbar-search"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                placeholder="Search"
+                                role="searchbox"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="Clear search input"
+                                className="bx--search-close bx--search-close--hidden"
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  focusable="false"
+                                  height={16}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  style={
+                                    Object {
+                                      "willChange": "transform",
+                                    }
+                                  }
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
                           </div>
                         </div>
                         <div

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1146,6 +1146,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         <div
                           className="iot--table-toolbar-search"
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          tabIndex="-1"
                         >
                           <div
                             className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -3211,6 +3214,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         <div
                           className="iot--table-toolbar-search"
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          tabIndex="-1"
                         >
                           <div
                             className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -5308,6 +5314,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         <div
                           className="iot--table-toolbar-search"
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          tabIndex="-1"
                         >
                           <div
                             className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -6989,6 +6998,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         <div
                           className="iot--table-toolbar-search"
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          tabIndex="-1"
                         >
                           <div
                             className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -9837,6 +9849,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         <div
                           className="iot--table-toolbar-search"
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          tabIndex="-1"
                         >
                           <div
                             className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -22119,6 +22134,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         <div
                           className="iot--table-toolbar-search"
                           onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          tabIndex="-1"
                         >
                           <div
                             className="bx--toolbar-action bx--toolbar-search-container-expandable"

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -723,6 +723,31 @@ storiesOf('Watson IoT|Table', module)
       },
     }
   )
+  .add(
+    'with pre-filled search',
+    () => (
+      <StatefulTable
+        secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
+        style={{ maxWidth: '300px' }}
+        columns={tableColumns.slice(0, 2)}
+        data={tableData}
+        actions={actions}
+        options={{ hasSearch: true, hasPagination: true, hasRowSelection: 'single' }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: 'toyota',
+            },
+          },
+        }}
+      />
+    ),
+    {
+      info: {
+        text: `The table will pre-fill a search value, expand the search input and trigger a search`,
+      },
+    }
+  )
   .add('with multi select and batch actions', () => (
     <StatefulTable
       secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -357,25 +357,9 @@ describe('Table', () => {
     expect(wrapper.find('.bx--search-input')).toHaveLength(1);
     expect(wrapper.find('.bx--search-input').prop('value')).toEqual('toyota');
 
-    const wrapper2 = mount(
-      <Table
-        columns={tableColumns}
-        data={tableData}
-        actions={mockActions}
-        options={{
-          hasSearch: true,
-        }}
-        view={{
-          toolbar: {
-            search: {
-              value: 'ferrari',
-            },
-          },
-        }}
-      />
-    );
+    wrapper.setProps({ view: { toolbar: { search: { defaultValue: 'ferrari' } } } });
+    wrapper.update();
 
-    expect(wrapper2.find('.bx--search-input')).toHaveLength(1);
-    expect(wrapper2.find('.bx--search-input').prop('value')).toEqual('ferrari');
+    expect(wrapper.find('.bx--search-input').prop('value')).toEqual('ferrari');
   });
 });

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -334,4 +334,48 @@ describe('Table', () => {
     fireEvent.keyDown(filterButton, { keyCode: keyCodes.ENTER });
     expect(mockActions.toolbar.onToggleFilter).toHaveBeenCalledTimes(1);
   });
+
+  test('toolbar search should render with default value', () => {
+    const wrapper = mount(
+      <Table
+        columns={tableColumns}
+        data={tableData}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              defaultValue: 'toyota',
+            },
+          },
+        }}
+      />
+    );
+
+    expect(wrapper.find('.bx--search-input')).toHaveLength(1);
+    expect(wrapper.find('.bx--search-input').prop('value')).toEqual('toyota');
+
+    const wrapper2 = mount(
+      <Table
+        columns={tableColumns}
+        data={tableData}
+        actions={mockActions}
+        options={{
+          hasSearch: true,
+        }}
+        view={{
+          toolbar: {
+            search: {
+              value: 'ferrari',
+            },
+          },
+        }}
+      />
+    );
+
+    expect(wrapper2.find('.bx--search-input')).toHaveLength(1);
+    expect(wrapper2.find('.bx--search-input').prop('value')).toEqual('ferrari');
+  });
 });

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -211,5 +211,5 @@ export const defaultI18NPropTypes = {
 };
 
 export const TableSearchPropTypes = PropTypes.shape({
-  value: PropTypes.string,
+  defaultValue: PropTypes.string,
 });

--- a/src/components/Table/TablePropTypes.js
+++ b/src/components/Table/TablePropTypes.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 
+import deprecate from '../../internal/deprecate';
+
 export const RowActionPropTypes = PropTypes.arrayOf(
   PropTypes.shape({
     /** Unique id of the action */
@@ -211,5 +213,12 @@ export const defaultI18NPropTypes = {
 };
 
 export const TableSearchPropTypes = PropTypes.shape({
+  value: deprecate(
+    PropTypes.string,
+    '\n The prop `value` has been deprecated in favor of `defaultValue`'
+  ),
   defaultValue: PropTypes.string,
+  defaultExpanded: PropTypes.bool,
+  onChange: PropTypes.func,
+  onExpand: PropTypes.func,
 });

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -9,6 +9,7 @@ import deprecate from '../../../internal/deprecate';
 import { TableSearchPropTypes, defaultI18NPropTypes } from '../TablePropTypes';
 import { tableTranslateWithId } from '../../../utils/componentUtilityFunctions';
 import { settings } from '../../../constants/Settings';
+import TableToolbarSearch from '../TableToolbarSearch/TableToolbarSearch';
 
 const { iotPrefix } = settings;
 
@@ -18,7 +19,6 @@ const {
   // TableToolbarAction,
   TableBatchActions,
   TableBatchAction,
-  TableToolbarSearch,
 } = DataTable;
 
 const propTypes = {

--- a/src/components/Table/TableToolbarSearch/TableToolbarSearch.jsx
+++ b/src/components/Table/TableToolbarSearch/TableToolbarSearch.jsx
@@ -1,0 +1,101 @@
+/* istanbul ignore file */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { DataTable } from 'carbon-components-react';
+import classnames from 'classnames';
+
+import { settings } from '../../../constants/Settings';
+
+const { iotPrefix } = settings;
+
+const { TableToolbarSearch: CarbonTableToolbarSearch } = DataTable;
+
+const propTypes = {
+  defaultValue: PropTypes.string,
+  defaultExpanded: PropTypes.bool,
+  onChange: PropTypes.func,
+  onExpand: PropTypes.func,
+};
+
+const defaultProps = {
+  defaultValue: '',
+  defaultExpanded: false,
+  onChange: null,
+  onExpand: null,
+};
+
+/**
+ * ----------------------------- WARNING ----------------------------
+ * This is a temporary solution to fix a bug in Carbon 9,
+ * to be removed when we import Carbon 10
+ * ------------------------------------------------------------------
+ */
+const TableToolbarSearch = ({
+  defaultValue,
+  defaultExpanded,
+  onChange: onChangeProp,
+  onExpand,
+  ...other
+}) => {
+  const toolbarSearch = useRef(null);
+  const [expanded, setExpanded] = useState(defaultExpanded || defaultValue);
+  const [focusTarget, setFocusTarget] = useState(null);
+
+  useEffect(
+    () => {
+      if (focusTarget) {
+        focusTarget.current.querySelector('input').focus();
+        setFocusTarget(null);
+      }
+    },
+    [focusTarget]
+  );
+
+  const handleExpand = (event, value) => {
+    setExpanded(value);
+    if (onExpand) {
+      onExpand(event, value);
+    }
+  };
+
+  const onClick = e => {
+    setFocusTarget(toolbarSearch);
+    handleExpand(e, true);
+  };
+
+  const onChange = e => {
+    if (onChangeProp) {
+      onChangeProp(e);
+    }
+  };
+
+  const onBlur = e => {
+    handleExpand(e, e.target.value !== '');
+  };
+
+  return (
+    <div
+      ref={toolbarSearch}
+      className={classnames(`${iotPrefix}--table-toolbar-search`, {
+        [`${iotPrefix}--table-toolbar-search__expanded`]: expanded,
+      })}
+      onClick={onClick}
+    >
+      <CarbonTableToolbarSearch
+        value={defaultValue}
+        expanded={expanded}
+        onChange={onChange}
+        onBlur={onBlur}
+        {...other}
+      />
+    </div>
+  );
+};
+
+TableToolbarSearch.propTypes = propTypes;
+TableToolbarSearch.defaultProps = defaultProps;
+
+export default TableToolbarSearch;

--- a/src/components/Table/TableToolbarSearch/TableToolbarSearch.jsx
+++ b/src/components/Table/TableToolbarSearch/TableToolbarSearch.jsx
@@ -1,6 +1,4 @@
 /* istanbul ignore file */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
@@ -14,13 +12,20 @@ const { iotPrefix } = settings;
 const { TableToolbarSearch: CarbonTableToolbarSearch } = DataTable;
 
 const propTypes = {
+  /** DEPRECATED: use defaultValue instead  */
+  value: PropTypes.string,
+  /** set a defaul value to the search bar and automatically expands it  */
   defaultValue: PropTypes.string,
+  /** renders the search box as expanded by default without setting a default value  */
   defaultExpanded: PropTypes.bool,
+  /** triggered on search change  */
   onChange: PropTypes.func,
+  /** triggered on field expand  */
   onExpand: PropTypes.func,
 };
 
 const defaultProps = {
+  value: '',
   defaultValue: '',
   defaultExpanded: false,
   onChange: null,
@@ -29,19 +34,21 @@ const defaultProps = {
 
 /**
  * ----------------------------- WARNING ----------------------------
- * This is a temporary solution to fix a bug in Carbon 9,
- * to be removed when we import Carbon 10
+ * This is a temporary solution to fix a bug in Carbon 10.9.1
+ * to be removed when we import Carbon 10.10.0 or higher
+ * https://github.com/IBM/carbon-addons-iot-react/issues/975
  * ------------------------------------------------------------------
  */
 const TableToolbarSearch = ({
+  value,
   defaultValue,
   defaultExpanded,
-  onChange: onChangeProp,
+  onChange,
   onExpand,
   ...other
 }) => {
   const toolbarSearch = useRef(null);
-  const [expanded, setExpanded] = useState(defaultExpanded || defaultValue);
+  const [expanded, setExpanded] = useState(defaultExpanded || defaultValue || value);
   const [focusTarget, setFocusTarget] = useState(null);
 
   useEffect(
@@ -54,10 +61,10 @@ const TableToolbarSearch = ({
     [focusTarget]
   );
 
-  const handleExpand = (event, value) => {
-    setExpanded(value);
+  const handleExpand = (event, val) => {
+    setExpanded(val);
     if (onExpand) {
-      onExpand(event, value);
+      onExpand(event, val);
     }
   };
 
@@ -66,26 +73,29 @@ const TableToolbarSearch = ({
     handleExpand(e, true);
   };
 
-  const onChange = e => {
-    if (onChangeProp) {
-      onChangeProp(e);
-    }
-  };
-
   const onBlur = e => {
     handleExpand(e, e.target.value !== '');
   };
 
+  const onKeyDown = e => {
+    if (e.keyCode === 13) {
+      onClick(e);
+    }
+  };
+
   return (
     <div
+      tabIndex="-1"
       ref={toolbarSearch}
       className={classnames(`${iotPrefix}--table-toolbar-search`, {
         [`${iotPrefix}--table-toolbar-search__expanded`]: expanded,
       })}
       onClick={onClick}
+      onKeyDown={onKeyDown}
+      role="button"
     >
       <CarbonTableToolbarSearch
-        value={defaultValue}
+        value={defaultValue || value}
         expanded={expanded}
         onChange={onChange}
         onBlur={onBlur}

--- a/src/components/Table/TableToolbarSearch/_table-toolbar-search.scss
+++ b/src/components/Table/TableToolbarSearch/_table-toolbar-search.scss
@@ -1,0 +1,12 @@
+@import '~carbon-components/scss/globals/scss/vars';
+@import '../../../globals/vars';
+
+.#{$iot-prefix}--table-toolbar-search {
+  display: flex;
+  flex: 0;
+  width: 100%;
+}
+
+.#{$iot-prefix}--table-toolbar-search__expanded {
+  flex: 1;
+}

--- a/src/components/Table/TableToolbarSearch/_table-toolbar-search.scss
+++ b/src/components/Table/TableToolbarSearch/_table-toolbar-search.scss
@@ -1,10 +1,13 @@
-@import '~carbon-components/scss/globals/scss/vars';
 @import '../../../globals/vars';
 
 .#{$iot-prefix}--table-toolbar-search {
   display: flex;
   flex: 0;
   width: 100%;
+  outline: none;
+  .bx--toolbar-action:focus {
+    outline: 2px solid #0062ff !important;
+  }
 }
 
 .#{$iot-prefix}--table-toolbar-search__expanded {

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -125,6 +125,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -1506,6 +1509,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -3251,6 +3257,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -3886,6 +3895,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -6306,6 +6318,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -7668,6 +7683,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -9030,6 +9048,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -10613,6 +10634,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -12196,6 +12220,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -13558,6 +13585,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -15513,6 +15543,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -17239,6 +17272,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -18924,6 +18960,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -21345,6 +21384,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -22720,6 +22762,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"
@@ -25505,6 +25550,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 <div
                   className="iot--table-toolbar-search"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
                 >
                   <div
                     className="bx--toolbar-action bx--toolbar-search-container-expandable"

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -123,1436 +123,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      disabled={true}
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="download-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Download table content"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
-                    />
-                    <path
-                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="filter-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="card--toolbar"
-                >
-                  <div
-                    className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
-                      title="Open and close list of options"
-                    >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={16}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <circle
-                          cx="8"
-                          cy="3"
-                          r="1"
-                        />
-                        <circle
-                          cx="8"
-                          cy="8"
-                          r="1"
-                        />
-                        <circle
-                          cx="8"
-                          cy="13"
-                          r="1"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <table
-                className="bx--data-table bx--data-table--no-border"
-                title={null}
-              >
-                <thead
-                  onMouseMove={null}
-                  onMouseUp={null}
-                >
-                  <tr>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="alert"
-                        id="column-alert"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Alert"
-                          >
-                            Alert
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="hour"
-                        id="column-hour"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Hour"
-                          >
-                            Hour
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="pressure"
-                        id="column-pressure"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Pressure"
-                          >
-                            Pressure
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody
-                  aria-live="polite"
-                >
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-0-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-0-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-0-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-1-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-1-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-1-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-2-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-2-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-2-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-4-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-4-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-4-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-5-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-5-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-5-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-6-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-6-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-6-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-7-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-7-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-7-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-8-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-8-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-8-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-9-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-9-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="hh:mm:ss"
-                        >
-                          hh:mm:ss
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-sample-values-table-list-9-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="--"
-                        >
-                          --
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              disabled={false}
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-29"
-                  id="bx-pagination-select-29-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-29"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 10 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-31"
-                    >
-                      Page number, of 1 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-31"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 1 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23L11 16 19 9 19 23z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9L21 16 13 23 13 9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard editable with expanded rows 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 izWJSI"
-        id="table-list"
-      >
-        <div
-          className="Card__CardContent-v5r71h-1 flVXpj"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions iot--table-batch-actions"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-Table"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    className="bx--tooltip__trigger"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
                     onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
-                >
-                  <div
-                    className="bx--search bx--search--sm table-toolbar-search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      disabled={true}
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -1566,10 +153,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        disabled={true}
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -1703,10 +334,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   onMouseUp={null}
                 >
                   <tr>
-                    <th
-                      className="bx--table-expand"
-                      scope="col"
-                    />
                     <th
                       aria-sort="none"
                       className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
@@ -1920,45 +547,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   aria-live="polite"
                 >
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2015,45 +606,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2110,45 +665,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2205,45 +724,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2300,45 +783,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2395,45 +842,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2490,45 +901,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2585,45 +960,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2680,45 +1019,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -2775,45 +1078,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                     </td>
                   </tr>
                   <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 hdodpz"
                     onClick={[Function]}
                   >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
                     <td
                       align="start"
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
@@ -3114,6 +1381,1751 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard editable with expanded rows 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 izWJSI"
+        id="table-list"
+      >
+        <div
+          className="Card__CardContent-v5r71h-1 flVXpj"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions iot--table-batch-actions"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-Table"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+              >
+                <div
+                  className="iot--table-toolbar-search"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
+                  >
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--search-magnifier"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                        />
+                      </svg>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        disabled={true}
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="download-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Download table content"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
+                    />
+                    <path
+                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="filter-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="card--toolbar"
+                >
+                  <div
+                    className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                      title="Open and close list of options"
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="8"
+                          cy="3"
+                          r="1"
+                        />
+                        <circle
+                          cx="8"
+                          cy="8"
+                          r="1"
+                        />
+                        <circle
+                          cx="8"
+                          cy="13"
+                          r="1"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <table
+                className="bx--data-table bx--data-table--no-border"
+                title={null}
+              >
+                <thead
+                  onMouseMove={null}
+                  onMouseUp={null}
+                >
+                  <tr>
+                    <th
+                      className="bx--table-expand"
+                      scope="col"
+                    />
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="alert"
+                        id="column-alert"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Alert"
+                          >
+                            Alert
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="hour"
+                        id="column-hour"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Hour"
+                          >
+                            Hour
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="pressure"
+                        id="column-pressure"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Pressure"
+                          >
+                            Pressure
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  aria-live="polite"
+                >
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-0-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-0-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-0-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-1-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-1-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-1-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-2-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-2-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-2-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-4-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-4-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-4-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-5-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-5-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-5-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-6-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-6-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-6-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-7-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-7-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-7-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-8-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-8-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-8-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-9-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-9-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="hh:mm:ss"
+                        >
+                          hh:mm:ss
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-sample-values-table-list-9-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="--"
+                        >
+                          --
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              disabled={false}
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-31"
+                  id="bx-pagination-select-31-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-31"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 10 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-33"
+                    >
+                      Page number, of 1 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-33"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 1 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23L11 16 19 9 19 23z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9L21 16 13 23 13 9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard empty table 1`] = `
 <div
   className="storybook-container"
@@ -3237,60 +3249,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -3304,10 +3279,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -3866,60 +3884,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -3933,10 +3914,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -5921,8 +5945,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-32"
-                  id="bx-pagination-select-32-count-label"
+                  htmlFor="bx-pagination-select-33"
+                  id="bx-pagination-select-33-count-label"
                 >
                   Items per page:
                 </label>
@@ -5941,7 +5965,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-33"
                           onChange={[Function]}
                           value={10}
                         >
@@ -6010,7 +6034,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-34"
+                      htmlFor="bx-pagination-select-35"
                     >
                       Page number, of 2 pages
                     </label>
@@ -6023,7 +6047,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34"
+                          id="bx-pagination-select-35"
                           onChange={[Function]}
                           value={1}
                         >
@@ -6280,60 +6304,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -6347,10 +6334,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -7277,8 +7307,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-28"
-                  id="bx-pagination-select-28-count-label"
+                  htmlFor="bx-pagination-select-29"
+                  id="bx-pagination-select-29-count-label"
                 >
                   Items per page:
                 </label>
@@ -7297,7 +7327,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7366,7 +7396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-30"
+                      htmlFor="bx-pagination-select-31"
                     >
                       Page number, of 2 pages
                     </label>
@@ -7379,7 +7409,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30"
+                          id="bx-pagination-select-31"
                           onChange={[Function]}
                           value={1}
                         >
@@ -7636,60 +7666,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -7703,10 +7696,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -8633,8 +8669,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-18"
-                  id="bx-pagination-select-18-count-label"
+                  htmlFor="bx-pagination-select-19"
+                  id="bx-pagination-select-19-count-label"
                 >
                   Items per page:
                 </label>
@@ -8653,7 +8689,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-18"
+                          id="bx-pagination-select-19"
                           onChange={[Function]}
                           value={10}
                         >
@@ -8722,7 +8758,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-20"
+                      htmlFor="bx-pagination-select-21"
                     >
                       Page number, of 2 pages
                     </label>
@@ -8735,7 +8771,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-20"
+                          id="bx-pagination-select-21"
                           onChange={[Function]}
                           value={1}
                         >
@@ -8992,60 +9028,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -9059,10 +9058,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -10210,8 +10252,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-19"
-                  id="bx-pagination-select-19-count-label"
+                  htmlFor="bx-pagination-select-20"
+                  id="bx-pagination-select-20-count-label"
                 >
                   Items per page:
                 </label>
@@ -10230,7 +10272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-19"
+                          id="bx-pagination-select-20"
                           onChange={[Function]}
                           value={10}
                         >
@@ -10299,7 +10341,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-21"
+                      htmlFor="bx-pagination-select-22"
                     >
                       Page number, of 2 pages
                     </label>
@@ -10312,7 +10354,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-21"
+                          id="bx-pagination-select-22"
                           onChange={[Function]}
                           value={1}
                         >
@@ -10569,60 +10611,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -10636,10 +10641,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -11787,8 +11835,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-25"
-                  id="bx-pagination-select-25-count-label"
+                  htmlFor="bx-pagination-select-26"
+                  id="bx-pagination-select-26-count-label"
                 >
                   Items per page:
                 </label>
@@ -11807,7 +11855,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={10}
                         >
@@ -11876,7 +11924,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-27"
+                      htmlFor="bx-pagination-select-28"
                     >
                       Page number, of 2 pages
                     </label>
@@ -11889,7 +11937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={1}
                         >
@@ -12146,60 +12194,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -12213,10 +12224,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -13143,8 +13197,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-26"
-                  id="bx-pagination-select-26-count-label"
+                  htmlFor="bx-pagination-select-27"
+                  id="bx-pagination-select-27-count-label"
                 >
                   Items per page:
                 </label>
@@ -13163,7 +13217,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13232,7 +13286,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-28"
+                      htmlFor="bx-pagination-select-29"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13245,7 +13299,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={1}
                         >
@@ -13502,60 +13556,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -13569,10 +13586,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -15072,3405 +15132,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                             />
                           </svg>
                         </button>
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              disabled={false}
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-20"
-                  id="bx-pagination-select-20-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-20"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-22"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-22"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23L11 16 19 9 19 23z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9L21 16 13 23 13 9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with row expansion 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 izWJSI"
-        id="table-list"
-      >
-        <div
-          className="Card__CardContent-v5r71h-1 flVXpj"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions iot--table-batch-actions"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-Table"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
-                >
-                  <div
-                    className="bx--search bx--search--sm table-toolbar-search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="download-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Download table content"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
-                    />
-                    <path
-                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="filter-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="card--toolbar"
-                >
-                  <div
-                    className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="card--toolbar-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
-                      title="Open and close list of options"
-                    >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={20}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                        />
-                        <path
-                          d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                  <button
-                    className="card--toolbar-action CardToolbar__ToolbarSVGWrapper-sc-1ekh8ti-0 ighPOu"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      description="Expand to fullscreen"
-                      focusable="false"
-                      height={20}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      title="Expand to fullscreen"
-                      viewBox="0 0 32 32"
-                      width={20}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
-                      />
-                      <path
-                        d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <table
-                className="bx--data-table bx--data-table--no-border"
-                title={null}
-              >
-                <thead
-                  onMouseMove={null}
-                  onMouseUp={null}
-                >
-                  <tr>
-                    <th
-                      className="bx--table-expand"
-                      scope="col"
-                    />
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="alert"
-                        id="column-alert"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Alert"
-                          >
-                            Alert
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="hour"
-                        id="column-hour"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Hour"
-                          >
-                            Hour
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="pressure"
-                        id="column-pressure"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Pressure"
-                          >
-                            Pressure
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody
-                  aria-live="polite"
-                >
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-1-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI005 Asset failure"
-                        >
-                          AHI005 Asset failure
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-1-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-1-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-2-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI003 process need to optimize adjust X variables"
-                        >
-                          AHI003 process need to optimize adjust X variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-2-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-2-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-6-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize."
-                        >
-                          AHI001 proccess need to optimize.
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-6-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-6-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-4-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-4-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-4-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-8-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-8-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-8-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-9-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-9-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-9-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-5-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize"
-                        >
-                          AHI001 proccess need to optimize
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-5-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-5-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              disabled={false}
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-27"
-                  id="bx-pagination-select-27-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-27"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-29"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-29"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23L11 16 19 9 19 23z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9L21 16 13 23 13 9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": "12px",
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with single actions 1`] = `
-<div
-  className="storybook-container"
-  style={
-    Object {
-      "padding": "3rem",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="Card__CardWrapper-v5r71h-0 izWJSI"
-        id="table-list"
-      >
-        <div
-          className="Card__CardContent-v5r71h-1 flVXpj"
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions iot--table-batch-actions"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-Table"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-              >
-                <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
-                >
-                  <div
-                    className="bx--search bx--search--sm table-toolbar-search"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="download-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Download table content"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
-                    />
-                    <path
-                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="filter-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="card--toolbar"
-                >
-                  <div
-                    className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="card--toolbar-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
-                      title="Open and close list of options"
-                    >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={20}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                        />
-                        <path
-                          d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                  <button
-                    className="card--toolbar-action CardToolbar__ToolbarSVGWrapper-sc-1ekh8ti-0 ighPOu"
-                    onClick={[Function]}
-                  >
-                    <svg
-                      description="Expand to fullscreen"
-                      focusable="false"
-                      height={20}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      title="Expand to fullscreen"
-                      viewBox="0 0 32 32"
-                      width={20}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
-                      />
-                      <path
-                        d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <table
-                className="bx--data-table bx--data-table--no-border"
-                title={null}
-              >
-                <thead
-                  onMouseMove={null}
-                  onMouseUp={null}
-                >
-                  <tr>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="alert"
-                        id="column-alert"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Alert"
-                          >
-                            Alert
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="hour"
-                        id="column-hour"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Hour"
-                          >
-                            Hour
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="pressure"
-                        id="column-pressure"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Pressure"
-                          >
-                            Pressure
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      align="start"
-                      className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-0 foRRTU"
-                      data-column="actionColumn"
-                      id="column-actionColumn"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                      width="60px"
-                    >
-                      <span
-                        className="bx--table-header-label"
-                      >
-                        <span
-                          title=""
-                        >
-                          
-                        </span>
-                      </span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody
-                  aria-live="polite"
-                >
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-11-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-10-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-1-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI005 Asset failure"
-                        >
-                          AHI005 Asset failure
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-1-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-1-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-1-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-2-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI003 process need to optimize adjust X variables"
-                        >
-                          AHI003 process need to optimize adjust X variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-2-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-2-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-2-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-6-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize."
-                        >
-                          AHI001 proccess need to optimize.
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-6-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-6-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-6-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-4-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-4-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-4-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-4-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-8-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-8-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-8-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-8-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-9-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-9-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-9-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-9-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-3-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-Table-row-5-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize"
-                        >
-                          AHI001 proccess need to optimize
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-Table-row-5-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-Table-row-5-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-Table-row-5-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
                       </span>
                     </td>
                   </tr>
@@ -18727,6 +15388,3417 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with row expansion 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 izWJSI"
+        id="table-list"
+      >
+        <div
+          className="Card__CardContent-v5r71h-1 flVXpj"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions iot--table-batch-actions"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-Table"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+              >
+                <div
+                  className="iot--table-toolbar-search"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
+                  >
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--search-magnifier"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                        />
+                      </svg>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="download-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Download table content"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
+                    />
+                    <path
+                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="filter-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="card--toolbar"
+                >
+                  <div
+                    className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="card--toolbar-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                      title="Open and close list of options"
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={20}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                        />
+                        <path
+                          d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                        />
+                        <path
+                          d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    className="card--toolbar-action CardToolbar__ToolbarSVGWrapper-sc-1ekh8ti-0 ighPOu"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      description="Expand to fullscreen"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      title="Expand to fullscreen"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                      />
+                      <path
+                        d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <table
+                className="bx--data-table bx--data-table--no-border"
+                title={null}
+              >
+                <thead
+                  onMouseMove={null}
+                  onMouseUp={null}
+                >
+                  <tr>
+                    <th
+                      className="bx--table-expand"
+                      scope="col"
+                    />
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="alert"
+                        id="column-alert"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Alert"
+                          >
+                            Alert
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="hour"
+                        id="column-hour"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Hour"
+                          >
+                            Hour
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="pressure"
+                        id="column-pressure"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Pressure"
+                          >
+                            Pressure
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  aria-live="polite"
+                >
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-10-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-10-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-10-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-1-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI005 Asset failure"
+                        >
+                          AHI005 Asset failure
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-1-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-1-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-2-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI003 process need to optimize adjust X variables"
+                        >
+                          AHI003 process need to optimize adjust X variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-2-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-2-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-6-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize."
+                        >
+                          AHI001 proccess need to optimize.
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-6-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-6-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-4-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-4-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-4-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-8-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-8-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-8-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-9-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-9-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-9-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-5-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize"
+                        >
+                          AHI001 proccess need to optimize
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-5-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-5-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              disabled={false}
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-28"
+                  id="bx-pagination-select-28-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-28"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-30"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-30"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23L11 16 19 9 19 23z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9L21 16 13 23 13 9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with single actions 1`] = `
+<div
+  className="storybook-container"
+  style={
+    Object {
+      "padding": "3rem",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="Card__CardWrapper-v5r71h-0 izWJSI"
+        id="table-list"
+      >
+        <div
+          className="Card__CardContent-v5r71h-1 flVXpj"
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions iot--table-batch-actions"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-Table"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    aria-haspopup="true"
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+              >
+                <div
+                  className="iot--table-toolbar-search"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
+                  >
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--search-magnifier"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                        />
+                      </svg>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="download-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Download table content"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
+                    />
+                    <path
+                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="filter-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="card--toolbar"
+                >
+                  <div
+                    className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="card--toolbar-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                      title="Open and close list of options"
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={20}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                        />
+                        <path
+                          d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                        />
+                        <path
+                          d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    className="card--toolbar-action CardToolbar__ToolbarSVGWrapper-sc-1ekh8ti-0 ighPOu"
+                    onClick={[Function]}
+                  >
+                    <svg
+                      description="Expand to fullscreen"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      title="Expand to fullscreen"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
+                      />
+                      <path
+                        d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <table
+                className="bx--data-table bx--data-table--no-border"
+                title={null}
+              >
+                <thead
+                  onMouseMove={null}
+                  onMouseUp={null}
+                >
+                  <tr>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="alert"
+                        id="column-alert"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Alert"
+                          >
+                            Alert
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="hour"
+                        id="column-hour"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Hour"
+                          >
+                            Hour
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="pressure"
+                        id="column-pressure"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            title="Pressure"
+                          >
+                            Pressure
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      align="start"
+                      className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-0 foRRTU"
+                      data-column="actionColumn"
+                      id="column-actionColumn"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                      width="60px"
+                    >
+                      <span
+                        className="bx--table-header-label"
+                      >
+                        <span
+                          title=""
+                        >
+                          
+                        </span>
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  aria-live="polite"
+                >
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-11-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-10-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-10-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-10-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-10-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-1-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI005 Asset failure"
+                        >
+                          AHI005 Asset failure
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-1-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-1-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-1-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-2-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI003 process need to optimize adjust X variables"
+                        >
+                          AHI003 process need to optimize adjust X variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-2-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-2-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-2-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-6-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize."
+                        >
+                          AHI001 proccess need to optimize.
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-6-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-6-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-6-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-4-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-4-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-4-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-4-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-8-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-8-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-8-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-8-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-9-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-9-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-9-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-9-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-3-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-Table-row-5-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize"
+                        >
+                          AHI001 proccess need to optimize
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-Table-row-5-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-Table-row-5-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-Table-row-5-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              disabled={false}
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-22"
+                  id="bx-pagination-select-22-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-22"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-24"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-24"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M19 23L11 16 19 9 19 23z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
+                      }
+                    }
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 9L21 16 13 23 13 9z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": "12px",
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard table with thresholds 1`] = `
 <div
   className="storybook-container"
@@ -18850,60 +18922,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -18917,10 +18952,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -20906,8 +20984,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-23"
-                  id="bx-pagination-select-23-count-label"
+                  htmlFor="bx-pagination-select-24"
+                  id="bx-pagination-select-24-count-label"
                 >
                   Items per page:
                 </label>
@@ -20926,7 +21004,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23"
+                          id="bx-pagination-select-24"
                           onChange={[Function]}
                           value={10}
                         >
@@ -20995,7 +21073,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-25"
+                      htmlFor="bx-pagination-select-26"
                     >
                       Page number, of 2 pages
                     </label>
@@ -21008,7 +21086,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={1}
                         >
@@ -21265,60 +21343,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -21332,10 +21373,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -22283,8 +22367,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-24"
-                  id="bx-pagination-select-24-count-label"
+                  htmlFor="bx-pagination-select-25"
+                  id="bx-pagination-select-25-count-label"
                 >
                   Items per page:
                 </label>
@@ -22303,7 +22387,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={10}
                         >
@@ -22372,7 +22456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-26"
+                      htmlFor="bx-pagination-select-27"
                     >
                       Page number, of 1 pages
                     </label>
@@ -22385,7 +22469,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={1}
                         >
@@ -22634,60 +22718,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -22701,10 +22748,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -25054,8 +25144,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-22"
-                  id="bx-pagination-select-22-count-label"
+                  htmlFor="bx-pagination-select-23"
+                  id="bx-pagination-select-23-count-label"
                 >
                   Items per page:
                 </label>
@@ -25074,7 +25164,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-22"
+                          id="bx-pagination-select-23"
                           onChange={[Function]}
                           value={10}
                         >
@@ -25143,7 +25233,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-24"
+                      htmlFor="bx-pagination-select-25"
                     >
                       Page number, of 2 pages
                     </label>
@@ -25156,7 +25246,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={1}
                         >
@@ -25413,60 +25503,23 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                 className="bx--toolbar-content iot--table-toolbar-content"
               >
                 <div
-                  className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                  onBlur={[Function]}
+                  className="iot--table-toolbar-search"
                   onClick={[Function]}
-                  onFocus={[Function]}
-                  role="search"
-                  tabIndex="0"
                 >
                   <div
-                    className="bx--search bx--search--sm table-toolbar-search"
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="search"
+                    tabIndex="0"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="bx--search-magnifier"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                      />
-                    </svg>
-                    <label
-                      className="bx--label"
-                      htmlFor="Table-toolbar-search"
-                    >
-                      Search
-                    </label>
-                    <input
-                      aria-hidden={true}
-                      autoComplete="off"
-                      className="bx--search-input"
-                      id="Table-toolbar-search"
-                      onChange={[Function]}
-                      placeholder="Search"
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Clear search input"
-                      className="bx--search-close bx--search-close--hidden"
-                      onClick={[Function]}
-                      type="button"
+                    <div
+                      className="bx--search bx--search--sm table-toolbar-search"
                     >
                       <svg
                         aria-hidden={true}
+                        className="bx--search-magnifier"
                         focusable="false"
                         height={16}
                         preserveAspectRatio="xMidYMid meet"
@@ -25480,10 +25533,53 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
                         />
                       </svg>
-                    </button>
+                      <label
+                        className="bx--label"
+                        htmlFor="Table-toolbar-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="Table-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -27374,8 +27470,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-31"
-                  id="bx-pagination-select-31-count-label"
+                  htmlFor="bx-pagination-select-32"
+                  id="bx-pagination-select-32-count-label"
                 >
                   Items per page:
                 </label>
@@ -27394,7 +27490,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
+                          id="bx-pagination-select-32"
                           onChange={[Function]}
                           value={10}
                         >
@@ -27463,7 +27559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-33"
+                      htmlFor="bx-pagination-select-34"
                     >
                       Page number, of 2 pages
                     </label>
@@ -27476,7 +27572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33"
+                          id="bx-pagination-select-34"
                           onChange={[Function]}
                           value={1}
                         >

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ export TableHead from './components/Table/TableHead/TableHead';
 export TableBody from './components/Table/TableBody/TableBody';
 export TableSkeletonWithHeaders from './components/Table/TableSkeletonWithHeaders/TableSkeletonWithHeaders';
 export TableToolbar from './components/Table/TableToolbar/TableToolbar';
+export TableToolbarSearch from './components/Table/TableToolbarSearch/TableToolbarSearch';
 export WizardModal from './components/WizardModal';
 export WizardInline from './components/WizardInline/WizardInline';
 export StatefulWizardInline from './components/WizardInline/StatefulWizardInline';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -184,11 +184,8 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/WizardInline/wizard-inline';
 @import 'components/TileGallery/tile-gallery';
 @import 'components/Table/TableToolbar/table-toolbar';
-<<<<<<< HEAD
 @import 'components/Table/pagination';
-=======
 @import 'components/Table/TableToolbarSearch/table-toolbar-search';
->>>>>>> fix(table): allow default values to be set
 @import 'components/Table/table';
 @import 'components/Button/button';
 @import 'components/SimplePagination/simple-pagination';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -184,7 +184,11 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/WizardInline/wizard-inline';
 @import 'components/TileGallery/tile-gallery';
 @import 'components/Table/TableToolbar/table-toolbar';
+<<<<<<< HEAD
 @import 'components/Table/pagination';
+=======
+@import 'components/Table/TableToolbarSearch/table-toolbar-search';
+>>>>>>> fix(table): allow default values to be set
 @import 'components/Table/table';
 @import 'components/Button/button';
 @import 'components/SimplePagination/simple-pagination';


### PR DESCRIPTION
#429

Closes #429

**Summary**
While we wait for Carbon 10 to be released and referenced, this is a port of their fix: https://github.com/carbon-design-system/carbon/commit/e97a7ed9be2911707066c406544310f6cb76f273

The default value can now be set with `view.toolbar.search.defaultValue`

**Change List (commits, features, bugs, etc)**

- Added a wrapper around TableToolbarSearch

**Acceptance Test (how to verify the PR)**

- Added a new story on ?path=/story/watson-iot-table--with-pre-filled-search
