### PR TITLE
fix(card-sizes): Update card sizes and card names

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -3,12 +3,14 @@ import VisibilitySensor from 'react-visibility-sensor';
 import { Tooltip, SkeletonText } from 'carbon-components-react';
 import styled from 'styled-components';
 import SizeMe from 'react-sizeme';
+import warning from 'warning';
 
 import { settings } from '../../constants/Settings';
 import {
   CARD_TITLE_HEIGHT,
   CARD_CONTENT_PADDING,
   CARD_SIZES,
+  CARD_LAYOUTS,
   ROW_HEIGHT,
   CARD_DIMENSIONS,
   DASHBOARD_BREAKPOINTS,
@@ -75,8 +77,8 @@ const EmptyMessageWrapper = styled.div`
 `;
 
 export const defaultProps = {
-  size: CARD_SIZES.SMALL,
-  layout: CARD_SIZES.HORIZONTAL,
+  size: CARD_SIZES.MEDIUMTHIN,
+  layout: CARD_LAYOUTS.HORIZONTAL,
   title: undefined,
   toolbar: undefined,
   hideHeader: false,
@@ -158,10 +160,33 @@ const Card = props => {
     values,
     ...others
   } = props;
-  const isXS = size === CARD_SIZES.XSMALL;
+  // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
+  const changedSize =
+    size === 'XSMALL'
+      ? 'SMALL'
+      : size === 'XSMALLWIDE'
+      ? 'SMALLWIDE'
+      : size === 'WIDE'
+      ? 'MEDIUMWIDE'
+      : size === 'TALL'
+      ? 'LARGETHIN'
+      : size === 'XLARGE'
+      ? 'LARGEWIDE'
+      : null;
+  let newSize = size;
+  if (changedSize) {
+    warning(
+      false,
+      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
+    );
+    newSize = changedSize;
+  }
+
+  const isSM = newSize === CARD_SIZES.SMALL;
+
   const dimensions = getCardMinSize(
     breakpoint,
-    size,
+    newSize,
     others.dashboardBreakpoints,
     others.cardDimensions,
     others.rowHeight,
@@ -278,20 +303,20 @@ const Card = props => {
                       <OptimizedSkeletonText
                         paragraph
                         lineCount={
-                          size === CARD_SIZES.XSMALL || size === CARD_SIZES.XSMALLWIDE ? 2 : 3
+                          newSize === CARD_SIZES.SMALL || newSize === CARD_SIZES.SMALLWIDE ? 2 : 3
                         }
                         width="100%"
                       />
                     </SkeletonWrapper>
                   ) : error ? (
                     <EmptyMessageWrapper>
-                      {size === CARD_SIZES.XSMALL || size === CARD_SIZES.XSMALLWIDE
+                      {newSize === CARD_SIZES.SMALL || newSize === CARD_SIZES.SMALLWIDE
                         ? strings.errorLoadingDataShortLabel
                         : `${strings.errorLoadingDataLabel} ${error}`}
                     </EmptyMessageWrapper>
                   ) : isEmpty && !isEditable ? (
                     <EmptyMessageWrapper>
-                      {isXS ? strings.noDataShortLabel : strings.noDataLabel}
+                      {isSM ? strings.noDataShortLabel : strings.noDataLabel}
                     </EmptyMessageWrapper>
                   ) : typeof children === 'function' ? ( // pass the measured size down to the children if it's an render function
                     children(getChildSize(cardSize, title), { cardToolbar, ...props })

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -3,7 +3,6 @@ import VisibilitySensor from 'react-visibility-sensor';
 import { Tooltip, SkeletonText } from 'carbon-components-react';
 import styled from 'styled-components';
 import SizeMe from 'react-sizeme';
-import warning from 'warning';
 
 import { settings } from '../../constants/Settings';
 import {
@@ -19,6 +18,7 @@ import {
 } from '../../constants/LayoutConstants';
 import { CardPropTypes } from '../../constants/PropTypes';
 import { getCardMinSize } from '../../utils/componentUtilityFunctions';
+import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
 
 import CardToolbar from './CardToolbar';
 
@@ -161,26 +161,7 @@ const Card = props => {
     ...others
   } = props;
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
-  const changedSize =
-    size === 'XSMALL'
-      ? 'SMALL'
-      : size === 'XSMALLWIDE'
-      ? 'SMALLWIDE'
-      : size === 'WIDE'
-      ? 'MEDIUMWIDE'
-      : size === 'TALL'
-      ? 'LARGETHIN'
-      : size === 'XLARGE'
-      ? 'LARGEWIDE'
-      : null;
-  let newSize = size;
-  if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
-    newSize = changedSize;
-  }
+  const newSize = getUpdatedCardSize(size);
 
   const isSM = newSize === CARD_SIZES.SMALL;
 

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -77,7 +77,7 @@ const EmptyMessageWrapper = styled.div`
 `;
 
 export const defaultProps = {
-  size: CARD_SIZES.MEDIUMTHIN,
+  size: CARD_SIZES.MEDIUM,
   layout: CARD_LAYOUTS.HORIZONTAL,
   title: undefined,
   toolbar: undefined,

--- a/src/components/Card/Card.story.jsx
+++ b/src/components/Card/Card.story.jsx
@@ -192,7 +192,7 @@ storiesOf('Watson IoT|Card', module)
             isEditable={boolean('isEditable', false)}
             isExpanded={boolean('isExpanded', false)}
             breakpoint="lg"
-            availableActions={{ range: i !== CARD_SIZES.XSMALL }}
+            availableActions={{ range: i !== CARD_SIZES.SMALL }}
             onCardAction={action('onCardAction')}
           />
         </div>
@@ -216,7 +216,7 @@ storiesOf('Watson IoT|Card', module)
     );
   })
   .add('error/small', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <Card
@@ -269,7 +269,7 @@ storiesOf('Watson IoT|Card', module)
           size={size}
           isEditable={boolean('isEditable', false)}
           values={[{ timestamp: 12341231231, value1: 'my value' }]}
-          availableActions={{ range: size !== CARD_SIZES.XSMALL, expand: true }}
+          availableActions={{ range: size !== CARD_SIZES.SMALL, expand: true }}
           onCardAction={action('onCardAction')}
         />
       );

--- a/src/components/Card/Card.test.jsx
+++ b/src/components/Card/Card.test.jsx
@@ -19,7 +19,7 @@ const cardProps = {
 };
 
 describe('Card testcases', () => {
-  test('xsmall', () => {
+  test('small', () => {
     const wrapper = mount(<Card {...cardProps} size={CARD_SIZES.SMALL} />);
 
     // small should have full header
@@ -62,7 +62,7 @@ describe('Card testcases', () => {
     wrapper = mount(
       <Card
         {...cardProps}
-        size={CARD_SIZES.XSMALL}
+        size={CARD_SIZES.SMALL}
         availableActions={{ range: true, expand: true }}
       />
     );
@@ -72,7 +72,7 @@ describe('Card testcases', () => {
     expect(wrapper.find(Popup20)).toHaveLength(1);
 
     wrapper = mount(
-      <Card {...cardProps} size={CARD_SIZES.XSMALL} isEditable availableActions={{ range: true }} />
+      <Card {...cardProps} size={CARD_SIZES.SMALL} isEditable availableActions={{ range: true }} />
     );
     // CardRangePicker icon should not render if isEditable prop is true
     expect(wrapper.find(CardRangePicker)).toHaveLength(0);
@@ -86,7 +86,7 @@ describe('Card testcases', () => {
     expect(wrapper.find(SkeletonWrapper)).toHaveLength(0);
     // with the isLoading prop SkeletonWrapper should  be rendered
     wrapper = mount(
-      <Card {...cardProps} isLoading size={CARD_SIZES.XSMALLWIDE} tooltip={tooltipElement} />
+      <Card {...cardProps} isLoading size={CARD_SIZES.SMALLWIDE} tooltip={tooltipElement} />
     );
     expect(wrapper.find(SkeletonWrapper)).toHaveLength(1);
   });

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -1216,7 +1216,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
         }
       >
         <h3>
-          XSMALL
+          SMALL
         </h3>
         <div
           style={
@@ -1228,7 +1228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
         >
           <div
             className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard-size-gallery-XSMALL"
+            id="facilitycard-size-gallery-SMALL"
           >
             <div
               className="card--header"
@@ -1259,7 +1259,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
           </div>
         </div>
         <h3>
-          XSMALLWIDE
+          SMALLWIDE
         </h3>
         <div
           style={
@@ -1271,7 +1271,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
         >
           <div
             className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard-size-gallery-XSMALLWIDE"
+            id="facilitycard-size-gallery-SMALLWIDE"
           >
             <div
               className="card--header"
@@ -1351,7 +1351,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
           </div>
         </div>
         <h3>
-          SMALL
+          MEDIUMTHIN
         </h3>
         <div
           style={
@@ -1363,7 +1363,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
         >
           <div
             className="Card__CardWrapper-v5r71h-0 bHPJyP"
-            id="facilitycard-size-gallery-SMALL"
+            id="facilitycard-size-gallery-MEDIUMTHIN"
           >
             <div
               className="card--header"
@@ -1433,98 +1433,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             </div>
             <div
               className="Card__CardContent-v5r71h-1 hxiPNM"
-            >
-              <div
-                className="Card__EmptyMessageWrapper-v5r71h-3 hrQFeA"
-              >
-                No data is available for this time range.
-              </div>
-            </div>
-          </div>
-        </div>
-        <h3>
-          TALL
-        </h3>
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 izWJSI"
-            id="facilitycard-size-gallery-TALL"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Card Title"
-              >
-                <div
-                  className="title--text"
-                >
-                  Card Title
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              >
-                <div
-                  className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
-                >
-                  <button
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    aria-label="Menu"
-                    className="card--toolbar-action bx--overflow-menu"
-                    onClick={[Function]}
-                    onClose={[Function]}
-                    onKeyDown={[Function]}
-                    open={false}
-                    tabIndex={0}
-                    title="Open and close list of options"
-                  >
-                    <svg
-                      aria-label="open and close list of options"
-                      className="bx--overflow-menu__icon"
-                      focusable="false"
-                      height={20}
-                      onClick={[Function]}
-                      onKeyDown={[Function]}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 32 32"
-                      width={20}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                      />
-                      <path
-                        d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                      />
-                      <path
-                        d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                      />
-                      <title>
-                        open and close list of options
-                      </title>
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 flVXpj"
             >
               <div
                 className="Card__EmptyMessageWrapper-v5r71h-3 hrQFeA"
@@ -1627,7 +1535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
           </div>
         </div>
         <h3>
-          WIDE
+          MEDIUMWIDE
         </h3>
         <div
           style={
@@ -1639,7 +1547,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
         >
           <div
             className="Card__CardWrapper-v5r71h-0 bHPJyP"
-            id="facilitycard-size-gallery-WIDE"
+            id="facilitycard-size-gallery-MEDIUMWIDE"
           >
             <div
               className="card--header"
@@ -1709,6 +1617,98 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
             </div>
             <div
               className="Card__CardContent-v5r71h-1 hxiPNM"
+            >
+              <div
+                className="Card__EmptyMessageWrapper-v5r71h-3 hrQFeA"
+              >
+                No data is available for this time range.
+              </div>
+            </div>
+          </div>
+        </div>
+        <h3>
+          LARGETHIN
+        </h3>
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 izWJSI"
+            id="facilitycard-size-gallery-LARGETHIN"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Card Title"
+              >
+                <div
+                  className="title--text"
+                >
+                  Card Title
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              >
+                <div
+                  className="CardToolbar__ToolbarDateRangeWrapper-sc-1ekh8ti-1 eWLmmw"
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    aria-label="Menu"
+                    className="card--toolbar-action bx--overflow-menu"
+                    onClick={[Function]}
+                    onClose={[Function]}
+                    onKeyDown={[Function]}
+                    open={false}
+                    tabIndex={0}
+                    title="Open and close list of options"
+                  >
+                    <svg
+                      aria-label="open and close list of options"
+                      className="bx--overflow-menu__icon"
+                      focusable="false"
+                      height={20}
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      style={
+                        Object {
+                          "willChange": "transform",
+                        }
+                      }
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
+                      />
+                      <path
+                        d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
+                      />
+                      <path
+                        d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
+                      />
+                      <title>
+                        open and close list of options
+                      </title>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 flVXpj"
             >
               <div
                 className="Card__EmptyMessageWrapper-v5r71h-3 hrQFeA"
@@ -1811,7 +1811,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
           </div>
         </div>
         <h3>
-          XLARGE
+          LARGEWIDE
         </h3>
         <div
           style={
@@ -1823,7 +1823,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Card 
         >
           <div
             className="Card__CardWrapper-v5r71h-0 izWJSI"
-            id="facilitycard-size-gallery-XLARGE"
+            id="facilitycard-size-gallery-LARGEWIDE"
           >
             <div
               className="card--header"

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -20,7 +20,7 @@ export const originalCards = [
     title:
       'Facility Metrics with a very long title that should be truncated and have a tooltip for the full text ',
     id: 'facilitycard',
-    size: CARD_SIZES.SMALL,
+    size: CARD_SIZES.MEDIUMTHIN,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -41,7 +41,7 @@ export const originalCards = [
   {
     title: 'Humidity',
     id: 'facilitycard-xs',
-    size: CARD_SIZES.XSMALL,
+    size: CARD_SIZES.SMALL,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -66,7 +66,7 @@ export const originalCards = [
   {
     title: 'Show tooltip when the card title has ellipsis ',
     id: 'facilitycard-tooltip',
-    size: CARD_SIZES.XSMALL,
+    size: CARD_SIZES.SMALL,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -90,7 +90,7 @@ export const originalCards = [
   },
   {
     id: 'section-card',
-    size: CARD_SIZES.XSMALLWIDE,
+    size: CARD_SIZES.SMALLWIDE,
     type: CARD_TYPES.CUSTOM,
     availableActions: {
       delete: true,
@@ -100,7 +100,7 @@ export const originalCards = [
   {
     title: 'Utilization',
     id: 'facilitycard-xs2',
-    size: CARD_SIZES.XSMALL,
+    size: CARD_SIZES.SMALL,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -115,7 +115,7 @@ export const originalCards = [
   {
     title: 'Alert Count',
     id: 'facilitycard-xs3',
-    size: CARD_SIZES.XSMALL,
+    size: CARD_SIZES.SMALL,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -134,7 +134,7 @@ export const originalCards = [
   {
     title: 'Comfort Level',
     id: 'facilitycard-comfort-level',
-    size: CARD_SIZES.XSMALL,
+    size: CARD_SIZES.SMALL,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -155,7 +155,7 @@ export const originalCards = [
   {
     title: 'Foot Traffic',
     id: 'facilitycard-xs4',
-    size: CARD_SIZES.XSMALL,
+    size: CARD_SIZES.SMALL,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -175,7 +175,7 @@ export const originalCards = [
     tooltip: <p>Health - of floor 8</p>,
     id: 'GaugeCard',
     title: 'Health',
-    size: CARD_SIZES.XSMALL,
+    size: CARD_SIZES.SMALL,
     type: CARD_TYPES.GAUGE,
     values: {
       usage: 73,
@@ -222,7 +222,7 @@ export const originalCards = [
   {
     title: 'Health',
     id: 'facilitycard-health',
-    size: CARD_SIZES.XSMALLWIDE,
+    size: CARD_SIZES.SMALLWIDE,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -701,7 +701,7 @@ storiesOf('Watson IoT|Dashboard', module)
         ].map((v, idx) => ({
           title: `${v[0]} ${v[2] || ''}`,
           id: `xsmall-number-${idx}`,
-          size: CARD_SIZES.XSMALL,
+          size: CARD_SIZES.SMALL,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [{ dataSourceId: 'v', unit: v[2] }],
@@ -715,7 +715,7 @@ storiesOf('Watson IoT|Dashboard', module)
         cards={[65.3, 48.7, 88.1, 103.2].map((v, idx) => ({
           title: 'Temperature',
           id: `xsmall-number-${idx}`,
-          size: CARD_SIZES.XSMALL,
+          size: CARD_SIZES.SMALL,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [
@@ -746,7 +746,7 @@ storiesOf('Watson IoT|Dashboard', module)
         cards={[38.2, 65.3, 77.7, 91].map((v, idx) => ({
           title: 'Humidity',
           id: `xsmall-number-threshold-${idx}`,
-          size: CARD_SIZES.XSMALL,
+          size: CARD_SIZES.SMALL,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [{ dataSourceId: 'v', unit: '%', thresholds: numberThresholds }],
@@ -762,7 +762,7 @@ storiesOf('Watson IoT|Dashboard', module)
           .map((v, idx) => ({
             title: 'Danger Level',
             id: `xsmall-string-threshold-${idx}`,
-            size: CARD_SIZES.XSMALL,
+            size: CARD_SIZES.SMALL,
             type: CARD_TYPES.VALUE,
             content: {
               attributes: [{ dataSourceId: 'v', thresholds: stringThresholds }],
@@ -785,7 +785,7 @@ storiesOf('Watson IoT|Dashboard', module)
           .map((v, idx) => ({
             title: `${v[0]} ${v[2] || ''}`,
             id: `xsmallwide-number-${idx}`,
-            size: CARD_SIZES.XSMALLWIDE,
+            size: CARD_SIZES.SMALLWIDE,
             type: CARD_TYPES.VALUE,
             content: {
               attributes: [{ dataSourceId: 'v', unit: v[2] }],
@@ -796,7 +796,7 @@ storiesOf('Watson IoT|Dashboard', module)
             [65.3, 48.7, 88.1, 103.2].map((v, idx) => ({
               title: 'Temperature',
               id: `xsmallwide-number-trend-${idx}`,
-              size: CARD_SIZES.XSMALLWIDE,
+              size: CARD_SIZES.SMALLWIDE,
               type: CARD_TYPES.VALUE,
               content: {
                 attributes: [
@@ -825,7 +825,7 @@ storiesOf('Watson IoT|Dashboard', module)
             [38.2, 65.3, 77.7, 91].map((v, idx) => ({
               title: 'Humidity',
               id: `xsmallwide-number-threshold-${idx}`,
-              size: CARD_SIZES.XSMALLWIDE,
+              size: CARD_SIZES.SMALLWIDE,
               type: CARD_TYPES.VALUE,
               content: {
                 attributes: [{ dataSourceId: 'v', unit: '%', thresholds: numberThresholds }],
@@ -839,7 +839,7 @@ storiesOf('Watson IoT|Dashboard', module)
               .map((v, idx) => ({
                 title: 'Danger Level',
                 id: `xsmallwide-string-threshold-${idx}`,
-                size: CARD_SIZES.XSMALLWIDE,
+                size: CARD_SIZES.SMALLWIDE,
                 type: CARD_TYPES.VALUE,
                 content: {
                   attributes: [{ dataSourceId: 'v', thresholds: stringThresholds }],
@@ -866,7 +866,7 @@ storiesOf('Watson IoT|Dashboard', module)
         ].map((v, idx) => ({
           title: v[0],
           id: `xsmallwide-multi-${idx}`,
-          size: CARD_SIZES.XSMALLWIDE,
+          size: CARD_SIZES.SMALLWIDE,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [
@@ -937,7 +937,7 @@ storiesOf('Watson IoT|Dashboard', module)
         ].map((v, idx) => ({
           title: v[0],
           id: `xsmallwide-multi-${idx}`,
-          size: CARD_SIZES.XSMALLWIDE,
+          size: CARD_SIZES.SMALLWIDE,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [
@@ -981,7 +981,7 @@ storiesOf('Watson IoT|Dashboard', module)
         ].map((v, idx) => ({
           title: 'Humidity',
           id: `xsmallwide-multi-number-threshold-${idx}`,
-          size: CARD_SIZES.XSMALLWIDE,
+          size: CARD_SIZES.SMALLWIDE,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [
@@ -1044,7 +1044,7 @@ storiesOf('Watson IoT|Dashboard', module)
         ].map((v, idx) => ({
           title: v[0],
           id: `xsmallwide-multi-number-threshold-${idx}`,
-          size: CARD_SIZES.SMALL,
+          size: CARD_SIZES.MEDIUMTHIN,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -20,7 +20,7 @@ export const originalCards = [
     title:
       'Facility Metrics with a very long title that should be truncated and have a tooltip for the full text ',
     id: 'facilitycard',
-    size: CARD_SIZES.MEDIUMTHIN,
+    size: CARD_SIZES.MEDIUM,
     type: CARD_TYPES.VALUE,
     availableActions: {
       delete: true,
@@ -1044,7 +1044,7 @@ storiesOf('Watson IoT|Dashboard', module)
         ].map((v, idx) => ({
           title: v[0],
           id: `xsmallwide-multi-number-threshold-${idx}`,
-          size: CARD_SIZES.MEDIUMTHIN,
+          size: CARD_SIZES.MEDIUM,
           type: CARD_TYPES.VALUE,
           content: {
             attributes: [
@@ -1164,7 +1164,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </ClickableTile>
                 ),
                 id: 'viewDashboards',
-                size: CARD_SIZES.MEDIUMTHIN,
+                size: CARD_SIZES.MEDIUM,
                 type: 'CUSTOM',
               },
               {
@@ -1198,7 +1198,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </ClickableTile>
                 ),
                 id: 'connectDevices',
-                size: CARD_SIZES.MEDIUMTHIN,
+                size: CARD_SIZES.MEDIUM,
                 type: 'CUSTOM',
               },
               {
@@ -1225,7 +1225,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </div>
                 ),
                 id: 'monitorEntities',
-                size: CARD_SIZES.MEDIUMTHIN,
+                size: CARD_SIZES.MEDIUM,
                 type: 'CUSTOM',
               },
               {

--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -1164,7 +1164,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </ClickableTile>
                 ),
                 id: 'viewDashboards',
-                size: 'SMALL',
+                size: CARD_SIZES.MEDIUMTHIN,
                 type: 'CUSTOM',
               },
               {
@@ -1198,7 +1198,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </ClickableTile>
                 ),
                 id: 'connectDevices',
-                size: 'SMALL',
+                size: CARD_SIZES.MEDIUMTHIN,
                 type: 'CUSTOM',
               },
               {
@@ -1225,7 +1225,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </div>
                 ),
                 id: 'monitorEntities',
-                size: 'SMALL',
+                size: CARD_SIZES.MEDIUMTHIN,
                 type: 'CUSTOM',
               },
               {
@@ -1247,7 +1247,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </div>
                 ),
                 id: 'trackUsage',
-                size: 'XSMALLWIDE',
+                size: CARD_SIZES.SMALLWIDE,
                 type: 'CUSTOM',
               },
               {
@@ -1269,7 +1269,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   </div>
                 ),
                 id: 'administerUsers',
-                size: 'XSMALLWIDE',
+                size: CARD_SIZES.SMALLWIDE,
                 type: 'CUSTOM',
               },
               {
@@ -1316,7 +1316,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   loadData: () => {},
                 },
                 id: 'tutorials',
-                size: 'WIDE',
+                size: CARD_SIZES.MEDIUMWIDE,
                 title: 'Tutorials',
                 type: 'LIST',
               },
@@ -1349,7 +1349,7 @@ storiesOf('Watson IoT|Dashboard', module)
                   loadData: () => {},
                 },
                 id: 'announcements',
-                size: 'WIDE',
+                size: CARD_SIZES.MEDIUMWIDE,
                 title: 'Announcements',
                 type: 'LIST',
               },

--- a/src/components/Dashboard/DashboardGrid.story.jsx
+++ b/src/components/Dashboard/DashboardGrid.story.jsx
@@ -14,7 +14,7 @@ const Cards = [
     title="Facility Metrics"
     key="facility"
     id="facility"
-    size={CARD_SIZES.MEDIUMTHIN}
+    size={CARD_SIZES.MEDIUM}
     type={CARD_TYPES.VALUE}
     availableActions={{
       delete: true,
@@ -134,6 +134,175 @@ storiesOf('Watson IoT|Dashboard Grid', module)
         track of which breakpoint is currently being used in your local components state, and pass back in the breakpoint accordingly.
         # Component Overview
         `,
+      },
+    }
+  )
+  .add(
+    'dashboard, all card sizes',
+    () => {
+      const CARDS_ALL_SIZES = [
+        <Card
+          title="Small"
+          key="Small"
+          id="Small"
+          size={CARD_SIZES.SMALL}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+        <Card
+          title="Small Wide"
+          key="Small Wide"
+          id="Small Wide"
+          size={CARD_SIZES.SMALLWIDE}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+        <Card
+          title="Medium Thin"
+          id="Medium Thin"
+          key="Medium Thin"
+          size={CARD_SIZES.MEDIUMTHIN}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+        <Card
+          title="Medium"
+          id="Medium"
+          key="Medium"
+          size={CARD_SIZES.MEDIUM}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+        <Card
+          title="Medium Wide"
+          id="Medium Wide"
+          key="Medium Wide"
+          size={CARD_SIZES.MEDIUMWIDE}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+        <Card
+          title="Large Thin"
+          id="Large Thin"
+          key="Large Thin"
+          size={CARD_SIZES.LARGETHIN}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+        <Card
+          title="Large"
+          id="Large"
+          key="Large"
+          size={CARD_SIZES.LARGE}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+        <Card
+          title="Large Wide"
+          id="Large Wide"
+          key="Large Wide"
+          size={CARD_SIZES.LARGEWIDE}
+          type={CARD_TYPES.VALUE}
+          availableActions={{
+            delete: true,
+          }}
+        />,
+      ];
+      return (
+        <Fragment>
+          Resize your window to see the callback handlers get triggered in the Actions tab.
+          <FullWidthWrapper>
+            <DashboardGrid
+              {...commonGridProps}
+              layouts={{
+                max: [
+                  { i: 'Small', x: 0, y: 0, w: 2, h: 1 },
+                  { i: 'Small Wide', x: 2, y: 0, w: 4, h: 1 },
+                  { i: 'Medium Thin', x: 0, y: 2, w: 2, h: 2 },
+                  { i: 'Medium', x: 2, y: 0, w: 4, h: 2 },
+                  { i: 'Medium Wide', x: 6, y: 2, w: 8, h: 2 },
+                  { i: 'Large Thin', x: 0, y: 4, w: 4, h: 4 },
+                  { i: 'Large', x: 4, y: 4, w: 8, h: 4 },
+                  { i: 'Large Wide', x: 8, y: 8, w: 16, h: 4 },
+                ],
+                xl: [
+                  { i: 'Small', x: 0, y: 0, w: 4, h: 1 },
+                  { i: 'Small Wide', x: 4, y: 0, w: 4, h: 1 },
+                  { i: 'Medium Thin', x: 0, y: 2, w: 4, h: 2 },
+                  { i: 'Medium', x: 4, y: 0, w: 4, h: 2 },
+                  { i: 'Medium Wide', x: 8, y: 2, w: 8, h: 2 },
+                  { i: 'Large Thin', x: 0, y: 4, w: 4, h: 4 },
+                  { i: 'Large', x: 4, y: 4, w: 8, h: 4 },
+                  { i: 'Large Wide', x: 8, y: 8, w: 16, h: 4 },
+                ],
+                lg: [
+                  { i: 'Small', x: 0, y: 0, w: 4, h: 1 },
+                  { i: 'Small Wide', x: 4, y: 0, w: 4, h: 1 },
+                  { i: 'Medium Thin', x: 0, y: 2, w: 4, h: 2 },
+                  { i: 'Medium', x: 4, y: 0, w: 4, h: 2 },
+                  { i: 'Medium Wide', x: 8, y: 2, w: 8, h: 2 },
+                  { i: 'Large Thin', x: 0, y: 4, w: 4, h: 4 },
+                  { i: 'Large', x: 4, y: 4, w: 8, h: 4 },
+                  { i: 'Large Wide', x: 8, y: 8, w: 16, h: 4 },
+                ],
+                md: [
+                  { i: 'Small', x: 0, y: 0, w: 4, h: 1 },
+                  { i: 'Small Wide', x: 4, y: 0, w: 4, h: 1 },
+                  { i: 'Medium Thin', x: 0, y: 2, w: 2, h: 2 },
+                  { i: 'Medium', x: 2, y: 0, w: 4, h: 2 },
+                  { i: 'Medium Wide', x: 8, y: 2, w: 8, h: 2 },
+                  { i: 'Large Thin', x: 0, y: 4, w: 4, h: 4 },
+                  { i: 'Large', x: 4, y: 4, w: 8, h: 4 },
+                  { i: 'Large Wide', x: 8, y: 8, w: 8, h: 4 },
+                ],
+                sm: [
+                  { i: 'Small', x: 0, y: 0, w: 2, h: 1 },
+                  { i: 'Small Wide', x: 4, y: 0, w: 4, h: 2 },
+                  { i: 'Medium Thin', x: 0, y: 0, w: 2, h: 2 },
+                  { i: 'Medium', x: 2, y: 0, w: 4, h: 2 },
+                  { i: 'Medium Wide', x: 8, y: 0, w: 4, h: 2 },
+                  { i: 'Large Thin', x: 0, y: 0, w: 4, h: 4 },
+                  { i: 'Large', x: 4, y: 0, w: 4, h: 4 },
+                  { i: 'Large Wide', x: 8, y: 0, w: 4, h: 4 },
+                ],
+                xs: [
+                  { i: 'Small', x: 0, y: 0, w: 4, h: 1 },
+                  { i: 'Small Wide', x: 4, y: 0, w: 4, h: 1 },
+                  { i: 'Medium Thin', x: 0, y: 0, w: 4, h: 2 },
+                  { i: 'Medium', x: 2, y: 0, w: 4, h: 2 },
+                  { i: 'Medium Wide', x: 8, y: 0, w: 4, h: 2 },
+                  { i: 'Large Thin', x: 0, y: 0, w: 4, h: 4 },
+                  { i: 'Large', x: 4, y: 0, w: 4, h: 4 },
+                  { i: 'Large Wide', x: 8, y: 0, w: 4, h: 4 },
+                ],
+              }}
+            >
+              {CARDS_ALL_SIZES}
+            </DashboardGrid>
+          </FullWidthWrapper>
+        </Fragment>
+      );
+    },
+    {
+      info: {
+        text: `
+      This is the simplest way to use the dashboard grid, just pass it a set of cards and let it figure out it's own layout to use.
+      # Component Overview
+      `,
       },
     }
   );

--- a/src/components/Dashboard/DashboardGrid.story.jsx
+++ b/src/components/Dashboard/DashboardGrid.story.jsx
@@ -14,7 +14,7 @@ const Cards = [
     title="Facility Metrics"
     key="facility"
     id="facility"
-    size={CARD_SIZES.SMALL}
+    size={CARD_SIZES.MEDIUMTHIN}
     type={CARD_TYPES.VALUE}
     availableActions={{
       delete: true,
@@ -25,7 +25,7 @@ const Cards = [
     title="Humidity"
     key="humidity"
     id="humidity"
-    size={CARD_SIZES.XSMALL}
+    size={CARD_SIZES.SMALL}
     type={CARD_TYPES.VALUE}
     availableActions={{
       delete: true,
@@ -36,7 +36,7 @@ const Cards = [
     title="Utilization"
     id="utilization"
     key="utilization"
-    size={CARD_SIZES.XSMALL}
+    size={CARD_SIZES.SMALL}
     type={CARD_TYPES.VALUE}
     availableActions={{
       delete: true,

--- a/src/components/Dashboard/DashboardGrid.test.jsx
+++ b/src/components/Dashboard/DashboardGrid.test.jsx
@@ -8,12 +8,12 @@ const componentUtilityFunctions = require('../../utils/componentUtilityFunctions
 describe('DashboardGrid', () => {
   test('findLayoutOrGenerate', () => {
     // if no layouts exist they should be generated
-    findLayoutOrGenerate({}, [{ id: 'mycard', size: CARD_SIZES.MEDIUMTHIN }]);
+    findLayoutOrGenerate({}, [{ id: 'mycard', size: CARD_SIZES.MEDIUM }]);
     expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
     componentUtilityFunctions.getLayout.mockClear();
     // if layout is missing card it should be regenerated
     findLayoutOrGenerate({ max: [], xl: [], lg: [], md: [], sm: [], xs: [] }, [
-      { id: 'mycard', size: CARD_SIZES.MEDIUMTHIN },
+      { id: 'mycard', size: CARD_SIZES.MEDIUM },
     ]);
     expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
     componentUtilityFunctions.getLayout.mockClear();
@@ -27,7 +27,7 @@ describe('DashboardGrid', () => {
         sm: [{ i: 'mycard', x: 0, y: 0 }],
         xs: [{ i: 'mycard', x: 0, y: 0 }],
       },
-      [{ id: 'mycard', size: CARD_SIZES.MEDIUMTHIN }]
+      [{ id: 'mycard', size: CARD_SIZES.MEDIUM }]
     );
     expect(componentUtilityFunctions.getLayout).not.toHaveBeenCalled();
     expect(newLayouts.max[0]).toHaveProperty('w');
@@ -42,7 +42,7 @@ describe('DashboardGrid', () => {
         sm: [{ i: 'boguscard', x: 0, y: 0 }],
         xs: [{ i: 'boguscard', x: 0, y: 0 }],
       },
-      [{ id: 'mycard', size: CARD_SIZES.MEDIUMTHIN }]
+      [{ id: 'mycard', size: CARD_SIZES.MEDIUM }]
     );
     // the bogus card was quietly removed from the layout
     expect(emptyLayouts.max).toHaveLength(1);

--- a/src/components/Dashboard/DashboardGrid.test.jsx
+++ b/src/components/Dashboard/DashboardGrid.test.jsx
@@ -8,12 +8,12 @@ const componentUtilityFunctions = require('../../utils/componentUtilityFunctions
 describe('DashboardGrid', () => {
   test('findLayoutOrGenerate', () => {
     // if no layouts exist they should be generated
-    findLayoutOrGenerate({}, [{ id: 'mycard', size: CARD_SIZES.SMALL }]);
+    findLayoutOrGenerate({}, [{ id: 'mycard', size: CARD_SIZES.MEDIUMTHIN }]);
     expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
     componentUtilityFunctions.getLayout.mockClear();
     // if layout is missing card it should be regenerated
     findLayoutOrGenerate({ max: [], xl: [], lg: [], md: [], sm: [], xs: [] }, [
-      { id: 'mycard', size: CARD_SIZES.SMALL },
+      { id: 'mycard', size: CARD_SIZES.MEDIUMTHIN },
     ]);
     expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();
     componentUtilityFunctions.getLayout.mockClear();
@@ -27,7 +27,7 @@ describe('DashboardGrid', () => {
         sm: [{ i: 'mycard', x: 0, y: 0 }],
         xs: [{ i: 'mycard', x: 0, y: 0 }],
       },
-      [{ id: 'mycard', size: CARD_SIZES.SMALL }]
+      [{ id: 'mycard', size: CARD_SIZES.MEDIUMTHIN }]
     );
     expect(componentUtilityFunctions.getLayout).not.toHaveBeenCalled();
     expect(newLayouts.max[0]).toHaveProperty('w');
@@ -42,7 +42,7 @@ describe('DashboardGrid', () => {
         sm: [{ i: 'boguscard', x: 0, y: 0 }],
         xs: [{ i: 'boguscard', x: 0, y: 0 }],
       },
-      [{ id: 'mycard', size: CARD_SIZES.SMALL }]
+      [{ id: 'mycard', size: CARD_SIZES.MEDIUMTHIN }]
     );
     // the bogus card was quietly removed from the layout
     expect(emptyLayouts.max).toHaveLength(1);

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -129,12 +129,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -142,7 +142,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="89 %"
                                 value={89}
                               >
@@ -152,7 +152,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -160,7 +160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -168,12 +168,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -181,7 +181,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="76 %"
                                 value={76}
                               >
@@ -191,7 +191,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Utilization"
                           >
                             Utilization
@@ -199,7 +199,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -207,12 +207,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -220,7 +220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -230,7 +230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Pressure"
                           >
                             Pressure
@@ -281,12 +281,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -294,7 +294,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -304,7 +304,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -352,12 +352,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -365,7 +365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -375,7 +375,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -465,12 +465,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="Average"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -478,7 +478,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="76 %"
                                 value={76}
                               >
@@ -488,7 +488,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="Average"
                           >
                             Average
@@ -539,12 +539,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="weekly"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -552,7 +552,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="35 "
                                 value={35}
                               >
@@ -562,7 +562,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="weekly"
                           >
                             weekly
@@ -613,12 +613,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -626,7 +626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="Bad "
                                 value="Bad"
                               >
@@ -661,7 +661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -709,12 +709,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -722,7 +722,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="13572 "
                                 value={13572}
                               >
@@ -732,7 +732,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -937,12 +937,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                          size="XSMALLWIDE"
+                          size="SMALLWIDE"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -950,7 +950,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
+                                size="SMALLWIDE"
                                 title="Healthy "
                                 value="Healthy"
                               >
@@ -985,7 +985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           />
                         </div>
                       </div>
@@ -2231,12 +2231,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2244,7 +2244,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="89 %"
                                 value={89}
                               >
@@ -2254,7 +2254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -2262,7 +2262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2270,12 +2270,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2283,7 +2283,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="76 %"
                                 value={76}
                               >
@@ -2293,7 +2293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Utilization"
                           >
                             Utilization
@@ -2301,7 +2301,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2309,12 +2309,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2322,7 +2322,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -2332,7 +2332,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Pressure"
                           >
                             Pressure
@@ -2383,12 +2383,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -2396,7 +2396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -2406,7 +2406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -2454,12 +2454,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -2467,7 +2467,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -2477,7 +2477,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -2567,12 +2567,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="Average"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2580,7 +2580,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="76 %"
                                 value={76}
                               >
@@ -2590,7 +2590,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="Average"
                           >
                             Average
@@ -2641,12 +2641,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="weekly"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2654,7 +2654,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="35 "
                                 value={35}
                               >
@@ -2664,7 +2664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="weekly"
                           >
                             weekly
@@ -2715,12 +2715,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -2728,7 +2728,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="Bad "
                                 value="Bad"
                               >
@@ -2763,7 +2763,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -2811,12 +2811,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2824,7 +2824,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="13572 "
                                 value={13572}
                               >
@@ -2834,7 +2834,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -3039,12 +3039,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                          size="XSMALLWIDE"
+                          size="SMALLWIDE"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -3052,7 +3052,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
+                                size="SMALLWIDE"
                                 title="Healthy "
                                 value="Healthy"
                               >
@@ -3087,7 +3087,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           />
                         </div>
                       </div>
@@ -4365,12 +4365,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4378,7 +4378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="89 %"
                                 value={89}
                               >
@@ -4388,7 +4388,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -4396,7 +4396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -4404,12 +4404,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4417,7 +4417,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="76 %"
                                 value={76}
                               >
@@ -4427,7 +4427,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Utilization"
                           >
                             Utilization
@@ -4435,7 +4435,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -4443,12 +4443,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4456,7 +4456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -4466,7 +4466,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Pressure"
                           >
                             Pressure
@@ -4517,12 +4517,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -4530,7 +4530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -4540,7 +4540,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -4588,12 +4588,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -4601,7 +4601,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -4611,7 +4611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -4701,12 +4701,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="Average"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4714,7 +4714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="76 %"
                                 value={76}
                               >
@@ -4724,7 +4724,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="Average"
                           >
                             Average
@@ -4775,12 +4775,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="weekly"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4788,7 +4788,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="35 "
                                 value={35}
                               >
@@ -4798,7 +4798,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="weekly"
                           >
                             weekly
@@ -4849,12 +4849,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -4862,7 +4862,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="Bad "
                                 value="Bad"
                               >
@@ -4897,7 +4897,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -4945,12 +4945,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4958,7 +4958,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="13572 "
                                 value={13572}
                               >
@@ -4968,7 +4968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -5173,12 +5173,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                          size="XSMALLWIDE"
+                          size="SMALLWIDE"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -5186,7 +5186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
+                                size="SMALLWIDE"
                                 title="Healthy "
                                 value="Healthy"
                               >
@@ -5221,7 +5221,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           />
                         </div>
                       </div>
@@ -9023,12 +9023,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9036,7 +9036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="89 %"
                                 value={89}
                               >
@@ -9046,7 +9046,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -9054,7 +9054,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -9062,12 +9062,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9075,7 +9075,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="76 %"
                                 value={76}
                               >
@@ -9085,7 +9085,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Utilization"
                           >
                             Utilization
@@ -9093,7 +9093,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -9101,12 +9101,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9114,7 +9114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -9124,7 +9124,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Pressure"
                           >
                             Pressure
@@ -9175,12 +9175,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -9188,7 +9188,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -9198,7 +9198,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -9246,12 +9246,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -9259,7 +9259,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -9269,7 +9269,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -9359,12 +9359,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="Average"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9372,7 +9372,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="76 %"
                                 value={76}
                               >
@@ -9382,7 +9382,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="Average"
                           >
                             Average
@@ -9433,12 +9433,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="weekly"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9446,7 +9446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="35 "
                                 value={35}
                               >
@@ -9456,7 +9456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="weekly"
                           >
                             weekly
@@ -9507,12 +9507,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -9520,7 +9520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="Bad "
                                 value="Bad"
                               >
@@ -9555,7 +9555,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -9603,12 +9603,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9616,7 +9616,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="13572 "
                                 value={13572}
                               >
@@ -9626,7 +9626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -9831,12 +9831,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                          size="XSMALLWIDE"
+                          size="SMALLWIDE"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -9844,7 +9844,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
+                                size="SMALLWIDE"
                                 title="Healthy "
                                 value="Healthy"
                               >
@@ -9879,7 +9879,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           />
                         </div>
                       </div>
@@ -11131,12 +11131,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -11144,7 +11144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="13 "
                                   value={13}
                                 >
@@ -11154,7 +11154,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11202,12 +11202,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11215,7 +11215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="1352 steps"
                                   value={1352}
                                 >
@@ -11225,7 +11225,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11273,12 +11273,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11286,7 +11286,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -11296,7 +11296,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11344,12 +11344,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11357,7 +11357,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="107324.3 kJ"
                                   value={107324.3}
                                 >
@@ -11367,7 +11367,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11415,12 +11415,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11428,7 +11428,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -11438,7 +11438,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11486,12 +11486,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -11499,7 +11499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="false "
                                   value={false}
                                 >
@@ -11513,7 +11513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11561,12 +11561,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -11574,7 +11574,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="true "
                                   value={true}
                                 >
@@ -11588,7 +11588,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11701,12 +11701,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -11714,7 +11714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="13 "
                                   value={13}
                                 >
@@ -11724,7 +11724,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11772,12 +11772,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11785,7 +11785,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="1352 steps"
                                   value={1352}
                                 >
@@ -11795,7 +11795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11843,12 +11843,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11856,7 +11856,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -11866,7 +11866,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11914,12 +11914,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11927,7 +11927,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="107324.3 kJ"
                                   value={107324.3}
                                 >
@@ -11937,7 +11937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -11985,12 +11985,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -11998,7 +11998,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -12008,7 +12008,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -12056,12 +12056,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -12069,7 +12069,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="false "
                                   value={false}
                                 >
@@ -12083,7 +12083,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -12131,12 +12131,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -12144,7 +12144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="true "
                                   value={true}
                                 >
@@ -12158,7 +12158,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -12271,12 +12271,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12284,7 +12284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="65.3 ˚F"
                                   value={65.3}
                                 >
@@ -12294,7 +12294,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -12342,12 +12342,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Weekly Avg"
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12355,7 +12355,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="48.7 ˚F"
                                   value={48.7}
                                 >
@@ -12365,7 +12365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 gHjNPp"
-                              size="XSMALL"
+                              size="SMALL"
                               title="Weekly Avg"
                             >
                               Weekly Avg
@@ -12416,12 +12416,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12429,7 +12429,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="88.1 ˚F"
                                   value={88.1}
                                 >
@@ -12439,7 +12439,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -12487,12 +12487,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Long label that might not fit"
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12500,7 +12500,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -12510,7 +12510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                               title="Long label that might not fit"
                             >
                               Long label that might not fit
@@ -12626,12 +12626,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12639,7 +12639,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="65.3 ˚F"
                                   value={65.3}
                                 >
@@ -12649,7 +12649,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -12697,12 +12697,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Weekly Avg"
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12710,7 +12710,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="48.7 ˚F"
                                   value={48.7}
                                 >
@@ -12720,7 +12720,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 gHjNPp"
-                              size="XSMALL"
+                              size="SMALL"
                               title="Weekly Avg"
                             >
                               Weekly Avg
@@ -12771,12 +12771,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12784,7 +12784,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="88.1 ˚F"
                                   value={88.1}
                                 >
@@ -12794,7 +12794,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -12842,12 +12842,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Long label that might not fit"
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12855,7 +12855,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -12865,7 +12865,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                               title="Long label that might not fit"
                             >
                               Long label that might not fit
@@ -12981,12 +12981,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -12994,7 +12994,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="38.2 %"
                                   value={38.2}
                                 >
@@ -13029,7 +13029,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13077,12 +13077,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -13090,7 +13090,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="65.3 %"
                                   value={65.3}
                                 >
@@ -13125,7 +13125,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13173,12 +13173,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -13186,7 +13186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="77.7 %"
                                   value={77.7}
                                 >
@@ -13221,7 +13221,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13269,12 +13269,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -13282,7 +13282,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="91 %"
                                   value={91}
                                 >
@@ -13317,7 +13317,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13430,12 +13430,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -13443,7 +13443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="38.2 %"
                                   value={38.2}
                                 >
@@ -13478,7 +13478,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13526,12 +13526,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -13539,7 +13539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="65.3 %"
                                   value={65.3}
                                 >
@@ -13574,7 +13574,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13622,12 +13622,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -13635,7 +13635,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="77.7 %"
                                   value={77.7}
                                 >
@@ -13670,7 +13670,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13718,12 +13718,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -13731,7 +13731,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="91 %"
                                   value={91}
                                 >
@@ -13766,7 +13766,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13879,12 +13879,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -13892,7 +13892,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Low "
                                   value="Low"
                                 >
@@ -13902,7 +13902,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -13950,12 +13950,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 cMAChm"
@@ -13963,7 +13963,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Guarded "
                                   value="Guarded"
                                 >
@@ -13973,7 +13973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14021,12 +14021,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 gIvHNE"
@@ -14034,7 +14034,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -14044,7 +14044,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14092,12 +14092,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -14105,7 +14105,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="High "
                                   value="High"
                                 >
@@ -14115,7 +14115,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14163,12 +14163,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -14176,7 +14176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -14186,7 +14186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14299,12 +14299,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -14312,7 +14312,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Low "
                                   value="Low"
                                 >
@@ -14322,7 +14322,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14370,12 +14370,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 cMAChm"
@@ -14383,7 +14383,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Guarded "
                                   value="Guarded"
                                 >
@@ -14393,7 +14393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14441,12 +14441,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 gIvHNE"
@@ -14454,7 +14454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -14464,7 +14464,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14512,12 +14512,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -14525,7 +14525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="High "
                                   value="High"
                                 >
@@ -14535,7 +14535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14583,12 +14583,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALL"
+                              size="SMALL"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -14596,7 +14596,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                                  size="XSMALL"
+                                  size="SMALL"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -14606,7 +14606,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                              size="XSMALL"
+                              size="SMALL"
                             />
                           </div>
                         </div>
@@ -14719,12 +14719,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -14732,7 +14732,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="13 "
                                   value={13}
                                 >
@@ -14742,7 +14742,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -14790,12 +14790,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -14803,7 +14803,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1352 steps"
                                   value={1352}
                                 >
@@ -14813,7 +14813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -14861,12 +14861,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -14874,7 +14874,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -14884,7 +14884,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -14932,12 +14932,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -14945,7 +14945,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="107324.3 kJ"
                                   value={107324.3}
                                 >
@@ -14955,7 +14955,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15003,12 +15003,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15016,7 +15016,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -15026,7 +15026,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15074,12 +15074,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15087,7 +15087,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="false "
                                   value={false}
                                 >
@@ -15101,7 +15101,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15149,12 +15149,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15162,7 +15162,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="true "
                                   value={true}
                                 >
@@ -15176,7 +15176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15224,12 +15224,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15237,7 +15237,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="65.3 ˚F"
                                   value={65.3}
                                 >
@@ -15247,7 +15247,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15295,12 +15295,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Weekly Avg"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15308,7 +15308,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="48.7 ˚F"
                                   value={48.7}
                                 >
@@ -15318,7 +15318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Weekly Avg"
                             >
                               Weekly Avg
@@ -15369,12 +15369,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15382,7 +15382,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="88.1 ˚F"
                                   value={88.1}
                                 >
@@ -15392,7 +15392,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15440,12 +15440,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Long label that might not fit"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15453,7 +15453,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -15463,7 +15463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Long label that might not fit"
                             >
                               Long label that might not fit
@@ -15514,12 +15514,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15527,7 +15527,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="38.2 %"
                                   value={38.2}
                                 >
@@ -15562,7 +15562,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15610,12 +15610,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15623,7 +15623,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="65.3 %"
                                   value={65.3}
                                 >
@@ -15658,7 +15658,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15706,12 +15706,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15719,7 +15719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="77.7 %"
                                   value={77.7}
                                 >
@@ -15754,7 +15754,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15802,12 +15802,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -15815,7 +15815,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="91 %"
                                   value={91}
                                 >
@@ -15850,7 +15850,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15898,12 +15898,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -15911,7 +15911,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Low "
                                   value="Low"
                                 >
@@ -15921,7 +15921,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -15969,12 +15969,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 cMAChm"
@@ -15982,7 +15982,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Guarded "
                                   value="Guarded"
                                 >
@@ -15992,7 +15992,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16040,12 +16040,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 gIvHNE"
@@ -16053,7 +16053,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -16063,7 +16063,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16111,12 +16111,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -16124,7 +16124,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="High "
                                   value="High"
                                 >
@@ -16134,7 +16134,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16182,12 +16182,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -16195,7 +16195,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -16205,7 +16205,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16318,12 +16318,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16331,7 +16331,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="13 "
                                   value={13}
                                 >
@@ -16341,7 +16341,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16389,12 +16389,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16402,7 +16402,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1352 steps"
                                   value={1352}
                                 >
@@ -16412,7 +16412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16460,12 +16460,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16473,7 +16473,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -16483,7 +16483,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16531,12 +16531,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16544,7 +16544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="107324.3 kJ"
                                   value={107324.3}
                                 >
@@ -16554,7 +16554,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16602,12 +16602,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16615,7 +16615,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -16625,7 +16625,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16673,12 +16673,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16686,7 +16686,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="false "
                                   value={false}
                                 >
@@ -16700,7 +16700,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16748,12 +16748,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16761,7 +16761,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="true "
                                   value={true}
                                 >
@@ -16775,7 +16775,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16823,12 +16823,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16836,7 +16836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="65.3 ˚F"
                                   value={65.3}
                                 >
@@ -16846,7 +16846,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -16894,12 +16894,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Weekly Avg"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16907,7 +16907,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="48.7 ˚F"
                                   value={48.7}
                                 >
@@ -16917,7 +16917,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Weekly Avg"
                             >
                               Weekly Avg
@@ -16968,12 +16968,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -16981,7 +16981,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="88.1 ˚F"
                                   value={88.1}
                                 >
@@ -16991,7 +16991,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17039,12 +17039,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Long label that might not fit"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -17052,7 +17052,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.2 ˚F"
                                   value={103.2}
                                 >
@@ -17062,7 +17062,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Long label that might not fit"
                             >
                               Long label that might not fit
@@ -17113,12 +17113,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -17126,7 +17126,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="38.2 %"
                                   value={38.2}
                                 >
@@ -17161,7 +17161,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17209,12 +17209,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -17222,7 +17222,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="65.3 %"
                                   value={65.3}
                                 >
@@ -17257,7 +17257,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17305,12 +17305,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -17318,7 +17318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="77.7 %"
                                   value={77.7}
                                 >
@@ -17353,7 +17353,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17401,12 +17401,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -17414,7 +17414,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="91 %"
                                   value={91}
                                 >
@@ -17449,7 +17449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17497,12 +17497,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -17510,7 +17510,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Low "
                                   value="Low"
                                 >
@@ -17520,7 +17520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17568,12 +17568,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 cMAChm"
@@ -17581,7 +17581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Guarded "
                                   value="Guarded"
                                 >
@@ -17591,7 +17591,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17639,12 +17639,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 gIvHNE"
@@ -17652,7 +17652,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -17662,7 +17662,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17710,12 +17710,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -17723,7 +17723,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="High "
                                   value="High"
                                 >
@@ -17733,7 +17733,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17781,12 +17781,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label={null}
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -17794,7 +17794,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -17804,7 +17804,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             />
                           </div>
                         </div>
@@ -17917,12 +17917,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Comfort Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -17930,7 +17930,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="89.2 %"
                                   value={89.2}
                                 >
@@ -17940,7 +17940,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Comfort Level"
                             >
                               Comfort Level
@@ -17948,12 +17948,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Pressure"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -17961,7 +17961,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="21.3 mb"
                                   value={21.3}
                                 >
@@ -17971,7 +17971,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Pressure"
                             >
                               Pressure
@@ -18022,12 +18022,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18035,7 +18035,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="88.3 ˚F"
                                   value={88.3}
                                 >
@@ -18045,7 +18045,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -18053,12 +18053,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Danger Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18066,7 +18066,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -18076,7 +18076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Danger Level"
                             >
                               Danger Level
@@ -18127,12 +18127,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18140,7 +18140,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.7 ˚F"
                                   value={103.7}
                                 >
@@ -18150,7 +18150,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -18158,12 +18158,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Foot Traffic"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18171,7 +18171,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -18181,7 +18181,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Foot Traffic"
                             >
                               Foot Traffic
@@ -18297,12 +18297,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Comfort Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18310,7 +18310,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="89.2 %"
                                   value={89.2}
                                 >
@@ -18320,7 +18320,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Comfort Level"
                             >
                               Comfort Level
@@ -18328,12 +18328,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Pressure"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18341,7 +18341,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="21.3 mb"
                                   value={21.3}
                                 >
@@ -18351,7 +18351,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Pressure"
                             >
                               Pressure
@@ -18402,12 +18402,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18415,7 +18415,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="88.3 ˚F"
                                   value={88.3}
                                 >
@@ -18425,7 +18425,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -18433,12 +18433,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Danger Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18446,7 +18446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -18456,7 +18456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Danger Level"
                             >
                               Danger Level
@@ -18507,12 +18507,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18520,7 +18520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.7 ˚F"
                                   value={103.7}
                                 >
@@ -18530,7 +18530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -18538,12 +18538,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Foot Traffic"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18551,7 +18551,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -18561,7 +18561,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Foot Traffic"
                             >
                               Foot Traffic
@@ -18677,12 +18677,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Comfort Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18690,7 +18690,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="89.2 %"
                                   value={89.2}
                                 >
@@ -18700,7 +18700,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Comfort Level"
                             >
                               Comfort Level
@@ -18708,12 +18708,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Pressure"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18721,7 +18721,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="21.3 mb"
                                   value={21.3}
                                 >
@@ -18731,7 +18731,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Pressure"
                             >
                               Pressure
@@ -18782,12 +18782,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18795,7 +18795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="88.3 ˚F"
                                   value={88.3}
                                 >
@@ -18805,7 +18805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -18813,12 +18813,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Danger Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18826,7 +18826,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -18836,7 +18836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Danger Level"
                             >
                               Danger Level
@@ -18887,12 +18887,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18900,7 +18900,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.7 ˚F"
                                   value={103.7}
                                 >
@@ -18910,7 +18910,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -18918,12 +18918,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Foot Traffic"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -18931,7 +18931,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -18941,7 +18941,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Foot Traffic"
                             >
                               Foot Traffic
@@ -19057,12 +19057,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Comfort Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19070,7 +19070,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="89.2 %"
                                   value={89.2}
                                 >
@@ -19080,7 +19080,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Comfort Level"
                             >
                               Comfort Level
@@ -19088,12 +19088,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Pressure"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19101,7 +19101,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="21.3 mb"
                                   value={21.3}
                                 >
@@ -19111,7 +19111,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Pressure"
                             >
                               Pressure
@@ -19162,12 +19162,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19175,7 +19175,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="88.3 ˚F"
                                   value={88.3}
                                 >
@@ -19185,7 +19185,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -19193,12 +19193,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Danger Level"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19206,7 +19206,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -19216,7 +19216,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Danger Level"
                             >
                               Danger Level
@@ -19267,12 +19267,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Temperature"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19280,7 +19280,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="103.7 ˚F"
                                   value={103.7}
                                 >
@@ -19290,7 +19290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Temperature"
                             >
                               Temperature
@@ -19298,12 +19298,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Foot Traffic"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19311,7 +19311,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="1709384.1 people"
                                   value={1709384.1}
                                 >
@@ -19321,7 +19321,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Foot Traffic"
                             >
                               Foot Traffic
@@ -19437,12 +19437,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Average"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19450,7 +19450,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="38.2 %"
                                   value={38.2}
                                 >
@@ -19485,7 +19485,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Average"
                             >
                               Average
@@ -19493,12 +19493,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Max"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19506,7 +19506,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="65.3 %"
                                   value={65.3}
                                 >
@@ -19541,7 +19541,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Max"
                             >
                               Max
@@ -19592,12 +19592,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Average"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19605,7 +19605,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="77.2 ˚F"
                                   value={77.2}
                                 >
@@ -19640,7 +19640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Average"
                             >
                               Average
@@ -19648,12 +19648,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Max"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19661,7 +19661,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="91.3 ˚F"
                                   value={91.3}
                                 >
@@ -19696,7 +19696,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Max"
                             >
                               Max
@@ -19812,12 +19812,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Average"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19825,7 +19825,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="38.2 %"
                                   value={38.2}
                                 >
@@ -19860,7 +19860,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Average"
                             >
                               Average
@@ -19868,12 +19868,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Max"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19881,7 +19881,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="65.3 %"
                                   value={65.3}
                                 >
@@ -19916,7 +19916,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Max"
                             >
                               Max
@@ -19967,12 +19967,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Average"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -19980,7 +19980,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="77.2 ˚F"
                                   value={77.2}
                                 >
@@ -20015,7 +20015,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Average"
                             >
                               Average
@@ -20023,12 +20023,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                               label="Max"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -20036,7 +20036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                  size="XSMALLWIDE"
+                                  size="SMALLWIDE"
                                   title="91.3 ˚F"
                                   value={91.3}
                                 >
@@ -20071,7 +20071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                              size="XSMALLWIDE"
+                              size="SMALLWIDE"
                               title="Max"
                             >
                               Max
@@ -20187,12 +20187,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="YTD"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20200,7 +20200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="13634.56 MWh"
                                   value={13634.56}
                                 >
@@ -20210,7 +20210,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="YTD"
                             >
                               YTD
@@ -20218,7 +20218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20226,12 +20226,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="MTD"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20239,7 +20239,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="1047.2 MWh"
                                   value={1047.2}
                                 >
@@ -20249,7 +20249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="MTD"
                             >
                               MTD
@@ -20257,7 +20257,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20265,12 +20265,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20278,7 +20278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="314.5 MWh"
                                   value={314.5}
                                 >
@@ -20288,7 +20288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Week"
                             >
                               Last Week
@@ -20339,12 +20339,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -20352,7 +20352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -20362,7 +20362,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Current"
                             >
                               Current
@@ -20370,7 +20370,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20378,12 +20378,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -20391,7 +20391,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Low "
                                   value="Low"
                                 >
@@ -20401,7 +20401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Week"
                             >
                               Last Week
@@ -20409,7 +20409,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20417,12 +20417,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -20430,7 +20430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="High "
                                   value="High"
                                 >
@@ -20440,7 +20440,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Month"
                             >
                               Last Month
@@ -20491,12 +20491,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -20504,7 +20504,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Low "
                                   value="Low"
                                 >
@@ -20539,7 +20539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Current"
                             >
                               Current
@@ -20547,7 +20547,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20555,12 +20555,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -20568,7 +20568,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -20603,7 +20603,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Week"
                             >
                               Last Week
@@ -20611,7 +20611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20619,12 +20619,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -20632,7 +20632,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -20667,7 +20667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Month"
                             >
                               Last Month
@@ -20783,12 +20783,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="YTD"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20796,7 +20796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="13634.56 MWh"
                                   value={13634.56}
                                 >
@@ -20806,7 +20806,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="YTD"
                             >
                               YTD
@@ -20814,7 +20814,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20822,12 +20822,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="MTD"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20835,7 +20835,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="1047.2 MWh"
                                   value={1047.2}
                                 >
@@ -20845,7 +20845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="MTD"
                             >
                               MTD
@@ -20853,7 +20853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20861,12 +20861,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20874,7 +20874,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="314.5 MWh"
                                   value={314.5}
                                 >
@@ -20884,7 +20884,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Week"
                             >
                               Last Week
@@ -20935,12 +20935,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -20948,7 +20948,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -20958,7 +20958,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Current"
                             >
                               Current
@@ -20966,7 +20966,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20974,12 +20974,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -20987,7 +20987,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Low "
                                   value="Low"
                                 >
@@ -20997,7 +20997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Week"
                             >
                               Last Week
@@ -21005,7 +21005,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21013,12 +21013,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -21026,7 +21026,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="High "
                                   value="High"
                                 >
@@ -21036,7 +21036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Month"
                             >
                               Last Month
@@ -21087,12 +21087,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -21100,7 +21100,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Low "
                                   value="Low"
                                 >
@@ -21135,7 +21135,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Current"
                             >
                               Current
@@ -21143,7 +21143,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21151,12 +21151,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -21164,7 +21164,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -21199,7 +21199,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Week"
                             >
                               Last Week
@@ -21207,7 +21207,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21215,12 +21215,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -21228,7 +21228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="SMALL"
+                                  size="MEDIUMTHIN"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -21263,7 +21263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="SMALL"
+                              size="MEDIUMTHIN"
                               title="Last Month"
                             >
                               Last Month
@@ -21468,12 +21468,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21481,7 +21481,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="89 %"
                                 value={89}
                               >
@@ -21491,7 +21491,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -21499,7 +21499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21507,12 +21507,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21520,7 +21520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="76 %"
                                 value={76}
                               >
@@ -21530,7 +21530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Utilization"
                           >
                             Utilization
@@ -21538,7 +21538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21546,12 +21546,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="SMALL"
+                          size="MEDIUMTHIN"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21559,7 +21559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="SMALL"
+                                size="MEDIUMTHIN"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -21569,7 +21569,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="SMALL"
+                            size="MEDIUMTHIN"
                             title="Pressure"
                           >
                             Pressure
@@ -21620,12 +21620,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -21633,7 +21633,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -21643,7 +21643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -21691,12 +21691,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 eIOMtV"
@@ -21704,7 +21704,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="62.1 %"
                                 value={62.1}
                               >
@@ -21714,7 +21714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -21804,12 +21804,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="Average"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21817,7 +21817,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="76 %"
                                 value={76}
                               >
@@ -21827,7 +21827,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="Average"
                           >
                             Average
@@ -21878,12 +21878,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label="weekly"
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21891,7 +21891,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="35 "
                                 value={35}
                               >
@@ -21901,7 +21901,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                             title="weekly"
                           >
                             weekly
@@ -21952,12 +21952,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -21965,7 +21965,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="Bad "
                                 value="Bad"
                               >
@@ -22000,7 +22000,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -22048,12 +22048,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="XSMALL"
+                          size="SMALL"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALL"
+                            size="SMALL"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -22061,7 +22061,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                                size="XSMALL"
+                                size="SMALL"
                                 title="13572 "
                                 value={13572}
                               >
@@ -22071,7 +22071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                            size="XSMALL"
+                            size="SMALL"
                           />
                         </div>
                       </div>
@@ -22276,12 +22276,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                          size="XSMALLWIDE"
+                          size="SMALLWIDE"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                             label={null}
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -22289,7 +22289,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                                size="XSMALLWIDE"
+                                size="SMALLWIDE"
                                 title="Healthy "
                                 value="Healthy"
                               >
@@ -22324,7 +22324,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                            size="XSMALLWIDE"
+                            size="SMALLWIDE"
                           />
                         </div>
                       </div>

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -129,12 +129,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -142,7 +142,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="89 %"
                                 value={89}
                               >
@@ -152,7 +152,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -160,7 +160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -168,12 +168,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -181,7 +181,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="76 %"
                                 value={76}
                               >
@@ -191,7 +191,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Utilization"
                           >
                             Utilization
@@ -199,7 +199,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -207,12 +207,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -220,7 +220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -230,7 +230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Pressure"
                           >
                             Pressure
@@ -2231,12 +2231,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2244,7 +2244,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="89 %"
                                 value={89}
                               >
@@ -2254,7 +2254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -2262,7 +2262,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2270,12 +2270,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2283,7 +2283,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="76 %"
                                 value={76}
                               >
@@ -2293,7 +2293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Utilization"
                           >
                             Utilization
@@ -2301,7 +2301,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2309,12 +2309,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2322,7 +2322,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -2332,7 +2332,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Pressure"
                           >
                             Pressure
@@ -4365,12 +4365,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4378,7 +4378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="89 %"
                                 value={89}
                               >
@@ -4388,7 +4388,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -4396,7 +4396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -4404,12 +4404,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4417,7 +4417,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="76 %"
                                 value={76}
                               >
@@ -4427,7 +4427,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Utilization"
                           >
                             Utilization
@@ -4435,7 +4435,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -4443,12 +4443,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -4456,7 +4456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -4466,7 +4466,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Pressure"
                           >
                             Pressure
@@ -9023,12 +9023,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9036,7 +9036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="89 %"
                                 value={89}
                               >
@@ -9046,7 +9046,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -9054,7 +9054,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -9062,12 +9062,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9075,7 +9075,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="76 %"
                                 value={76}
                               >
@@ -9085,7 +9085,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Utilization"
                           >
                             Utilization
@@ -9093,7 +9093,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -9101,12 +9101,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -9114,7 +9114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -9124,7 +9124,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Pressure"
                           >
                             Pressure
@@ -20187,12 +20187,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="YTD"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20200,7 +20200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="13634.56 MWh"
                                   value={13634.56}
                                 >
@@ -20210,7 +20210,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="YTD"
                             >
                               YTD
@@ -20218,7 +20218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20226,12 +20226,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="MTD"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20239,7 +20239,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="1047.2 MWh"
                                   value={1047.2}
                                 >
@@ -20249,7 +20249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="MTD"
                             >
                               MTD
@@ -20257,7 +20257,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20265,12 +20265,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20278,7 +20278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="314.5 MWh"
                                   value={314.5}
                                 >
@@ -20288,7 +20288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Week"
                             >
                               Last Week
@@ -20339,12 +20339,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -20352,7 +20352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -20362,7 +20362,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Current"
                             >
                               Current
@@ -20370,7 +20370,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20378,12 +20378,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -20391,7 +20391,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Low "
                                   value="Low"
                                 >
@@ -20401,7 +20401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Week"
                             >
                               Last Week
@@ -20409,7 +20409,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20417,12 +20417,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -20430,7 +20430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="High "
                                   value="High"
                                 >
@@ -20440,7 +20440,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Month"
                             >
                               Last Month
@@ -20491,12 +20491,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -20504,7 +20504,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Low "
                                   value="Low"
                                 >
@@ -20539,7 +20539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Current"
                             >
                               Current
@@ -20547,7 +20547,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20555,12 +20555,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -20568,7 +20568,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -20603,7 +20603,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Week"
                             >
                               Last Week
@@ -20611,7 +20611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20619,12 +20619,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -20632,7 +20632,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -20667,7 +20667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Month"
                             >
                               Last Month
@@ -20783,12 +20783,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="YTD"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20796,7 +20796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="13634.56 MWh"
                                   value={13634.56}
                                 >
@@ -20806,7 +20806,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="YTD"
                             >
                               YTD
@@ -20814,7 +20814,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20822,12 +20822,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="MTD"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20835,7 +20835,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="1047.2 MWh"
                                   value={1047.2}
                                 >
@@ -20845,7 +20845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="MTD"
                             >
                               MTD
@@ -20853,7 +20853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20861,12 +20861,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -20874,7 +20874,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="314.5 MWh"
                                   value={314.5}
                                 >
@@ -20884,7 +20884,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Week"
                             >
                               Last Week
@@ -20935,12 +20935,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
@@ -20948,7 +20948,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -20958,7 +20958,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Current"
                             >
                               Current
@@ -20966,7 +20966,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -20974,12 +20974,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 fZOGnQ"
@@ -20987,7 +20987,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Low "
                                   value="Low"
                                 >
@@ -20997,7 +20997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Week"
                             >
                               Last Week
@@ -21005,7 +21005,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21013,12 +21013,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 eBvnHB"
@@ -21026,7 +21026,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="High "
                                   value="High"
                                 >
@@ -21036,7 +21036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Month"
                             >
                               Last Month
@@ -21087,12 +21087,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         >
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Current"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -21100,7 +21100,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Low "
                                   value="Low"
                                 >
@@ -21135,7 +21135,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Current"
                             >
                               Current
@@ -21143,7 +21143,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21151,12 +21151,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Week"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -21164,7 +21164,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Severe "
                                   value="Severe"
                                 >
@@ -21199,7 +21199,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Week"
                             >
                               Last Week
@@ -21207,7 +21207,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <hr
                               className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21215,12 +21215,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                               label="Last Month"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                             >
                               <div
                                 className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -21228,7 +21228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                               >
                                 <span
                                   className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                  size="MEDIUMTHIN"
+                                  size="MEDIUM"
                                   title="Elevated "
                                   value="Elevated"
                                 >
@@ -21263,7 +21263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             </div>
                             <div
                               className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                              size="MEDIUMTHIN"
+                              size="MEDIUM"
                               title="Last Month"
                             >
                               Last Month
@@ -21468,12 +21468,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                       >
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Comfort Level"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21481,7 +21481,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="89 %"
                                 value={89}
                               >
@@ -21491,7 +21491,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Comfort Level"
                           >
                             Comfort Level
@@ -21499,7 +21499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21507,12 +21507,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Utilization"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21520,7 +21520,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="76 %"
                                 value={76}
                               >
@@ -21530,7 +21530,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Utilization"
                           >
                             Utilization
@@ -21538,7 +21538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <hr
                             className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -21546,12 +21546,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                         </div>
                         <div
                           className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                          size="MEDIUMTHIN"
+                          size="MEDIUM"
                         >
                           <div
                             className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                             label="Pressure"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                           >
                             <div
                               className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -21559,7 +21559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                             >
                               <span
                                 className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                                size="MEDIUMTHIN"
+                                size="MEDIUM"
                                 title="21.4 mb"
                                 value={21.4}
                               >
@@ -21569,7 +21569,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                           </div>
                           <div
                             className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                            size="MEDIUMTHIN"
+                            size="MEDIUM"
                             title="Pressure"
                           >
                             Pressure

--- a/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/DashboardGrid.story.storyshot
@@ -1,5 +1,403 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashboard Grid dashboard, all card sizes 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        Resize your window to see the callback handlers get triggered in the Actions tab.
+        <div
+          style={
+            Object {
+              "width": "calc(100vw - 6rem)",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <div
+              className="react-grid-layout DashboardGrid__StyledGridLayout-vxs00g-0 hTrCDO"
+              style={
+                Object {
+                  "height": "1776px",
+                }
+              }
+            >
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
+                id="Small"
+                style={
+                  Object {
+                    "MozTransform": "translate(16px,16px)",
+                    "OTransform": "translate(16px,16px)",
+                    "WebkitTransform": "translate(16px,16px)",
+                    "height": "144px",
+                    "msTransform": "translate(16px,16px)",
+                    "position": "absolute",
+                    "transform": "translate(16px,16px)",
+                    "width": "300px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Small"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Small
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 ggrDpu"
+                />
+              </div>
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
+                id="Small Wide"
+                style={
+                  Object {
+                    "MozTransform": "translate(332px,16px)",
+                    "OTransform": "translate(332px,16px)",
+                    "WebkitTransform": "translate(332px,16px)",
+                    "height": "144px",
+                    "msTransform": "translate(332px,16px)",
+                    "position": "absolute",
+                    "transform": "translate(332px,16px)",
+                    "width": "300px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Small Wide"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Small Wide
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 ggrDpu"
+                />
+              </div>
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bHPJyP"
+                id="Medium Thin"
+                style={
+                  Object {
+                    "MozTransform": "translate(16px,176px)",
+                    "OTransform": "translate(16px,176px)",
+                    "WebkitTransform": "translate(16px,176px)",
+                    "height": "304px",
+                    "msTransform": "translate(16px,176px)",
+                    "position": "absolute",
+                    "transform": "translate(16px,176px)",
+                    "width": "300px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Medium Thin"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Medium Thin
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 hxiPNM"
+                />
+              </div>
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bHPJyP"
+                id="Medium"
+                style={
+                  Object {
+                    "MozTransform": "translate(332px,176px)",
+                    "OTransform": "translate(332px,176px)",
+                    "WebkitTransform": "translate(332px,176px)",
+                    "height": "304px",
+                    "msTransform": "translate(332px,176px)",
+                    "position": "absolute",
+                    "transform": "translate(332px,176px)",
+                    "width": "300px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Medium"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Medium
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 hxiPNM"
+                />
+              </div>
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bHPJyP"
+                id="Medium Wide"
+                style={
+                  Object {
+                    "MozTransform": "translate(648px,16px)",
+                    "OTransform": "translate(648px,16px)",
+                    "WebkitTransform": "translate(648px,16px)",
+                    "height": "304px",
+                    "msTransform": "translate(648px,16px)",
+                    "position": "absolute",
+                    "transform": "translate(648px,16px)",
+                    "width": "616px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Medium Wide"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Medium Wide
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 hxiPNM"
+                />
+              </div>
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 izWJSI"
+                id="Large Thin"
+                style={
+                  Object {
+                    "MozTransform": "translate(16px,496px)",
+                    "OTransform": "translate(16px,496px)",
+                    "WebkitTransform": "translate(16px,496px)",
+                    "height": "624px",
+                    "msTransform": "translate(16px,496px)",
+                    "position": "absolute",
+                    "transform": "translate(16px,496px)",
+                    "width": "300px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Large Thin"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Large Thin
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 flVXpj"
+                />
+              </div>
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 izWJSI"
+                id="Large"
+                style={
+                  Object {
+                    "MozTransform": "translate(332px,496px)",
+                    "OTransform": "translate(332px,496px)",
+                    "WebkitTransform": "translate(332px,496px)",
+                    "height": "624px",
+                    "msTransform": "translate(332px,496px)",
+                    "position": "absolute",
+                    "transform": "translate(332px,496px)",
+                    "width": "616px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Large"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Large
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 flVXpj"
+                />
+              </div>
+              <div
+                className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 izWJSI"
+                id="Large Wide"
+                style={
+                  Object {
+                    "MozTransform": "translate(16px,1136px)",
+                    "OTransform": "translate(16px,1136px)",
+                    "WebkitTransform": "translate(16px,1136px)",
+                    "height": "624px",
+                    "msTransform": "translate(16px,1136px)",
+                    "position": "absolute",
+                    "transform": "translate(16px,1136px)",
+                    "width": "1248px",
+                  }
+                }
+                type="VALUE"
+              >
+                <div
+                  className="card--header"
+                >
+                  <span
+                    className="card--title"
+                    title="Large Wide"
+                  >
+                    <div
+                      className="title--text"
+                    >
+                      Large Wide
+                    </div>
+                  </span>
+                  <div
+                    className="card--toolbar"
+                  />
+                </div>
+                <div
+                  className="Card__CardContent-v5r71h-1 flVXpj"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashboard Grid dashboard, custom layout 1`] = `
 <div
   style={

--- a/src/components/GaugeCard/GaugeCard.story.jsx
+++ b/src/components/GaugeCard/GaugeCard.story.jsx
@@ -54,7 +54,7 @@ storiesOf('Watson IoT Experimental|GaugeCard', module).add('basic', () => {
         tooltip={<p>Health - of floor 8</p>}
         id="GaugeCard"
         title={text('Text', 'Health')}
-        size={CARD_SIZES.XSMALL}
+        size={CARD_SIZES.SMALL}
         values={{
           usage: number('Gauge value', 81),
           usageTrend: '12%',

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
 import Image32 from '@carbon/icons-react/lib/image/32';
-import warning from 'warning';
 
 import { ImageCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
-import { CARD_SIZES, DEPRECATED_SIZES } from '../../constants/LayoutConstants';
+import { CARD_SIZES } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
+import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
 
 import ImageHotspots from './ImageHotspots';
 
@@ -50,26 +50,7 @@ const ImageCard = ({
   const hotspots = values ? values.hotspots || [] : [];
 
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
-  const changedSize =
-    size === 'XSMALL'
-      ? 'SMALL'
-      : size === 'XSMALLWIDE'
-      ? 'SMALLWIDE'
-      : size === 'WIDE'
-      ? 'MEDIUMWIDE'
-      : size === 'TALL'
-      ? 'LARGETHIN'
-      : size === 'XLARGE'
-      ? 'LARGEWIDE'
-      : null;
-  let newSize = size;
-  if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
-    newSize = changedSize;
-  }
+  const newSize = getUpdatedCardSize(size);
 
   const supportedSizes = [
     CARD_SIZES.MEDIUMTHIN,

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
 import Image32 from '@carbon/icons-react/lib/image/32';
+import warning from 'warning';
 
 import { ImageCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
-import { CARD_SIZES } from '../../constants/LayoutConstants';
+import { CARD_SIZES, DEPRECATED_SIZES } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
 
 import ImageHotspots from './ImageHotspots';
@@ -47,14 +48,37 @@ const ImageCard = ({
 }) => {
   const { src } = content;
   const hotspots = values ? values.hotspots || [] : [];
+
+  // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
+  const changedSize =
+    size === 'XSMALL'
+      ? 'SMALL'
+      : size === 'XSMALLWIDE'
+      ? 'SMALLWIDE'
+      : size === 'WIDE'
+      ? 'MEDIUMWIDE'
+      : size === 'TALL'
+      ? 'LARGETHIN'
+      : size === 'XLARGE'
+      ? 'LARGEWIDE'
+      : null;
+  let newSize = size;
+  if (changedSize) {
+    warning(
+      false,
+      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
+    );
+    newSize = changedSize;
+  }
+
   const supportedSizes = [
-    CARD_SIZES.SMALL,
+    CARD_SIZES.MEDIUMTHIN,
     CARD_SIZES.MEDIUM,
-    CARD_SIZES.WIDE,
+    CARD_SIZES.MEDIUMWIDE,
     CARD_SIZES.LARGE,
-    CARD_SIZES.XLARGE,
+    CARD_SIZES.LARGEWIDE,
   ];
-  const supportedSize = supportedSizes.includes(size);
+  const supportedSize = supportedSizes.includes(newSize);
   const availableActions = { expand: supportedSize };
 
   const isCardLoading = isNil(src) && !isEditable && !error;
@@ -62,7 +86,7 @@ const ImageCard = ({
   return (
     <Card
       title={title}
-      size={size}
+      size={newSize}
       onCardAction={onCardAction}
       availableActions={availableActions}
       isLoading={isCardLoading} // only show the spinner if we don't have an image

--- a/src/components/ImageCard/ImageCard.story.jsx
+++ b/src/components/ImageCard/ImageCard.story.jsx
@@ -49,7 +49,7 @@ const values = {
 
 storiesOf('Watson IoT|ImageCard', module)
   .add('basic', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ImageCard
@@ -65,7 +65,7 @@ storiesOf('Watson IoT|ImageCard', module)
     );
   })
   .add('custom renderIconByName', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ImageCard
@@ -94,7 +94,7 @@ storiesOf('Watson IoT|ImageCard', module)
     );
   })
   .add('isEditable', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ImageCard
@@ -111,7 +111,7 @@ storiesOf('Watson IoT|ImageCard', module)
     );
   })
   .add('hotspots are loading', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ImageCard
@@ -128,7 +128,7 @@ storiesOf('Watson IoT|ImageCard', module)
     );
   })
   .add('error', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ImageCard
@@ -146,7 +146,7 @@ storiesOf('Watson IoT|ImageCard', module)
     );
   })
   .add('error loading image', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ImageCard

--- a/src/components/ListCard/ListCard.story.jsx
+++ b/src/components/ListCard/ListCard.story.jsx
@@ -247,7 +247,7 @@ storiesOf('Watson IoT Experimental|ListCard', module)
     );
   })
   .add('with extra content', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.WIDE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMWIDE);
 
     return (
       <ListCardExtraContent
@@ -258,7 +258,7 @@ storiesOf('Watson IoT Experimental|ListCard', module)
     );
   })
   .add('with extra long content', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.WIDE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMWIDE);
 
     return (
       <ListCardExtraContentLong

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -7,6 +7,7 @@ import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
 import capitalize from 'lodash/capitalize';
 import OverFlowMenuIcon from '@carbon/icons-react/lib/overflow-menu--vertical/20';
+import warning from 'warning';
 
 import { CardPropTypes, TableCardPropTypes } from '../../constants/PropTypes';
 import Card, { defaultProps as CardDefaultProps } from '../Card/Card';
@@ -259,6 +260,28 @@ const TableCard = ({
   tooltip,
   ...others
 }) => {
+  // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
+  const changedSize =
+    size === 'XSMALL'
+      ? 'SMALL'
+      : size === 'XSMALLWIDE'
+      ? 'SMALLWIDE'
+      : size === 'WIDE'
+      ? 'MEDIUMWIDE'
+      : size === 'TALL'
+      ? 'LARGETHIN'
+      : size === 'XLARGE'
+      ? 'LARGEWIDE'
+      : null;
+  let newSize = size;
+  if (changedSize) {
+    warning(
+      false,
+      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
+    );
+    newSize = changedSize;
+  }
+
   /** adds the id to the card action */
   const cachedOnCardAction = useCallback((...args) => onCardAction(id, ...args), [
     onCardAction,
@@ -504,7 +527,7 @@ const TableCard = ({
           id: i.dataSourceId ? i.dataSourceId : i.id,
           name: i.label ? i.label : i.dataSourceId || '', // don't force label to be required
           isSortable: true,
-          width: i.width ? `${i.width}px` : size === CARD_SIZES.TALL ? '150px' : '', // force the text wrap
+          width: i.width ? `${i.width}px` : newSize === CARD_SIZES.LARGETHIN ? '150px' : '', // force the text wrap
           filter: i.filter
             ? i.filter
             : { placeholderText: strings.defaultFilterStringPlaceholdText }, // if filter not send we send empty object
@@ -512,14 +535,14 @@ const TableCard = ({
         .concat(hasActionColumn ? actionColumn : [])
         .map(column => {
           const columnPriority = column.priority || 1; // default to 1 if not provided
-          switch (size) {
-            case CARD_SIZES.TALL:
+          switch (newSize) {
+            case CARD_SIZES.LARGETHIN:
               return columnPriority === 1 ? column : null;
 
             case CARD_SIZES.LARGE:
               return columnPriority === 1 || columnPriority === 2 ? column : null;
 
-            case CARD_SIZES.XLARGE:
+            case CARD_SIZES.LARGEWIDE:
               return column;
 
             default:
@@ -527,7 +550,7 @@ const TableCard = ({
           }
         })
         .filter(i => i),
-    [actionColumn, hasActionColumn, newColumns, size, strings.defaultFilterStringPlaceholdText]
+    [actionColumn, hasActionColumn, newColumns, newSize, strings.defaultFilterStringPlaceholdText]
   );
 
   const filteredTimestampColumns = useMemo(
@@ -677,7 +700,7 @@ const TableCard = ({
     columnsToRender.filter(item => item.id !== 'actionColumn' && !item.id.includes('iconColumn'))
       .length;
 
-  const hasFilter = size !== CARD_SIZES.TALL;
+  const hasFilter = newSize !== CARD_SIZES.LARGETHIN;
 
   const hasRowExpansion = !!(expandedRows && expandedRows.length);
 
@@ -703,7 +726,7 @@ const TableCard = ({
   return (
     <Card
       id={id}
-      size={size}
+      size={newSize}
       onCardAction={onCardAction}
       availableActions={{ expand: isExpandable, range: true }}
       isEditable={isEditable}

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -7,7 +7,6 @@ import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
 import capitalize from 'lodash/capitalize';
 import OverFlowMenuIcon from '@carbon/icons-react/lib/overflow-menu--vertical/20';
-import warning from 'warning';
 
 import { CardPropTypes, TableCardPropTypes } from '../../constants/PropTypes';
 import Card, { defaultProps as CardDefaultProps } from '../Card/Card';
@@ -16,6 +15,7 @@ import StatefulTable from '../Table/StatefulTable';
 import { generateTableSampleValues } from '../TimeSeriesCard/timeSeriesUtils';
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import CardToolbar from '../Card/CardToolbar';
+import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
 
 const StyledOverflowMenu = styled(OverflowMenu)`
   &&& {
@@ -261,26 +261,7 @@ const TableCard = ({
   ...others
 }) => {
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
-  const changedSize =
-    size === 'XSMALL'
-      ? 'SMALL'
-      : size === 'XSMALLWIDE'
-      ? 'SMALLWIDE'
-      : size === 'WIDE'
-      ? 'MEDIUMWIDE'
-      : size === 'TALL'
-      ? 'LARGETHIN'
-      : size === 'XLARGE'
-      ? 'LARGEWIDE'
-      : null;
-  let newSize = size;
-  if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
-    newSize = changedSize;
-  }
+  const newSize = getUpdatedCardSize(size);
 
   /** adds the id to the card action */
   const cachedOnCardAction = useCallback((...args) => onCardAction(id, ...args), [

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -29,8 +29,8 @@ storiesOf('Watson IoT|TableCard', module)
       </div>
     );
   })
-  .add('size - xlarge with tooltip', () => {
-    const size = CARD_SIZES.XLARGE;
+  .add('size - large-wide with tooltip', () => {
+    const size = CARD_SIZES.LARGEWIDE;
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <TableCard
@@ -48,7 +48,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with multiple actions', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.LARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     const tableDataWithActions = tableData.map(item => {
       return {
@@ -73,7 +73,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with single actions', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.LARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     const tableDataWithActions = tableData.map(item => {
       return {
@@ -98,7 +98,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with thresholds, precision and expanded rows', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.XLARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
     const thresholds = [
       // this threshold is applied to the whole row, not a particular attribute
@@ -169,7 +169,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with thresholds', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.XLARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
     const thresholds = [
       // this threshold is applied to the whole row, not a particular attribute
@@ -219,7 +219,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with thresholds only with value', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.XLARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
     const thresholds = [
       // this threshold is applied to the whole row, not a particular attribute
@@ -270,7 +270,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with custom column sort', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.XLARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
     const tableCustomColumns = tableColumns.map(item =>
       item.dataSourceId === 'count' ? { ...item, sort: 'DESC' } : item
@@ -293,7 +293,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with fixed column size', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.LARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     const tableCustomColumns = tableColumns.map((item, index) =>
       index === 0 ? { ...item, width: 250, name: 'Alert with long string name' } : item
@@ -316,7 +316,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('table with row expansion', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.LARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -446,7 +446,7 @@ storiesOf('Watson IoT|TableCard', module)
     );
   })
   .add('i18n', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.XLARGE], CARD_SIZES.XLARGE);
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
     const thresholds = [
       // this threshold is applied to the whole row, not a particular attribute

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -95,7 +95,7 @@ describe('TableCard', () => {
           columns: tableColumns,
         }}
         values={tableData}
-        size={CARD_SIZES.XLARGE}
+        size={CARD_SIZES.LARGEWIDE}
       />
     );
     expect(wrapper.find('TableHeader').length).toBe(tableColumns.length);

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -9023,7 +9023,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Table
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard size - xlarge with tooltip 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TableCard size - large-wide with tooltip 1`] = `
 <div
   style={
     Object {

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -10,13 +10,13 @@ import filter from 'lodash/filter';
 import memoize from 'lodash/memoize';
 import capitalize from 'lodash/capitalize';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import warning from 'warning';
 
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
 import { CARD_SIZES, TIME_SERIES_TYPES, DISABLED_COLORS } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
 import StatefulTable from '../Table/StatefulTable';
+import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
 
 import {
   generateSampleValues,
@@ -218,26 +218,7 @@ const TimeSeriesCard = ({
   );
 
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
-  const changedSize =
-    size === 'XSMALL'
-      ? 'SMALL'
-      : size === 'XSMALLWIDE'
-      ? 'SMALLWIDE'
-      : size === 'WIDE'
-      ? 'MEDIUMWIDE'
-      : size === 'TALL'
-      ? 'LARGETHIN'
-      : size === 'XLARGE'
-      ? 'LARGEWIDE'
-      : null;
-  let newSize = size;
-  if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
-    newSize = changedSize;
-  }
+  const newSize = getUpdatedCardSize(size);
 
   const maxTicksPerSize = useMemo(
     () => {

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -904,7 +904,7 @@ storiesOf('Watson IoT|TimeSeriesCard', module)
       </div>
     );
   })
-  .add('Xlarge / multi line - (No X/Y Label)', () => {
+  .add('largewide / multi line - (No X/Y Label)', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -905,7 +905,7 @@ storiesOf('Watson IoT|TimeSeriesCard', module)
     );
   })
   .add('Xlarge / multi line - (No X/Y Label)', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XLARGE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGEWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <TimeSeriesCard

--- a/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -52,8 +52,8 @@ describe('TimeSeriesCard tests', () => {
   });
   test('determine precision', () => {
     expect(determinePrecision(CARD_SIZES.LARGE, 700)).toEqual(0);
-    expect(determinePrecision(CARD_SIZES.XSMALL, 11.45)).toEqual(0);
-    expect(determinePrecision(CARD_SIZES.XSMALL, 1.45, 1)).toEqual(1);
+    expect(determinePrecision(CARD_SIZES.SMALL, 11.45)).toEqual(0);
+    expect(determinePrecision(CARD_SIZES.SMALL, 1.45, 1)).toEqual(1);
     expect(determinePrecision(CARD_SIZES.LARGE, 1.45, 1)).toEqual(1);
   });
   test('valueFormatter', () => {

--- a/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
+++ b/src/components/TimeSeriesCard/__snapshots__/TimeSeriesCard.story.storyshot
@@ -1,116 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeSeriesCard Xlarge / multi line - (No X/Y Label) 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "1056px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 izWJSI"
-            id="facility-temperature"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Temperature"
-              >
-                <div
-                  className="title--text"
-                >
-                  Temperature
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 flVXpj"
-            >
-              <div
-                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
-                size="XLARGE"
-              >
-                <div
-                  className="chart-holder"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeSeriesCard bar chart 1`] = `
 <div
   style={
@@ -2291,6 +2180,117 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeS
               <div
                 className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
                 size="LARGE"
+              >
+                <div
+                  className="chart-holder"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|TimeSeriesCard largewide / multi line - (No X/Y Label) 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "1056px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 izWJSI"
+            id="facility-temperature"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Temperature"
+              >
+                <div
+                  className="title--text"
+                >
+                  Temperature
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 flVXpj"
+            >
+              <div
+                className="TimeSeriesCard__LineChartWrapper-q25vbg-1 eEHcwc"
+                size="LARGEWIDE"
               >
                 <div
                   className="chart-holder"

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -4,10 +4,10 @@ import styled from 'styled-components';
 import isNil from 'lodash/isNil';
 import { Icon } from 'carbon-components-react';
 import withSize from 'react-sizeme';
-import warning from 'warning';
 
 import icons from '../../utils/bundledIcons';
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
+import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
 
 import ValueRenderer from './ValueRenderer';
 import UnitRenderer from './UnitRenderer';
@@ -118,26 +118,8 @@ const Attribute = ({
   size, // eslint-disable-line
 }) => {
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
-  const changedSize =
-    size === 'XSMALL'
-      ? 'SMALL'
-      : size === 'XSMALLWIDE'
-      ? 'SMALLWIDE'
-      : size === 'WIDE'
-      ? 'MEDIUMWIDE'
-      : size === 'TALL'
-      ? 'LARGETHIN'
-      : size === 'XLARGE'
-      ? 'LARGEWIDE'
-      : null;
-  let newSize = size;
-  if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
-    newSize = changedSize;
-  }
+  const newSize = getUpdatedCardSize(size);
+
   // matching threshold will be the first match in the list, or a value of null
   const matchingThreshold = thresholds
     .filter(t => {

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import isNil from 'lodash/isNil';
 import { Icon } from 'carbon-components-react';
 import withSize from 'react-sizeme';
+import warning from 'warning';
 
 import icons from '../../utils/bundledIcons';
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
@@ -17,7 +18,7 @@ const StyledAttribute = styled.div`
   ${props => (props.isVertical && props.alignValue ? `justify-content: ${props.alignValue};` : '')};
   order: 1;
   ${props =>
-    !props.label || props.isVertical || props.size === CARD_SIZES.XSMALL
+    !props.label || props.isVertical || props.size === CARD_SIZES.SMALL
       ? 'width: 100%'
       : 'width: 50%'};
 `;
@@ -116,6 +117,27 @@ const Attribute = ({
   renderIconByName,
   size, // eslint-disable-line
 }) => {
+  // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
+  const changedSize =
+    size === 'XSMALL'
+      ? 'SMALL'
+      : size === 'XSMALLWIDE'
+      ? 'SMALLWIDE'
+      : size === 'WIDE'
+      ? 'MEDIUMWIDE'
+      : size === 'TALL'
+      ? 'LARGETHIN'
+      : size === 'XLARGE'
+      ? 'LARGEWIDE'
+      : null;
+  let newSize = size;
+  if (changedSize) {
+    warning(
+      false,
+      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
+    );
+    newSize = changedSize;
+  }
   // matching threshold will be the first match in the list, or a value of null
   const matchingThreshold = thresholds
     .filter(t => {
@@ -166,7 +188,7 @@ const Attribute = ({
       {({ size: measuredSize }) => {
         return (
           <StyledAttribute
-            size={size}
+            size={newSize}
             alignValue={alignValue}
             isVertical={isVertical}
             isMini={isMini}
@@ -178,7 +200,7 @@ const Attribute = ({
               layout={layout}
               isSmall={isSmall}
               isMini={isMini}
-              size={size}
+              size={newSize}
               thresholds={thresholds}
               precision={precision}
               isVertical={isVertical}

--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -3,13 +3,15 @@ import styled from 'styled-components';
 import withSize from 'react-sizeme';
 import isEmpty from 'lodash/isEmpty';
 import filter from 'lodash/filter';
-import warning from 'warning';
 
 import { ValueCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
 import { CARD_LAYOUTS, CARD_SIZES, CARD_CONTENT_PADDING } from '../../constants/LayoutConstants';
 import { COLORS } from '../../styles/styles';
 import Card from '../Card/Card';
-import { determineMaxValueCardAttributeCount } from '../../utils/cardUtilityFunctions';
+import {
+  determineMaxValueCardAttributeCount,
+  getUpdatedCardSize,
+} from '../../utils/cardUtilityFunctions';
 
 import Attribute from './Attribute';
 
@@ -211,26 +213,7 @@ const ValueCard = ({ title, content, size, values, isEditable, i18n, ...others }
     ...others.availableActions,
   };
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
-  const changedSize =
-    size === 'XSMALL'
-      ? 'SMALL'
-      : size === 'XSMALLWIDE'
-      ? 'SMALLWIDE'
-      : size === 'WIDE'
-      ? 'MEDIUMWIDE'
-      : size === 'TALL'
-      ? 'LARGETHIN'
-      : size === 'XLARGE'
-      ? 'LARGEWIDE'
-      : null;
-  let newSize = size;
-  if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
-    newSize = changedSize;
-  }
+  const newSize = getUpdatedCardSize(size);
 
   return (
     <withSize.SizeMe>

--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -88,7 +88,7 @@ const determineLabelFontSize = ({ size, layout, attributeCount, isVertical }) =>
     case CARD_SIZES.SMALLWIDE:
       fontSize = 0.875;
       break;
-    case CARD_SIZES.MEDIUMTHIN:
+    case CARD_SIZES.MEDIUM:
       fontSize = isVertical && attributeCount > 2 ? 0.875 : 1;
       break;
     case CARD_SIZES.LARGETHIN:
@@ -102,7 +102,7 @@ const determineLabelFontSize = ({ size, layout, attributeCount, isVertical }) =>
 
 /** * Determines the label alignment */
 const getLabelAlignment = ({ size, isVertical, attributeCount }) => {
-  if (attributeCount === 1 && size === CARD_SIZES.MEDIUMTHIN && isVertical) {
+  if (attributeCount === 1 && size === CARD_SIZES.MEDIUM && isVertical) {
     return 'center';
   }
   return isVertical ? 'left' : 'right';
@@ -127,7 +127,7 @@ const AttributeLabel = styled.div`
   ${props => `font-size: ${determineLabelFontSize(props)}rem;`};
   text-align: ${props => getLabelAlignment(props)};
   ${props =>
-    (props.isVertical || props.size === CARD_SIZES.SMALL || props.size === CARD_SIZES.MEDIUMTHIN) &&
+    (props.isVertical || props.size === CARD_SIZES.SMALL || props.size === CARD_SIZES.MEDIUM) &&
     `padding-top: 0.25rem;`};
   ${props =>
     !(props.isVertical || props.size === CARD_SIZES.SMALL || props.size === CARD_SIZES.SMALLWIDE) &&
@@ -200,7 +200,7 @@ const isLabelAboveValue = (size, layout, attributes, measuredSize) => {
   switch (size) {
     case CARD_SIZES.SMALLWIDE:
       return layout === CARD_LAYOUTS.HORIZONTAL;
-    case CARD_SIZES.MEDIUMTHIN:
+    case CARD_SIZES.MEDIUM:
       return attributes.length === 1 || !measuredSize || measuredSize.width < 300;
     default:
       return !measuredSize || measuredSize.width < 300;

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -10,7 +10,7 @@ import ValueCard from './ValueCard';
 
 storiesOf('Watson IoT|ValueCard', module)
   .add('xsmall / basic', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -32,7 +32,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / long', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -54,7 +54,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / units', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
         <ValueCard
@@ -76,7 +76,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / title', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -98,7 +98,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / trend down', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
         <ValueCard
@@ -120,7 +120,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / trend up', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
         <ValueCard
@@ -142,7 +142,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / thresholds (number, no icon)', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ValueCard
@@ -180,7 +180,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / thresholds (number, icon)', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ValueCard
@@ -209,7 +209,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmall / thresholds (number, custom renderIconByName)', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ValueCard
@@ -251,7 +251,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmallwide / thresholds (string)', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALLWIDE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALLWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ValueCard
@@ -286,7 +286,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmallwide / vertical 2', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALLWIDE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALLWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
         <ValueCard
@@ -312,7 +312,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('xsmallwide / horizontal 2', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALLWIDE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALLWIDE);
     return (
       <div style={{ width: `${number('cardWidth', 300)}px`, margin: 20 }}>
         <ValueCard
@@ -342,7 +342,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('small / vertical / single', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -361,7 +361,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('small / vertical / multiple', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -391,7 +391,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('small / vertical /  2', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -419,7 +419,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('small / vertical /  3', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -500,7 +500,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('small / horizontal /  2', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `300px`), margin: 20 }}>
         <ValueCard
@@ -592,7 +592,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('tall / vertical /  6', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.TALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGETHIN);
     return (
       <div style={{ width: text('cardWidth', `250px`), margin: 20 }}>
         <ValueCard
@@ -630,7 +630,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('wide / horizontal /  3', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.WIDE);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMWIDE);
     return (
       <div style={{ width: text('cardWidth', `300px`), margin: 20 }}>
         <ValueCard
@@ -660,7 +660,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('with boolean', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -675,7 +675,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('empty state', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -689,7 +689,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('long titles and values', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.XSMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -712,7 +712,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('long titles and values/multiple', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -743,7 +743,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('editable', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -771,7 +771,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('dataFilters', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `300px`), margin: 20 }}>
         <ValueCard

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -341,8 +341,8 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('medium-thin / vertical / single', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+  .add('medium / vertical / single', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -360,8 +360,8 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('medium-thin / vertical / multiple', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+  .add('medium / vertical / multiple', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -390,8 +390,8 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('medium-thin / vertical /  2', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+  .add('medium / vertical /  2', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -418,8 +418,8 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('medium-thin / vertical /  3', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+  .add('medium / vertical /  3', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -499,8 +499,8 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('medium-thin / horizontal /  2', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+  .add('medium / horizontal /  2', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `300px`), margin: 20 }}>
         <ValueCard
@@ -675,7 +675,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('empty state', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -712,7 +712,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('long titles and values/multiple', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -743,7 +743,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('editable', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
         <ValueCard
@@ -771,7 +771,7 @@ storiesOf('Watson IoT|ValueCard', module)
     );
   })
   .add('dataFilters', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
     return (
       <div style={{ width: text('cardWidth', `300px`), margin: 20 }}>
         <ValueCard

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -9,7 +9,7 @@ import { getCardMinSize } from '../../utils/componentUtilityFunctions';
 import ValueCard from './ValueCard';
 
 storiesOf('Watson IoT|ValueCard', module)
-  .add('xsmall / basic', () => {
+  .add('small / basic', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
@@ -31,7 +31,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / long', () => {
+  .add('small / long', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
@@ -53,7 +53,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / units', () => {
+  .add('small / units', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
@@ -75,7 +75,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / title', () => {
+  .add('small / title', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
@@ -97,7 +97,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / trend down', () => {
+  .add('small / trend down', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
@@ -119,7 +119,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / trend up', () => {
+  .add('small / trend up', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
@@ -141,7 +141,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / thresholds (number, no icon)', () => {
+  .add('small / thresholds (number, no icon)', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -179,7 +179,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / thresholds (number, icon)', () => {
+  .add('small / thresholds (number, icon)', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -208,7 +208,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmall / thresholds (number, custom renderIconByName)', () => {
+  .add('small / thresholds (number, custom renderIconByName)', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -250,7 +250,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmallwide / thresholds (string)', () => {
+  .add('smallwide / thresholds (string)', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALLWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -285,7 +285,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmallwide / vertical 2', () => {
+  .add('smallwide / vertical 2', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALLWIDE);
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -311,7 +311,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('xsmallwide / horizontal 2', () => {
+  .add('smallwide / horizontal 2', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALLWIDE);
     return (
       <div style={{ width: `${number('cardWidth', 300)}px`, margin: 20 }}>
@@ -341,7 +341,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('small / vertical / single', () => {
+  .add('medium-thin / vertical / single', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
@@ -360,7 +360,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('small / vertical / multiple', () => {
+  .add('medium-thin / vertical / multiple', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
@@ -390,7 +390,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('small / vertical /  2', () => {
+  .add('medium-thin / vertical /  2', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
@@ -418,7 +418,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('small / vertical /  3', () => {
+  .add('medium-thin / vertical /  3', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
@@ -499,7 +499,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('small / horizontal /  2', () => {
+  .add('medium-thin / horizontal /  2', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `300px`), margin: 20 }}>
@@ -591,7 +591,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('tall / vertical /  6', () => {
+  .add('large-thin / vertical /  6', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.LARGETHIN);
     return (
       <div style={{ width: text('cardWidth', `250px`), margin: 20 }}>
@@ -629,7 +629,7 @@ storiesOf('Watson IoT|ValueCard', module)
       </div>
     );
   })
-  .add('wide / horizontal /  3', () => {
+  .add('medium-wide / horizontal /  3', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMWIDE);
     return (
       <div style={{ width: text('cardWidth', `300px`), margin: 20 }}>

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
+import warning from 'warning';
 
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
 
@@ -40,9 +41,9 @@ const Attribute = styled.div`
 const determineFontSize = ({ value, size, isSmall, isMini, layout }) => {
   if (typeof value === 'string') {
     switch (size) {
-      case CARD_SIZES.XSMALL:
+      case CARD_SIZES.SMALL:
         return value.length > 4 ? 1 : 2;
-      case CARD_SIZES.XSMALLWIDE:
+      case CARD_SIZES.SMALLWIDE:
         return layout === CARD_LAYOUTS.HORIZONTAL ? 1.25 : 1;
       default:
     }
@@ -73,7 +74,7 @@ const determinePrecision = (size, value, precision) => {
   }
   // If the card is xsmall we don't have room for decimals!
   switch (size) {
-    case CARD_SIZES.XSMALL:
+    case CARD_SIZES.SMALL:
       return Math.abs(value) > 9 ? 0 : precision;
     default:
   }
@@ -92,7 +93,29 @@ const ValueRenderer = ({
   color,
   isVertical,
 }) => {
-  const precision = determinePrecision(size, value, precisionProp);
+  // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
+  const changedSize =
+    size === 'XSMALL'
+      ? 'SMALL'
+      : size === 'XSMALLWIDE'
+      ? 'SMALLWIDE'
+      : size === 'WIDE'
+      ? 'MEDIUMWIDE'
+      : size === 'TALL'
+      ? 'LARGETHIN'
+      : size === 'XLARGE'
+      ? 'LARGEWIDE'
+      : null;
+  let newSize = size;
+  if (changedSize) {
+    warning(
+      false,
+      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
+    );
+    newSize = changedSize;
+  }
+
+  const precision = determinePrecision(newSize, value, precisionProp);
   let renderValue = value;
   if (typeof value === 'boolean') {
     renderValue = <StyledBoolean>{value.toString()}</StyledBoolean>;
@@ -114,7 +137,7 @@ const ValueRenderer = ({
   return (
     <Attribute unit={unit} isSmall={isSmall} isMini={isMini} color={color} isVertical={isVertical}>
       <AttributeValue
-        size={size}
+        size={newSize}
         title={`${value} ${unit || ''}`}
         layout={layout}
         isSmall={isSmall}

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
-import warning from 'warning';
 
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
+import { getUpdatedCardSize } from '../../utils/cardUtilityFunctions';
 
 const propTypes = {
   value: PropTypes.any, // eslint-disable-line
@@ -94,26 +94,7 @@ const ValueRenderer = ({
   isVertical,
 }) => {
   // Checks size property against new size naming convention and reassigns to closest supported size if necessary.
-  const changedSize =
-    size === 'XSMALL'
-      ? 'SMALL'
-      : size === 'XSMALLWIDE'
-      ? 'SMALLWIDE'
-      : size === 'WIDE'
-      ? 'MEDIUMWIDE'
-      : size === 'TALL'
-      ? 'LARGETHIN'
-      : size === 'XLARGE'
-      ? 'LARGEWIDE'
-      : null;
-  let newSize = size;
-  if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${size} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
-    newSize = changedSize;
-  }
+  const newSize = getUpdatedCardSize(size);
 
   const precision = determinePrecision(newSize, value, precisionProp);
   let renderValue = value;

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -72,24 +72,24 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               className="Card__CardContent-v5r71h-1 hxiPNM"
             >
               <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
               >
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Device 1 Comfort"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="100 %"
                         value="100"
                       >
@@ -99,36 +99,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Device 1 Comfort"
                   >
                     Device 1 Comfort
                   </div>
                 </div>
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Device 2 Comfort"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="50 %"
                         value="50"
                       >
@@ -138,7 +130,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Device 2 Comfort"
                   >
                     Device 2 Comfort
@@ -249,24 +241,24 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               className="Card__CardContent-v5r71h-1 hxiPNM"
             >
               <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
               >
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Monthly summary"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="-- Wh"
                         value="--"
                       >
@@ -276,36 +268,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Monthly summary"
                   >
                     Monthly summary
                   </div>
                 </div>
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Yearly summary"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="-- Wh"
                         value="--"
                       >
@@ -315,7 +299,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Yearly summary"
                   >
                     Yearly summary
@@ -1338,24 +1322,24 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               className="Card__CardContent-v5r71h-1 hxiPNM"
             >
               <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
               >
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Monthly summary"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="100000000 Wh"
                         value={100000000}
                       >
@@ -1365,36 +1349,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Monthly summary"
                   >
                     Monthly summary
                   </div>
                 </div>
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Yearly summary"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="40000000000000 Wh"
                         value={40000000000000}
                       >
@@ -1404,10 +1380,179 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Yearly summary"
                   >
                     Yearly summary
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium / horizontal /  2 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "300px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bHPJyP"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Facility Conditions"
+              >
+                <div
+                  className="title--text"
+                >
+                  Facility Conditions
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 hxiPNM"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Comfort Level"
+                    size="MEDIUM"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
+                        title="89 %"
+                        value={89}
+                      >
+                        89
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
+                    size="MEDIUM"
+                    title="Comfort Level"
+                  >
+                    Comfort Level
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Average Temperature"
+                    size="MEDIUM"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
+                        title="76.7 ˚F"
+                        value={76.7}
+                      >
+                        76.7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
+                    size="MEDIUM"
+                    title="Average Temperature"
+                  >
+                    Average Temperature
                   </div>
                 </div>
               </div>
@@ -1541,7 +1686,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     </div>
                   </div>
                   <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 jvOQzz"
+                    className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
                     size="MEDIUM"
                     title="Comfort Level"
                   >
@@ -1580,7 +1725,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     </div>
                   </div>
                   <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 jvOQzz"
+                    className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
                     size="MEDIUM"
                     title="Average Temperature"
                   >
@@ -1619,7 +1764,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     </div>
                   </div>
                   <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 krPcSU"
+                    className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
                     size="MEDIUM"
                     title="Utilization"
                   >
@@ -1659,7 +1804,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / horizontal /  2 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium / vertical /  2 1`] = `
 <div
   style={
     Object {
@@ -1702,7 +1847,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
           style={
             Object {
               "margin": 20,
-              "width": "300px",
+              "width": "252px",
             }
           }
         >
@@ -1731,24 +1876,24 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               className="Card__CardContent-v5r71h-1 hxiPNM"
             >
               <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
               >
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="89 %"
                         value={89}
                       >
@@ -1758,36 +1903,28 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Comfort Level"
                   >
                     Comfort Level
                   </div>
                 </div>
                 <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -1797,7 +1934,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -1836,7 +1973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical /  2 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium / vertical /  3 1`] = `
 <div
   style={
     Object {
@@ -1912,12 +2049,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1925,184 +2062,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
-                        title="89 %"
-                        value={89}
-                      >
-                        89
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
-                    title="Comfort Level"
-                  >
-                    Comfort Level
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Average Temperature"
-                    size="MEDIUMTHIN"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
-                        title="76.7 ˚F"
-                        value={76.7}
-                      >
-                        76.7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
-                    title="Average Temperature"
-                  >
-                    Average Temperature
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical /  3 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bHPJyP"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Facility Conditions"
-              >
-                <div
-                  className="title--text"
-                >
-                  Facility Conditions
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 hxiPNM"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Comfort Level"
-                    size="MEDIUMTHIN"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        size="MEDIUM"
                         title="89 %"
                         value={89}
                       >
@@ -2137,7 +2097,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -2145,7 +2105,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2153,12 +2113,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2166,7 +2126,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        size="MEDIUM"
                         title="null ˚F"
                         value={null}
                       >
@@ -2176,7 +2136,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -2184,7 +2144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2192,12 +2152,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Humidity"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2205,7 +2165,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        size="MEDIUM"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -2240,7 +2200,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Humidity"
                   >
                     Humidity
@@ -2279,7 +2239,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical / multiple 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium / vertical / multiple 1`] = `
 <div
   style={
     Object {
@@ -2355,12 +2315,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2368,7 +2328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        size="MEDIUM"
                         title="89 %"
                         value={89}
                       >
@@ -2378,7 +2338,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -2386,7 +2346,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2394,12 +2354,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2407,7 +2367,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        size="MEDIUM"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -2417,7 +2377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -2425,7 +2385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2433,12 +2393,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Utilization"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2446,7 +2406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        size="MEDIUM"
                         title="76 %"
                         value={76}
                       >
@@ -2456,7 +2416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Utilization"
                   >
                     Utilization
@@ -2495,7 +2455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical / single 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium / vertical / single 1`] = `
 <div
   style={
     Object {
@@ -2567,24 +2527,24 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               className="Card__CardContent-v5r71h-1 hxiPNM"
             >
               <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                  size="MEDIUMTHIN"
+                  size="MEDIUM"
                 >
                   <div
-                    className="Attribute__StyledAttribute-dhraql-0 eexmWz"
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                     label="Comfort Level"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
                       color={null}
                     >
                       <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="MEDIUMTHIN"
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="MEDIUM"
                         title="89 %"
                         value={89}
                       >
@@ -2594,7 +2554,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 cAyPcU"
-                    size="MEDIUMTHIN"
+                    size="MEDIUM"
                     title="Comfort Level"
                   >
                     Comfort Level

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -76,12 +76,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Device 1 Comfort"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -89,7 +89,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="100 %"
                         value="100"
                       >
@@ -99,7 +99,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Device 1 Comfort"
                   >
                     Device 1 Comfort
@@ -107,7 +107,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -115,12 +115,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Device 2 Comfort"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -128,7 +128,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="50 %"
                         value="50"
                       >
@@ -138,7 +138,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Device 2 Comfort"
                   >
                     Device 2 Comfort
@@ -253,12 +253,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Monthly summary"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -266,7 +266,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="-- Wh"
                         value="--"
                       >
@@ -276,7 +276,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Monthly summary"
                   >
                     Monthly summary
@@ -284,7 +284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -292,12 +292,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Yearly summary"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -305,7 +305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="-- Wh"
                         value="--"
                       >
@@ -315,7 +315,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Yearly summary"
                   >
                     Yearly summary
@@ -756,6 +756,378 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard large-thin / vertical /  6 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "250px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 izWJSI"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Facility Conditions"
+              >
+                <div
+                  className="title--text"
+                >
+                  Facility Conditions
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 flVXpj"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Comfort Level"
+                    size="LARGETHIN"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                        size="LARGETHIN"
+                        title="89 %"
+                        value={89}
+                      >
+                        89
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
+                    size="LARGETHIN"
+                    title="Comfort Level"
+                  >
+                    Comfort Level
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <hr
+                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                  />
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Average Temperature"
+                    size="LARGETHIN"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                        size="LARGETHIN"
+                        title="76.7 ˚F"
+                        value={76.7}
+                      >
+                        76.7
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
+                    size="LARGETHIN"
+                    title="Average Temperature"
+                  >
+                    Average Temperature
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <hr
+                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                  />
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Utilization"
+                    size="LARGETHIN"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                        size="LARGETHIN"
+                        title="76 %"
+                        value={76}
+                      >
+                        76
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
+                    size="LARGETHIN"
+                    title="Utilization"
+                  >
+                    Utilization
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <hr
+                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                  />
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="CPU"
+                    size="LARGETHIN"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                        size="LARGETHIN"
+                        title="76 %"
+                        value={76}
+                      >
+                        76
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
+                    size="LARGETHIN"
+                    title="CPU"
+                  >
+                    CPU
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <hr
+                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                  />
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Humidity"
+                    size="LARGETHIN"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                        size="LARGETHIN"
+                        title="76 %"
+                        value={76}
+                      >
+                        76
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
+                    size="LARGETHIN"
+                    title="Humidity"
+                  >
+                    Humidity
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <hr
+                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                  />
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Air flow"
+                    size="LARGETHIN"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                        size="LARGETHIN"
+                        title="76 %"
+                        value={76}
+                      >
+                        76
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
+                    size="LARGETHIN"
+                    title="Air flow"
+                  >
+                    Air flow
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <hr
+                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+                  />
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="LARGETHIN"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                    label="Air quality"
+                    size="LARGETHIN"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                        size="LARGETHIN"
+                        title="76 %"
+                        value={76}
+                      >
+                        76
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
+                    size="LARGETHIN"
+                    title="Air quality"
+                  >
+                    Air quality
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard long titles and values 1`] = `
 <div
   style={
@@ -832,12 +1204,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
+                  size="SMALL"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                     label="Monthly summary"
-                    size="XSMALL"
+                    size="SMALL"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -845,7 +1217,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                        size="XSMALL"
+                        size="SMALL"
                         title="20000000000000000 "
                         value={20000000000000000}
                       >
@@ -855,7 +1227,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 gHjNPp"
-                    size="XSMALL"
+                    size="SMALL"
                     title="Monthly summary"
                   >
                     Monthly summary
@@ -970,12 +1342,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Monthly summary"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -983,7 +1355,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="100000000 Wh"
                         value={100000000}
                       >
@@ -993,7 +1365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Monthly summary"
                   >
                     Monthly summary
@@ -1001,7 +1373,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -1009,12 +1381,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Yearly summary"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1022,7 +1394,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="40000000000000 Wh"
                         value={40000000000000}
                       >
@@ -1032,7 +1404,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Yearly summary"
                   >
                     Yearly summary
@@ -1287,7 +1659,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / horizontal /  2 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / horizontal /  2 1`] = `
 <div
   style={
     Object {
@@ -1363,12 +1735,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1376,7 +1748,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="89 %"
                         value={89}
                       >
@@ -1386,7 +1758,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -1394,7 +1766,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -1402,12 +1774,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1415,7 +1787,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -1425,7 +1797,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -1464,7 +1836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / vertical /  2 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical /  2 1`] = `
 <div
   style={
     Object {
@@ -1540,12 +1912,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1553,7 +1925,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="89 %"
                         value={89}
                       >
@@ -1563,7 +1935,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -1571,7 +1943,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -1579,12 +1951,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1592,7 +1964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -1602,7 +1974,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -1641,7 +2013,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / vertical /  3 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical /  3 1`] = `
 <div
   style={
     Object {
@@ -1717,12 +2089,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1730,7 +2102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="89 %"
                         value={89}
                       >
@@ -1765,7 +2137,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -1773,7 +2145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -1781,12 +2153,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1794,7 +2166,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="null ˚F"
                         value={null}
                       >
@@ -1804,7 +2176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -1812,7 +2184,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -1820,12 +2192,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Humidity"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1833,7 +2205,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -1868,7 +2240,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Humidity"
                   >
                     Humidity
@@ -1907,7 +2279,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / vertical / multiple 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical / multiple 1`] = `
 <div
   style={
     Object {
@@ -1983,12 +2355,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -1996,7 +2368,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="89 %"
                         value={89}
                       >
@@ -2006,7 +2378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -2014,7 +2386,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2022,12 +2394,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2035,7 +2407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -2045,7 +2417,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -2053,7 +2425,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2061,12 +2433,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Utilization"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2074,7 +2446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="76 %"
                         value={76}
                       >
@@ -2084,7 +2456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Utilization"
                   >
                     Utilization
@@ -2123,7 +2495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / vertical / single 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-thin / vertical / single 1`] = `
 <div
   style={
     Object {
@@ -2199,12 +2571,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                  size="SMALL"
+                  size="MEDIUMTHIN"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 eexmWz"
                     label="Comfort Level"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
@@ -2212,7 +2584,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="SMALL"
+                        size="MEDIUMTHIN"
                         title="89 %"
                         value={89}
                       >
@@ -2222,7 +2594,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 cAyPcU"
-                    size="SMALL"
+                    size="MEDIUMTHIN"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -2261,379 +2633,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard tall / vertical /  6 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "250px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 izWJSI"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Facility Conditions"
-              >
-                <div
-                  className="title--text"
-                >
-                  Facility Conditions
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 flVXpj"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Comfort Level"
-                    size="TALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="TALL"
-                        title="89 %"
-                        value={89}
-                      >
-                        89
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
-                    size="TALL"
-                    title="Comfort Level"
-                  >
-                    Comfort Level
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Average Temperature"
-                    size="TALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="TALL"
-                        title="76.7 ˚F"
-                        value={76.7}
-                      >
-                        76.7
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
-                    size="TALL"
-                    title="Average Temperature"
-                  >
-                    Average Temperature
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Utilization"
-                    size="TALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="TALL"
-                        title="76 %"
-                        value={76}
-                      >
-                        76
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
-                    size="TALL"
-                    title="Utilization"
-                  >
-                    Utilization
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="CPU"
-                    size="TALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="TALL"
-                        title="76 %"
-                        value={76}
-                      >
-                        76
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
-                    size="TALL"
-                    title="CPU"
-                  >
-                    CPU
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Humidity"
-                    size="TALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="TALL"
-                        title="76 %"
-                        value={76}
-                      >
-                        76
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
-                    size="TALL"
-                    title="Humidity"
-                  >
-                    Humidity
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Air flow"
-                    size="TALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="TALL"
-                        title="76 %"
-                        value={76}
-                      >
-                        76
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
-                    size="TALL"
-                    title="Air flow"
-                  >
-                    Air flow
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <hr
-                    className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-                  />
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="TALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                    label="Air quality"
-                    size="TALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="TALL"
-                        title="76 %"
-                        value={76}
-                      >
-                        76
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
-                    size="TALL"
-                    title="Air quality"
-                  >
-                    Air quality
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard wide / horizontal /  3 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard medium-wide / horizontal /  3 1`] = `
 <div
   style={
     Object {
@@ -2709,12 +2709,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="WIDE"
+                  size="MEDIUMWIDE"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Comfort Level"
-                    size="WIDE"
+                    size="MEDIUMWIDE"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2722,7 +2722,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="WIDE"
+                        size="MEDIUMWIDE"
                         title="89 %"
                         value={89}
                       >
@@ -2732,7 +2732,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 jvOQzz"
-                    size="WIDE"
+                    size="MEDIUMWIDE"
                     title="Comfort Level"
                   >
                     Comfort Level
@@ -2740,7 +2740,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="WIDE"
+                  size="MEDIUMWIDE"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2748,12 +2748,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="WIDE"
+                  size="MEDIUMWIDE"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Average Temperature"
-                    size="WIDE"
+                    size="MEDIUMWIDE"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2761,7 +2761,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="WIDE"
+                        size="MEDIUMWIDE"
                         title="76.7 ˚F"
                         value={76.7}
                       >
@@ -2771,7 +2771,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 jvOQzz"
-                    size="WIDE"
+                    size="MEDIUMWIDE"
                     title="Average Temperature"
                   >
                     Average Temperature
@@ -2779,7 +2779,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="WIDE"
+                  size="MEDIUMWIDE"
                 >
                   <hr
                     className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
@@ -2787,12 +2787,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                 </div>
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="WIDE"
+                  size="MEDIUMWIDE"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
                     label="Utilization"
-                    size="WIDE"
+                    size="MEDIUMWIDE"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2800,7 +2800,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
-                        size="WIDE"
+                        size="MEDIUMWIDE"
                         title="76 %"
                         value={76}
                       >
@@ -2810,10 +2810,1784 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 krPcSU"
-                    size="WIDE"
+                    size="MEDIUMWIDE"
                     title="Utilization"
                   >
                     Utilization
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / basic 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Occupancy"
+              >
+                <div
+                  className="title--text"
+                >
+                  Occupancy
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="SMALL"
+                        title="88 %"
+                        value={88}
+                      >
+                        88
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / long 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Occupancy"
+              >
+                <div
+                  className="title--text"
+                >
+                  Occupancy
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                        size="SMALL"
+                        title="Really really busy %"
+                        value="Really really busy"
+                      >
+                        Really really busy
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / thresholds (number, custom renderIconByName) 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Alert Count"
+              >
+                <div
+                  className="title--text"
+                >
+                  Alert Count
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="SMALL"
+                        title="4 "
+                        value={4}
+                      >
+                        4
+                      </span>
+                    </div>
+                    <div
+                      className="Attribute__StyledIcon-dhraql-5 gssLPC"
+                    >
+                      <div
+                        className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
+                      >
+                        <svg
+                          description="< 5"
+                          fill="green"
+                          focusable="true"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          tabIndex="0"
+                          title="< 5"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                          />
+                          <title>
+                            &lt; 5
+                          </title>
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / thresholds (number, icon) 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Alert Count"
+              >
+                <div
+                  className="title--text"
+                >
+                  Alert Count
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="SMALL"
+                        title="4 "
+                        value={4}
+                      >
+                        4
+                      </span>
+                    </div>
+                    <div
+                      className="Attribute__StyledIcon-dhraql-5 gssLPC"
+                    >
+                      <div
+                        className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
+                      >
+                        <svg
+                          aria-label="< 5"
+                          className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
+                          fill="green"
+                          fillRule="evenodd"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            &lt; 5
+                          </title>
+                          <path
+                            d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / thresholds (number, no icon) 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Alert Count"
+              >
+                <div
+                  className="title--text"
+                >
+                  Alert Count
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
+                      color="red"
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="SMALL"
+                        title="35 "
+                        value={35}
+                      >
+                        35
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / title 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Foot Traffic"
+              >
+                <div
+                  className="title--text"
+                >
+                  Foot Traffic
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label="Average"
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                        size="SMALL"
+                        title="13572 "
+                        value={13572}
+                      >
+                        14K
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                    title="Average"
+                  >
+                    Average
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / trend down 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "150px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Foot Traffic"
+              >
+                <div
+                  className="title--text"
+                >
+                  Foot Traffic
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                        size="SMALL"
+                        title="13572 "
+                        value={13572}
+                      >
+                        14K
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / trend up 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "150px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Alert Count"
+              >
+                <div
+                  className="title--text"
+                >
+                  Alert Count
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                        size="SMALL"
+                        title="35 "
+                        value={35}
+                      >
+                        35
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard small / units 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "150px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Occupancy"
+              >
+                <div
+                  className="title--text"
+                >
+                  Occupancy
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                  size="SMALL"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALL"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                        size="SMALL"
+                        title="88 %"
+                        value={88}
+                      >
+                        88
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                    size="SMALL"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard smallwide / horizontal 2 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "300px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Status"
+              >
+                <div
+                  className="title--text"
+                >
+                  Status
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
+                  size="SMALLWIDE"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label="Status"
+                    size="SMALLWIDE"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                        size="SMALLWIDE"
+                        title="Problem "
+                        value="Problem"
+                      >
+                        Problem
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
+                    size="SMALLWIDE"
+                    title="Status"
+                  >
+                    Status
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
+                  size="SMALLWIDE"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label="Comfort level"
+                    size="SMALLWIDE"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                        size="SMALLWIDE"
+                        title="Healthy feels"
+                        value="Healthy"
+                      >
+                        Healthy
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
+                    size="SMALLWIDE"
+                    title="Comfort level"
+                  >
+                    Comfort level
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard smallwide / thresholds (string) 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Status"
+              >
+                <div
+                  className="title--text"
+                >
+                  Status
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
+                  size="SMALLWIDE"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label={null}
+                    size="SMALLWIDE"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                        size="SMALLWIDE"
+                        title="Unhealthy "
+                        value="Unhealthy"
+                      >
+                        Unhealthy
+                      </span>
+                    </div>
+                    <div
+                      className="Attribute__StyledIcon-dhraql-5 gssLPC"
+                    >
+                      <div
+                        className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
+                      >
+                        <svg
+                          aria-label="= Unhealthy"
+                          className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
+                          fill="red"
+                          fillRule="evenodd"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            = Unhealthy
+                          </title>
+                          <path
+                            d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
+                    size="SMALLWIDE"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        className="info__show-button"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#027ac5",
+            "border": "none",
+            "borderRadius": "0 0 0 5px",
+            "color": "#fff",
+            "cursor": "pointer",
+            "display": "block",
+            "fontFamily": "sans-serif",
+            "fontSize": "12px",
+            "padding": "5px 15px",
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        type="button"
+      >
+        Show Info
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard smallwide / vertical 2 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "bottom": "0",
+      "display": "flex",
+      "left": "0",
+      "overflow": "auto",
+      "position": "fixed",
+      "right": "0",
+      "top": "0",
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "margin": "auto",
+        "maxHeight": "100%",
+      }
+    }
+  >
+    <div
+      className="storybook-container"
+      style={
+        Object {
+          "padding": "3rem",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "position": "relative",
+            "zIndex": 0,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "margin": 20,
+              "width": "252px",
+            }
+          }
+        >
+          <div
+            className="Card__CardWrapper-v5r71h-0 bAafuV"
+            id="facilitycard"
+          >
+            <div
+              className="card--header"
+            >
+              <span
+                className="card--title"
+                title="Status"
+              >
+                <div
+                  className="title--text"
+                >
+                  Status
+                </div>
+              </span>
+              <div
+                className="card--toolbar"
+              />
+            </div>
+            <div
+              className="Card__CardContent-v5r71h-1 ggrDpu"
+            >
+              <div
+                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+              >
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
+                  size="SMALLWIDE"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label="Status"
+                    size="SMALLWIDE"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                        size="SMALLWIDE"
+                        title="Good "
+                        value="Good"
+                      >
+                        Good
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
+                    size="SMALLWIDE"
+                    title="Status"
+                  >
+                    Status
+                  </div>
+                </div>
+                <div
+                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
+                  size="SMALLWIDE"
+                >
+                  <div
+                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                    label="Comfort level"
+                    size="SMALLWIDE"
+                  >
+                    <div
+                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                      color={null}
+                    >
+                      <span
+                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                        size="SMALLWIDE"
+                        title="Healthy "
+                        value="Healthy"
+                      >
+                        Healthy
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
+                    size="SMALLWIDE"
+                    title="Comfort level"
+                  >
+                    Comfort level
                   </div>
                 </div>
               </div>
@@ -2925,12 +4699,12 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
               >
                 <div
                   className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
+                  size="SMALL"
                 >
                   <div
                     className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
                     label="Monthly summary"
-                    size="XSMALL"
+                    size="SMALL"
                   >
                     <div
                       className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
@@ -2938,7 +4712,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                     >
                       <span
                         className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                        size="XSMALL"
+                        size="SMALL"
                         title="false "
                         value={false}
                       >
@@ -2952,1784 +4726,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Value
                   </div>
                   <div
                     className="ValueCard__AttributeLabel-hyxf2q-4 gHjNPp"
-                    size="XSMALL"
+                    size="SMALL"
                     title="Monthly summary"
                   >
                     Monthly summary
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / basic 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Occupancy"
-              >
-                <div
-                  className="title--text"
-                >
-                  Occupancy
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                        size="XSMALL"
-                        title="88 %"
-                        value={88}
-                      >
-                        88
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / long 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Occupancy"
-              >
-                <div
-                  className="title--text"
-                >
-                  Occupancy
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                        size="XSMALL"
-                        title="Really really busy %"
-                        value="Really really busy"
-                      >
-                        Really really busy
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / thresholds (number, custom renderIconByName) 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Alert Count"
-              >
-                <div
-                  className="title--text"
-                >
-                  Alert Count
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                        size="XSMALL"
-                        title="4 "
-                        value={4}
-                      >
-                        4
-                      </span>
-                    </div>
-                    <div
-                      className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                    >
-                      <div
-                        className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                      >
-                        <svg
-                          description="< 5"
-                          fill="green"
-                          focusable="true"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          tabIndex="0"
-                          title="< 5"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
-                          />
-                          <title>
-                            &lt; 5
-                          </title>
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / thresholds (number, icon) 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Alert Count"
-              >
-                <div
-                  className="title--text"
-                >
-                  Alert Count
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                        size="XSMALL"
-                        title="4 "
-                        value={4}
-                      >
-                        4
-                      </span>
-                    </div>
-                    <div
-                      className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                    >
-                      <div
-                        className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                      >
-                        <svg
-                          aria-label="< 5"
-                          className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
-                          fill="green"
-                          fillRule="evenodd"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            &lt; 5
-                          </title>
-                          <path
-                            d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16zm3.293-11.332L6.75 9.21 4.707 7.168 3.293 8.582 6.75 12.04l5.957-5.957-1.414-1.414z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / thresholds (number, no icon) 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Alert Count"
-              >
-                <div
-                  className="title--text"
-                >
-                  Alert Count
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 bShNpT"
-                      color="red"
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                        size="XSMALL"
-                        title="35 "
-                        value={35}
-                      >
-                        35
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / title 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Foot Traffic"
-              >
-                <div
-                  className="title--text"
-                >
-                  Foot Traffic
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label="Average"
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                        size="XSMALL"
-                        title="13572 "
-                        value={13572}
-                      >
-                        14K
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                    title="Average"
-                  >
-                    Average
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / trend down 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "150px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Foot Traffic"
-              >
-                <div
-                  className="title--text"
-                >
-                  Foot Traffic
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                        size="XSMALL"
-                        title="13572 "
-                        value={13572}
-                      >
-                        14K
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / trend up 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "150px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Alert Count"
-              >
-                <div
-                  className="title--text"
-                >
-                  Alert Count
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
-                        size="XSMALL"
-                        title="35 "
-                        value={35}
-                      >
-                        35
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmall / units 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "150px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Occupancy"
-              >
-                <div
-                  className="title--text"
-                >
-                  Occupancy
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                  size="XSMALL"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALL"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                        size="XSMALL"
-                        title="88 %"
-                        value={88}
-                      >
-                        88
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                    size="XSMALL"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmallwide / horizontal 2 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "300px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Status"
-              >
-                <div
-                  className="title--text"
-                >
-                  Status
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                  size="XSMALLWIDE"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label="Status"
-                    size="XSMALLWIDE"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                        size="XSMALLWIDE"
-                        title="Problem "
-                        value="Problem"
-                      >
-                        Problem
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                    size="XSMALLWIDE"
-                    title="Status"
-                  >
-                    Status
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                  size="XSMALLWIDE"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label="Comfort level"
-                    size="XSMALLWIDE"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                        size="XSMALLWIDE"
-                        title="Healthy feels"
-                        value="Healthy"
-                      >
-                        Healthy
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                    size="XSMALLWIDE"
-                    title="Comfort level"
-                  >
-                    Comfort level
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmallwide / thresholds (string) 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Status"
-              >
-                <div
-                  className="title--text"
-                >
-                  Status
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
-                  size="XSMALLWIDE"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label={null}
-                    size="XSMALLWIDE"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                        size="XSMALLWIDE"
-                        title="Unhealthy "
-                        value="Unhealthy"
-                      >
-                        Unhealthy
-                      </span>
-                    </div>
-                    <div
-                      className="Attribute__StyledIcon-dhraql-5 gssLPC"
-                    >
-                      <div
-                        className="Attribute__ThresholdIconWrapper-dhraql-2 iEsJiF"
-                      >
-                        <svg
-                          aria-label="= Unhealthy"
-                          className="Attribute__ThresholdIcon-dhraql-3 elzdlt"
-                          fill="red"
-                          fillRule="evenodd"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            = Unhealthy
-                          </title>
-                          <path
-                            d="M8 6.586L5.879 4.464 4.464 5.88 6.586 8l-2.122 2.121 1.415 1.415L8 9.414l2.121 2.122 1.415-1.415L9.414 8l2.122-2.121-1.415-1.415L8 6.586zM8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                    size="XSMALLWIDE"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <button
-        className="info__show-button"
-        onClick={[Function]}
-        style={
-          Object {
-            "background": "#027ac5",
-            "border": "none",
-            "borderRadius": "0 0 0 5px",
-            "color": "#fff",
-            "cursor": "pointer",
-            "display": "block",
-            "fontFamily": "sans-serif",
-            "fontSize": "12px",
-            "padding": "5px 15px",
-            "position": "fixed",
-            "right": 0,
-            "top": 0,
-          }
-        }
-        type="button"
-      >
-        Show Info
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|ValueCard xsmallwide / vertical 2 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "bottom": "0",
-      "display": "flex",
-      "left": "0",
-      "overflow": "auto",
-      "position": "fixed",
-      "right": "0",
-      "top": "0",
-    }
-  }
->
-  <div
-    style={
-      Object {
-        "margin": "auto",
-        "maxHeight": "100%",
-      }
-    }
-  >
-    <div
-      className="storybook-container"
-      style={
-        Object {
-          "padding": "3rem",
-        }
-      }
-    >
-      <div
-        style={
-          Object {
-            "position": "relative",
-            "zIndex": 0,
-          }
-        }
-      >
-        <div
-          style={
-            Object {
-              "margin": 20,
-              "width": "252px",
-            }
-          }
-        >
-          <div
-            className="Card__CardWrapper-v5r71h-0 bAafuV"
-            id="facilitycard"
-          >
-            <div
-              className="card--header"
-            >
-              <span
-                className="card--title"
-                title="Status"
-              >
-                <div
-                  className="title--text"
-                >
-                  Status
-                </div>
-              </span>
-              <div
-                className="card--toolbar"
-              />
-            </div>
-            <div
-              className="Card__CardContent-v5r71h-1 ggrDpu"
-            >
-              <div
-                className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-              >
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                  size="XSMALLWIDE"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label="Status"
-                    size="XSMALLWIDE"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                        size="XSMALLWIDE"
-                        title="Good "
-                        value="Good"
-                      >
-                        Good
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                    size="XSMALLWIDE"
-                    title="Status"
-                  >
-                    Status
-                  </div>
-                </div>
-                <div
-                  className="ValueCard__AttributeWrapper-hyxf2q-1 plcOs"
-                  size="XSMALLWIDE"
-                >
-                  <div
-                    className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                    label="Comfort level"
-                    size="XSMALLWIDE"
-                  >
-                    <div
-                      className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                      color={null}
-                    >
-                      <span
-                        className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
-                        size="XSMALLWIDE"
-                        title="Healthy "
-                        value="Healthy"
-                      >
-                        Healthy
-                      </span>
-                    </div>
-                  </div>
-                  <div
-                    className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
-                    size="XSMALLWIDE"
-                    title="Comfort level"
-                  >
-                    Comfort level
                   </div>
                 </div>
               </div>

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -99,7 +99,7 @@ export const GUTTER = 16;
 export const CARD_DIMENSIONS = {
   SMALL: {
     max: { w: 2, h: 1 },
-    xl: { w: 4, h: 1 },
+    xl: { w: 2, h: 1 },
     lg: { w: 4, h: 1 },
     md: { w: 4, h: 1 },
     sm: { w: 2, h: 1 },
@@ -115,7 +115,7 @@ export const CARD_DIMENSIONS = {
   },
   MEDIUMTHIN: {
     max: { w: 2, h: 2 },
-    xl: { w: 4, h: 2 },
+    xl: { w: 2, h: 2 },
     lg: { w: 4, h: 2 },
     md: { w: 2, h: 2 },
     sm: { w: 2, h: 2 },

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -10,17 +10,20 @@ export const COLORS = {
 
 export const DISABLED_COLORS = ['#e0e0e0', '#cacaca', '#a8a8a8', '#8d8d8d', '#6f6f6f'];
 
-export const DEPRECATED_SIZES = ['XSMALL', 'XSMALLWIDE', 'WIDE', 'TALL', 'XLARGE'];
-
-export const OLD_CARD_SIZES = {
+export const LEGACY_CARD_SIZES = {
   XSMALL: 'XSMALL',
   XSMALLWIDE: 'XSMALLWIDE',
-  SMALL: 'SMALL',
   TALL: 'TALL',
-  MEDIUM: 'MEDIUM',
   WIDE: 'WIDE',
-  LARGE: 'LARGE',
   XLARGE: 'XLARGE',
+  SMALL: 'SMALL',
+  SMALLWIDE: 'SMALLWIDE',
+  MEDIUMTHIN: 'MEDIUMTHIN',
+  MEDIUM: 'MEDIUM',
+  MEDIUMWIDE: 'MEDIUMWIDE',
+  LARGETHIN: 'LARGETHIN',
+  LARGE: 'LARGE',
+  LARGEWIDE: 'LARGEWIDE',
 };
 
 export const CARD_SIZES = {

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -10,7 +10,9 @@ export const COLORS = {
 
 export const DISABLED_COLORS = ['#e0e0e0', '#cacaca', '#a8a8a8', '#8d8d8d', '#6f6f6f'];
 
-export const CARD_SIZES = {
+export const DEPRECATED_SIZES = ['XSMALL', 'XSMALLWIDE', 'WIDE', 'TALL', 'XLARGE'];
+
+export const OLD_CARD_SIZES = {
   XSMALL: 'XSMALL',
   XSMALLWIDE: 'XSMALLWIDE',
   SMALL: 'SMALL',
@@ -19,6 +21,17 @@ export const CARD_SIZES = {
   WIDE: 'WIDE',
   LARGE: 'LARGE',
   XLARGE: 'XLARGE',
+};
+
+export const CARD_SIZES = {
+  SMALL: 'SMALL',
+  SMALLWIDE: 'SMALLWIDE',
+  MEDIUMTHIN: 'MEDIUMTHIN',
+  MEDIUM: 'MEDIUM',
+  MEDIUMWIDE: 'MEDIUMWIDE',
+  LARGETHIN: 'LARGETHIN',
+  LARGE: 'LARGE',
+  LARGEWIDE: 'LARGEWIDE',
 };
 
 export const CARD_TYPES = {
@@ -88,37 +101,29 @@ export const GUTTER = 16;
  */
 
 export const CARD_DIMENSIONS = {
-  XSMALL: {
+  SMALL: {
     max: { w: 2, h: 1 },
-    xl: { w: 2, h: 1 },
+    xl: { w: 4, h: 1 },
     lg: { w: 4, h: 1 },
-    md: { w: 2, h: 1 },
+    md: { w: 4, h: 1 },
     sm: { w: 2, h: 1 },
     xs: { w: 4, h: 1 },
   },
-  XSMALLWIDE: {
+  SMALLWIDE: {
     max: { w: 4, h: 1 },
     xl: { w: 4, h: 1 },
     lg: { w: 4, h: 1 },
     md: { w: 4, h: 1 },
-    sm: { w: 4, h: 1 },
+    sm: { w: 4, h: 2 },
     xs: { w: 4, h: 1 },
   },
-  SMALL: {
+  MEDIUMTHIN: {
     max: { w: 2, h: 2 },
-    xl: { w: 2, h: 2 },
+    xl: { w: 4, h: 2 },
     lg: { w: 4, h: 2 },
     md: { w: 2, h: 2 },
     sm: { w: 2, h: 2 },
     xs: { w: 4, h: 2 },
-  },
-  TALL: {
-    max: { w: 4, h: 4 },
-    xl: { w: 4, h: 4 },
-    lg: { w: 4, h: 4 },
-    md: { w: 4, h: 4 },
-    sm: { w: 4, h: 4 },
-    xs: { w: 4, h: 4 },
   },
   MEDIUM: {
     max: { w: 4, h: 2 },
@@ -128,13 +133,21 @@ export const CARD_DIMENSIONS = {
     sm: { w: 4, h: 2 },
     xs: { w: 4, h: 2 },
   },
-  WIDE: {
+  MEDIUMWIDE: {
     max: { w: 8, h: 2 },
     xl: { w: 8, h: 2 },
     lg: { w: 8, h: 2 },
     md: { w: 8, h: 2 },
     sm: { w: 4, h: 2 },
     xs: { w: 4, h: 2 },
+  },
+  LARGETHIN: {
+    max: { w: 4, h: 4 },
+    xl: { w: 4, h: 4 },
+    lg: { w: 4, h: 4 },
+    md: { w: 4, h: 4 },
+    sm: { w: 4, h: 4 },
+    xs: { w: 4, h: 4 },
   },
   LARGE: {
     max: { w: 8, h: 4 },
@@ -144,7 +157,7 @@ export const CARD_DIMENSIONS = {
     sm: { w: 4, h: 4 },
     xs: { w: 4, h: 4 },
   },
-  XLARGE: {
+  LARGEWIDE: {
     max: { w: 16, h: 4 },
     xl: { w: 16, h: 4 },
     lg: { w: 16, h: 4 },

--- a/src/constants/LayoutConstants.js
+++ b/src/constants/LayoutConstants.js
@@ -10,12 +10,7 @@ export const COLORS = {
 
 export const DISABLED_COLORS = ['#e0e0e0', '#cacaca', '#a8a8a8', '#8d8d8d', '#6f6f6f'];
 
-export const LEGACY_CARD_SIZES = {
-  XSMALL: 'XSMALL',
-  XSMALLWIDE: 'XSMALLWIDE',
-  TALL: 'TALL',
-  WIDE: 'WIDE',
-  XLARGE: 'XLARGE',
+export const CARD_SIZES = {
   SMALL: 'SMALL',
   SMALLWIDE: 'SMALLWIDE',
   MEDIUMTHIN: 'MEDIUMTHIN',
@@ -26,15 +21,13 @@ export const LEGACY_CARD_SIZES = {
   LARGEWIDE: 'LARGEWIDE',
 };
 
-export const CARD_SIZES = {
-  SMALL: 'SMALL',
-  SMALLWIDE: 'SMALLWIDE',
-  MEDIUMTHIN: 'MEDIUMTHIN',
-  MEDIUM: 'MEDIUM',
-  MEDIUMWIDE: 'MEDIUMWIDE',
-  LARGETHIN: 'LARGETHIN',
-  LARGE: 'LARGE',
-  LARGEWIDE: 'LARGEWIDE',
+export const LEGACY_CARD_SIZES = {
+  XSMALL: 'XSMALL',
+  XSMALLWIDE: 'XSMALLWIDE',
+  TALL: 'TALL',
+  WIDE: 'WIDE',
+  XLARGE: 'XLARGE',
+  ...CARD_SIZES,
 };
 
 export const CARD_TYPES = {

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -2,7 +2,12 @@ import PropTypes from 'prop-types';
 
 import { bundledIconNames } from '../utils/bundledIcons';
 
-import { CARD_SIZES, CARD_LAYOUTS, DASHBOARD_SIZES, TIME_SERIES_TYPES } from './LayoutConstants';
+import {
+  CARD_LAYOUTS,
+  DASHBOARD_SIZES,
+  TIME_SERIES_TYPES,
+  LEGACY_CARD_SIZES,
+} from './LayoutConstants';
 
 export const AttributePropTypes = PropTypes.shape({
   label: PropTypes.string, // optional for little cards
@@ -271,7 +276,7 @@ export const CardPropTypes = {
   isExpanded: PropTypes.bool,
   /** should hide the header */
   hideHeader: PropTypes.bool,
-  size: PropTypes.oneOf(Object.values(CARD_SIZES)),
+  size: PropTypes.oneOf(Object.values(LEGACY_CARD_SIZES)),
   layout: PropTypes.oneOf(Object.values(CARD_LAYOUTS)),
   breakpoint: PropTypes.oneOf(Object.values(DASHBOARD_SIZES)),
   /** Optional range to pass at the card level */

--- a/src/utils/__tests__/cardUtilityFunctions.test.js
+++ b/src/utils/__tests__/cardUtilityFunctions.test.js
@@ -1,4 +1,4 @@
-import { determineCardRange, compareGrains } from '../cardUtilityFunctions';
+import { determineCardRange, compareGrains, getUpdatedCardSize } from '../cardUtilityFunctions';
 
 describe('cardUtilityFunctions', () => {
   test('determineCardRange', () => {
@@ -9,5 +9,13 @@ describe('cardUtilityFunctions', () => {
     expect(compareGrains('day', 'day')).toEqual(0);
     expect(compareGrains('hour', 'day')).toEqual(-1);
     expect(compareGrains('week', 'day')).toEqual(1);
+  });
+  test('GetUpdatedCardSize', () => {
+    expect(getUpdatedCardSize('XSMALL')).toEqual('SMALL');
+    expect(getUpdatedCardSize('XSMALLWIDE')).toEqual('SMALLWIDE');
+    expect(getUpdatedCardSize('WIDE')).toEqual('MEDIUMWIDE');
+    expect(getUpdatedCardSize('TALL')).toEqual('LARGETHIN');
+    expect(getUpdatedCardSize('XLARGE')).toEqual('LARGEWIDE');
+    expect(getUpdatedCardSize('MEDIUM')).toEqual('MEDIUM');
   });
 });

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -72,22 +72,22 @@ export const compareGrains = (grain1, grain2) => {
 export const determineMaxValueCardAttributeCount = (size, currentAttributeCount) => {
   let attributeCount = currentAttributeCount;
   switch (size) {
-    case CARD_SIZES.XSMALL:
+    case CARD_SIZES.SMALL:
       attributeCount = 1;
       break;
-    case CARD_SIZES.XSMALLWIDE:
+    case CARD_SIZES.SMALLWIDE:
       attributeCount = 2;
       break;
     case CARD_SIZES.MEDIUM:
-    case CARD_SIZES.SMALL:
-    case CARD_SIZES.WIDE:
+    case CARD_SIZES.MEDIUMTHIN:
+    case CARD_SIZES.MEDIUMWIDE:
       attributeCount = 3;
       break;
     case CARD_SIZES.LARGE:
       attributeCount = 5;
       break;
-    case CARD_SIZES.TALL:
-    case CARD_SIZES.XLARGE:
+    case CARD_SIZES.LARGETHIN:
+    case CARD_SIZES.LARGEWIDE:
       attributeCount = 7;
       break;
     default:

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -112,10 +112,12 @@ export const getUpdatedCardSize = oldSize => {
       : null;
   let newSize = oldSize;
   if (changedSize) {
-    warning(
-      false,
-      `You have set your card to a ${oldSize} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
-    );
+    if (__DEV__) {
+      warning(
+        false,
+        `You have set your card to a ${oldSize} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
+      );
+    }
     newSize = changedSize;
   }
   return newSize;

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -80,8 +80,8 @@ export const determineMaxValueCardAttributeCount = (size, currentAttributeCount)
     case CARD_SIZES.SMALLWIDE:
       attributeCount = 2;
       break;
-    case CARD_SIZES.MEDIUM:
     case CARD_SIZES.MEDIUMTHIN:
+    case CARD_SIZES.MEDIUM:
     case CARD_SIZES.MEDIUMWIDE:
       attributeCount = 3;
       break;

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -1,3 +1,5 @@
+import warning from 'warning';
+
 import { CARD_SIZES } from '../constants/LayoutConstants';
 
 /**
@@ -93,4 +95,28 @@ export const determineMaxValueCardAttributeCount = (size, currentAttributeCount)
     default:
   }
   return attributeCount;
+};
+
+export const getUpdatedCardSize = oldSize => {
+  const changedSize =
+    oldSize === 'XSMALL'
+      ? 'SMALL'
+      : oldSize === 'XSMALLWIDE'
+      ? 'SMALLWIDE'
+      : oldSize === 'WIDE'
+      ? 'MEDIUMWIDE'
+      : oldSize === 'TALL'
+      ? 'LARGETHIN'
+      : oldSize === 'XLARGE'
+      ? 'LARGEWIDE'
+      : null;
+  let newSize = oldSize;
+  if (changedSize) {
+    warning(
+      false,
+      `You have set your card to a ${oldSize} size. This size name is deprecated. The card will be displayed as a ${changedSize} size.`
+    );
+    newSize = changedSize;
+  }
+  return newSize;
 };


### PR DESCRIPTION
Closes #

**Summary**

This PR addresses this issue:
https://github.ibm.com/wiotp/monitoring-dashboard/issues/774

The card sizes and size names have been updated to reflect the latest design/implementation.

**Change List (commits, features, bugs, etc)**

-Updated the constants CARD_SIZES, CARD_DIMENSIONS, and DASHBOARD_BREAKPOINTS.
-Updated each use of these constants throughout the repo to reflect the changes.
-Added a getUpdatedCardSize utility function to warn the user of deprecated size names and change their specified card size to the one that most closely matches it in the new set.

**Acceptance Test (how to verify the PR)**

View any card in the story and see the names/sizes are updated.
