### PR TITLE
Breadcrumb knobs

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useReducer, Children } from 'react';
+import React, { useState, useEffect, useRef, Children } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';

--- a/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, Children } from 'react';
+import React, { useState, useEffect, useRef, useReducer, Children } from 'react';
 import useResizeObserver from 'use-resize-observer';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -51,7 +51,18 @@ const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
   });
   const [overflowItems, setOverflowItems] = useState([]);
   const [afterOverflowItems, setAfterOverflowItems] = useState(childrenItems.slice(1));
+  const [prevChildren, setPrevChildren] = useState([]);
 
+  useEffect(
+    () => {
+      if (hasOverflow) {
+        setOverflowItems([]);
+        setAfterOverflowItems(childrenItems.slice(1));
+        setPrevChildren(children);
+      }
+    }, // eslint-disable-next-line react-hooks/exhaustive-deps
+    [children]
+  );
   /** update breadcrumbs  */
   useEffect(
     () => {
@@ -79,7 +90,7 @@ const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
         }
       }
     }, // eslint-disable-next-line react-hooks/exhaustive-deps
-    [breadcrumbRef.current?.clientWidth, breadcrumbRef.current?.scrollWidth]
+    [breadcrumbRef.current?.clientWidth, breadcrumbRef.current?.scrollWidth, prevChildren]
   );
 
   return (

--- a/src/components/Breadcrumb/Breadcrumb.story.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.story.jsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { withKnobs, boolean, text } from '@storybook/addon-knobs';
 import { BreadcrumbSkeleton, BreadcrumbItem } from 'carbon-components-react';
 
 import Breadcrumb from './Breadcrumb';
@@ -41,7 +41,7 @@ storiesOf('Watson IoT | Breadcrumb', module)
         <Breadcrumb {...props()}>
           <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
           <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
-          <BreadcrumbItem href="#">Breadcrumb 3</BreadcrumbItem>
+          <BreadcrumbItem href="#">{text('Breadcrumb 3 text', 'Breadcrumb 3')}</BreadcrumbItem>
         </Breadcrumb>
       );
     },
@@ -106,11 +106,15 @@ storiesOf('Watson IoT | Breadcrumb', module)
               <BreadcrumbItem href="#" title="3 A really long page name">
                 3 A really long page name
               </BreadcrumbItem>
-              <BreadcrumbItem href="#" title="4 Another page">
-                4 Another page
+              <BreadcrumbItem href="#" title={text('Breadcrumb 4 text', '4 Another page')}>
+                {text('Breadcrumb 4 text', '4 Another page')}
               </BreadcrumbItem>
-              <BreadcrumbItem href="#" isCurrentPage title="5th level page">
-                5th level page
+              <BreadcrumbItem
+                href="#"
+                isCurrentPage
+                title={text('Breadcrumb 5 text', '5 page name')}
+              >
+                {text('Breadcrumb 5 text', '5 page name')}
               </BreadcrumbItem>
             </Breadcrumb>
           </div>

--- a/src/components/Breadcrumb/Breadcrumb.story.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.story.jsx
@@ -112,9 +112,9 @@ storiesOf('Watson IoT | Breadcrumb', module)
               <BreadcrumbItem
                 href="#"
                 isCurrentPage
-                title={text('Breadcrumb 5 text', '5 page name')}
+                title={text('Breadcrumb 5 text', '5th level page')}
               >
-                {text('Breadcrumb 5 text', '5 page name')}
+                {text('Breadcrumb 5 text', '5th level page')}
               </BreadcrumbItem>
             </Breadcrumb>
           </div>


### PR DESCRIPTION
Closes #924

**Summary**

This allows for children to update component. 

**Change List (commits, features, bugs, etc)**

- change breadcrumb to update when Children prop changes
- changed stories to have knobs to change text. 

**Acceptance Test (how to verify the PR)**

checkout story for resize and change knobs. Text should update. 
