### PR TITLE
fix(cardrenderer): custom cards should not pass content to div

### DIFF
--- a/src/components/Dashboard/CardRenderer.jsx
+++ b/src/components/Dashboard/CardRenderer.jsx
@@ -193,7 +193,7 @@ const CardRenderer = React.memo(
     ) : type === CARD_TYPES.GAUGE ? (
       <GaugeCard {...commonCardProps} />
     ) : type === CARD_TYPES.CUSTOM ? (
-      <Card hideHeader={isNil(card.title)} {...commonCardProps}>
+      <Card hideHeader={isNil(card.title)} {...omit(commonCardProps, 'content')}>
         {card.content}
       </Card>
     ) : null;

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -383,17 +383,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
-                    content={
-                      <h2
-                        style={
-                          Object {
-                            "padding": "1rem",
-                          }
-                        }
-                      >
-                        Section Header
-                      </h2>
-                    }
                     id="section-card"
                     style={
                       Object {
@@ -2485,17 +2474,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
-                    content={
-                      <h2
-                        style={
-                          Object {
-                            "padding": "1rem",
-                          }
-                        }
-                      >
-                        Section Header
-                      </h2>
-                    }
                     id="section-card"
                     style={
                       Object {
@@ -4619,17 +4597,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
-                    content={
-                      <h2
-                        style={
-                          Object {
-                            "padding": "1rem",
-                          }
-                        }
-                      >
-                        Section Header
-                      </h2>
-                    }
                     id="section-card"
                     style={
                       Object {
@@ -9275,17 +9242,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
-                    content={
-                      <h2
-                        style={
-                          Object {
-                            "padding": "1rem",
-                          }
-                        }
-                      >
-                        Section Header
-                      </h2>
-                    }
                     id="section-card"
                     style={
                       Object {
@@ -21720,17 +21676,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   </div>
                   <div
                     className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
-                    content={
-                      <h2
-                        style={
-                          Object {
-                            "padding": "1rem",
-                          }
-                        }
-                      >
-                        Section Header
-                      </h2>
-                    }
                     id="section-card"
                     style={
                       Object {
@@ -23518,58 +23463,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                   >
                     <div
                       className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bHPJyP"
-                      content={
-                        <ClickableTile
-                          clicked={false}
-                          handleClick={[Function]}
-                          handleKeyDown={[Function]}
-                          href="https://internetofthings.ibmcloud.com"
-                          light={false}
-                          style={
-                            Object {
-                              "height": "100%",
-                              "padding": "0 0 0 0",
-                            }
-                          }
-                        >
-                          <div
-                            style={
-                              Object {
-                                "padding": "12px",
-                              }
-                            }
-                          >
-                            <h4>
-                              View Dashboards
-                            </h4>
-                            <br />
-                            <p>
-                              View pinned dashboards to keep track of your world in IoT.
-                            </p>
-                            <div
-                              style={
-                                Object {
-                                  "bottom": "0",
-                                  "padding": "0 36px 16px 0",
-                                  "position": "absolute",
-                                  "textAlign": "right",
-                                  "width": "100%",
-                                }
-                              }
-                            >
-                              <img
-                                alt="View Dashboards"
-                                src="dashboard.svg"
-                                style={
-                                  Object {
-                                    "width": "50%",
-                                  }
-                                }
-                              />
-                            </div>
-                          </div>
-                        </ClickableTile>
-                      }
                       id="viewDashboards"
                       style={
                         Object {
@@ -23641,58 +23534,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     </div>
                     <div
                       className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bHPJyP"
-                      content={
-                        <ClickableTile
-                          clicked={false}
-                          handleClick={[Function]}
-                          handleKeyDown={[Function]}
-                          href="https://internetofthings.ibmcloud.com"
-                          light={false}
-                          style={
-                            Object {
-                              "height": "100%",
-                              "padding": "0 0 0 0",
-                            }
-                          }
-                        >
-                          <div
-                            style={
-                              Object {
-                                "padding": "12px",
-                              }
-                            }
-                          >
-                            <h4>
-                              Connect Devices
-                            </h4>
-                            <br />
-                            <p>
-                              Connect devices and collect data by using the Watson IoT Platform Service.
-                            </p>
-                            <div
-                              style={
-                                Object {
-                                  "bottom": "0",
-                                  "padding": "0 36px 16px 0",
-                                  "position": "absolute",
-                                  "textAlign": "right",
-                                  "width": "100%",
-                                }
-                              }
-                            >
-                              <img
-                                alt="Connect Devices"
-                                src="computer-chip.svg"
-                                style={
-                                  Object {
-                                    "width": "50%",
-                                  }
-                                }
-                              />
-                            </div>
-                          </div>
-                        </ClickableTile>
-                      }
                       id="connectDevices"
                       style={
                         Object {
@@ -23764,44 +23605,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     </div>
                     <div
                       className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bHPJyP"
-                      content={
-                        <div
-                          style={
-                            Object {
-                              "padding": "12px",
-                            }
-                          }
-                        >
-                          <h4>
-                            Monitor Entities
-                          </h4>
-                          <br />
-                          <p>
-                            Expore your entities and analyze their associated data.
-                          </p>
-                          <div
-                            style={
-                              Object {
-                                "bottom": "0",
-                                "padding": "0 36px 16px 0",
-                                "position": "absolute",
-                                "textAlign": "right",
-                                "width": "100%",
-                              }
-                            }
-                          >
-                            <img
-                              alt="Monitor Entities"
-                              src="data-scientist-illustration.svg"
-                              style={
-                                Object {
-                                  "width": "50%",
-                                }
-                              }
-                            />
-                          </div>
-                        </div>
-                      }
                       id="monitorEntities"
                       style={
                         Object {
@@ -23860,35 +23663,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     </div>
                     <div
                       className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
-                      content={
-                        <div
-                          style={
-                            Object {
-                              "padding": "12px",
-                            }
-                          }
-                        >
-                          <h4>
-                            Track Usage
-                          </h4>
-                          <br />
-                          <div
-                            style={
-                              Object {
-                                "bottom": "0",
-                                "padding": "0 36px 16px 0",
-                                "position": "absolute",
-                                "textAlign": "right",
-                                "width": "100%",
-                              }
-                            }
-                          >
-                            <ForwardRef(Application32)
-                              aria-label="Track Usage"
-                            />
-                          </div>
-                        </div>
-                      }
                       id="trackUsage"
                       style={
                         Object {
@@ -23954,35 +23728,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT|Dashb
                     </div>
                     <div
                       className="react-grid-item cssTransforms Card__CardWrapper-v5r71h-0 bAafuV"
-                      content={
-                        <div
-                          style={
-                            Object {
-                              "padding": "12px",
-                            }
-                          }
-                        >
-                          <h4>
-                            Administer Users
-                          </h4>
-                          <br />
-                          <div
-                            style={
-                              Object {
-                                "bottom": "0",
-                                "padding": "0 36px 16px 0",
-                                "position": "absolute",
-                                "textAlign": "right",
-                                "width": "100%",
-                              }
-                            }
-                          >
-                            <ForwardRef(Group32)
-                              aria-label="Track Usage"
-                            />
-                          </div>
-                        </div>
-                      }
                       id="administerUsers"
                       style={
                         Object {


### PR DESCRIPTION
Closes #

**Summary**

- Small fix where for custom card types, the content prop was being passed downstream to the div that was being rendered and it was throwing an exception to the javascript console.

**Acceptance Test (how to verify the PR)**

- Verify in the Dashboard stories with Custom cards, no exceptions logged to the javascript console.
