### PR TITLE
fix(timeseries): set the right amout of chart labels

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -9,6 +9,7 @@ import filter from 'lodash/filter';
 import memoize from 'lodash/memoize';
 import capitalize from 'lodash/capitalize';
 import useDeepCompareEffect from 'use-deep-compare-effect';
+import uniqBy from 'lodash/uniqBy';
 
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
@@ -96,7 +97,7 @@ export const determinePrecision = (size, value, defaultPrecision) => {
  */
 export const formatChartData = (timeDataSourceId = 'timestamp', series, values) => {
   return {
-    labels: series.map(({ label }) => label),
+    labels: uniqBy(values, timeDataSourceId).map(val => val[timeDataSourceId]),
     datasets: series.map(({ dataSourceId, dataFilter = {}, label, color }) => ({
       label,
       ...(color ? { fillColors: [color] } : {}),

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -9,7 +9,6 @@ import filter from 'lodash/filter';
 import memoize from 'lodash/memoize';
 import capitalize from 'lodash/capitalize';
 import useDeepCompareEffect from 'use-deep-compare-effect';
-import uniqBy from 'lodash/uniqBy';
 
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 import { TimeSeriesCardPropTypes, CardPropTypes } from '../../constants/PropTypes';
@@ -97,7 +96,7 @@ export const determinePrecision = (size, value, defaultPrecision) => {
  */
 export const formatChartData = (timeDataSourceId = 'timestamp', series, values) => {
   return {
-    labels: uniqBy(values, timeDataSourceId).map(val => val[timeDataSourceId]),
+    labels: [...new Set(values.map(val => val[timeDataSourceId]))],
     datasets: series.map(({ dataSourceId, dataFilter = {}, label, color }) => ({
       label,
       ...(color ? { fillColors: [color] } : {}),


### PR DESCRIPTION
Closes #984 

**Summary**

It's very likely related to a bug on carbon-charts I just reported: https://github.com/carbon-design-system/carbon-charts/issues/521

**Acceptance Test (how to verify the PR)**

- ?path=/story/watson-iot-dashboard--full-screen-bar-chart-card should render correctly
