### PR TITLE
fix(charts): legend labels should render correctly on RTL

### DIFF
--- a/src/globals/_charts.scss
+++ b/src/globals/_charts.scss
@@ -1,6 +1,9 @@
 @import '~@carbon/charts/styles.css';
 
 html[dir='rtl'] .chart-holder {
+  .legend-item {
+    direction: ltr;
+  }
   .axis {
     direction: ltr;
     .axis-title {


### PR DESCRIPTION
Closes #986 

**Summary**

- added some css specific to the legend items

**Acceptance Test (how to verify the PR)**

- check any chart with a legend (ie. ?path=/story/watson-iot-timeseriescard--largewide-multi-line-no-x-y-label) and switch to RTL: nothing should change
