### PR TITLE
fix(tablecard): render data function now working

### DIFF
--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -137,4 +137,58 @@ describe('TableCard', () => {
     const totalColumns = tableColumns.filter(item => item.priority === 1 || item.priority === 2);
     expect(wrapper.find('TableHeader').length).toBe(totalColumns.length + 1); // +1 for action column
   });
+  test('Columns should use custom render fuction when present', () => {
+    const mockRenderFunc = jest.fn(() => {
+      return <p className="myCustomRenderedCell" />;
+    });
+    const columnWithRenderFunction = [
+      {
+        dataSourceId: 'alert',
+        label: 'Alert',
+        priority: 1,
+        renderDataFunction: mockRenderFunc,
+      },
+    ];
+    const wrapper = mount(
+      <TableCard
+        title="Open Alerts"
+        content={{
+          columns: columnWithRenderFunction,
+        }}
+        values={[tableData[0]]}
+        size={CARD_SIZES.LARGE}
+      />
+    );
+    expect(wrapper.find('TableCell .myCustomRenderedCell').length).toBe(1);
+    expect(mockRenderFunc).toHaveBeenCalledWith({
+      columnId: 'alert',
+      row: {
+        alert: 'AHI005 Asset failure',
+        count: 1.2039201932,
+        hour: 1563877570000,
+        long_description: 'long description for a given event payload',
+      },
+      rowId: 'row-1',
+      value: 'AHI005 Asset failure',
+    });
+
+    const columnNormal = [
+      {
+        dataSourceId: 'alert',
+        label: 'Alert 2',
+        priority: 1,
+      },
+    ];
+    const wrapper2 = mount(
+      <TableCard
+        title="Open Alerts"
+        content={{
+          columns: columnNormal,
+        }}
+        values={[tableData[0]]}
+        size={CARD_SIZES.LARGE}
+      />
+    );
+    expect(wrapper2.find('TableCell .myCustomRenderedCell').length).toBe(0);
+  });
 });

--- a/src/constants/PropTypes.js
+++ b/src/constants/PropTypes.js
@@ -116,7 +116,8 @@ export const TableCardPropTypes = {
         width: PropTypes.number,
         label: PropTypes.string.isRequired,
         priority: PropTypes.number,
-        renderer: PropTypes.func,
+        /** See the renderDataFunction for TablePropTypes */
+        renderDataFunction: PropTypes.func,
         type: PropTypes.string,
       })
     ).isRequired,

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9258,7 +9258,7 @@ Map {
                       "priority": Object {
                         "type": "number",
                       },
-                      "renderer": Object {
+                      "renderDataFunction": Object {
                         "type": "func",
                       },
                       "type": Object {


### PR DESCRIPTION
Closes #766

**Summary**
The objects in the column array can now contain a render-function called renderDataFunction.

**Change List (commits, features, bugs, etc)**
Prop was incorrectly called `renderer` but should have been `renderDataFunction` to work with the underlying Table component. Renamed prop and added unit test.


**Acceptance Test (how to verify the PR)**
Add a renderDataFunction function to a TableColumnsProp in content.columns[colItem] the same way you would do for a table.
