### PR TITLE
fix(breadcrumb): disable hasOverflow functionality when ResizeObserver not supported

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.jsx
@@ -7,6 +7,7 @@ import { Breadcrumb as CarbonBreadcrumb } from 'carbon-components-react';
 import warning from 'warning';
 
 import { OverflowMenuItem, OverflowMenu } from '../../index';
+import { browserSupports } from '../../utils/componentUtilityFunctions';
 
 const propTypes = {
   /**
@@ -52,6 +53,7 @@ const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
   const [afterOverflowItems, setAfterOverflowItems] = useState(childrenItems.slice(1));
   const [prevChildren, setPrevChildren] = useState([]);
 
+  const browserSupportsResizeObserver = browserSupports('ResizeObserver');
   useResizeObserver({
     useDefaults: false,
     ref: breadcrumbRef,
@@ -59,7 +61,7 @@ const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
 
   if (__DEV__) {
     warning(
-      typeof ResizeObserver !== 'undefined' && hasOverflow,
+      browserSupportsResizeObserver && hasOverflow,
       'You have set hasOverflow to true, but the current browser does not support ResizeObserver. You will need to include a ResizeObserver polyfill for hasOverflow to function properly.'
     );
   }
@@ -109,7 +111,7 @@ const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
       className={classnames('breadcrumb--container', {
         'breadcrumb--container__overflowfull': afterOverflowItems.length === 1,
       })}
-      ref={typeof ResizeObserver !== 'undefined' ? breadcrumbRef : null}
+      ref={browserSupportsResizeObserver ? breadcrumbRef : null}
       data-testid="overflow"
     >
       {hasOverflow ? (

--- a/src/components/Breadcrumb/Breadcrumb.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { OverflowMenuHorizontal20 } from '@carbon/icons-react';
 import { Breadcrumb as CarbonBreadcrumb } from 'carbon-components-react';
+import warning from 'warning';
 
 import { OverflowMenuItem, OverflowMenu } from '../../index';
 
@@ -46,16 +47,26 @@ const defaultProps = {
 const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
   const childrenItems = Children.map(children, child => child);
   const breakingWidth = useRef([]);
-  const { ref: breadcrumbRef } = useResizeObserver({
-    useDefaults: false,
-  });
+  const breadcrumbRef = useRef(null);
   const [overflowItems, setOverflowItems] = useState([]);
   const [afterOverflowItems, setAfterOverflowItems] = useState(childrenItems.slice(1));
   const [prevChildren, setPrevChildren] = useState([]);
 
+  useResizeObserver({
+    useDefaults: false,
+    ref: breadcrumbRef,
+  });
+
+  if (__DEV__) {
+    warning(
+      typeof ResizeObserver !== 'undefined' && hasOverflow,
+      'You have set hasOverflow to true, but the current browser does not support ResizeObserver. You will need to include a ResizeObserver polyfill for hasOverflow to function properly.'
+    );
+  }
+
   useEffect(
     () => {
-      if (hasOverflow) {
+      if (hasOverflow && breadcrumbRef.current) {
         setOverflowItems([]);
         setAfterOverflowItems(childrenItems.slice(1));
         setPrevChildren(children);
@@ -66,7 +77,7 @@ const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
   /** update breadcrumbs  */
   useEffect(
     () => {
-      if (hasOverflow) {
+      if (hasOverflow && breadcrumbRef.current) {
         // The visible list is overflowing
         if (breadcrumbRef.current.clientWidth < breadcrumbRef.current.scrollWidth) {
           // Record the width of the list
@@ -98,7 +109,7 @@ const Breadcrumb = ({ children, className, hasOverflow, ...other }) => {
       className={classnames('breadcrumb--container', {
         'breadcrumb--container__overflowfull': afterOverflowItems.length === 1,
       })}
-      ref={breadcrumbRef}
+      ref={typeof ResizeObserver !== 'undefined' ? breadcrumbRef : null}
       data-testid="overflow"
     >
       {hasOverflow ? (

--- a/src/components/Breadcrumb/Breadcrumb.story.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.story.jsx
@@ -23,12 +23,13 @@ const props = () => ({
 
 const PolyfillWarning = () => (
   <p style={{ marginTop: '5rem' }}>
-    Note: This prop utilizes a{' '}
+    Note: `hasOverflow` utilizes a{' '}
     <a href="https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver">ResizeObserver</a> to
-    detect changes to the container width. A{' '}
-    <a href="https://www.npmjs.com/package/resize-observer-polyfill">polyfill</a> will likely need
-    to be added to your application due to{' '}
-    <a href="https://caniuse.com/#feat=resizeobserver">current browser support</a>.
+    detect changes to the container width. This library does not provide a{' '}
+    <a href="https://www.npmjs.com/package/resize-observer-polyfill">polyfill</a>, it will likely
+    need to be added to your application due to{' '}
+    <a href="https://caniuse.com/#feat=resizeobserver">current browser support</a>. This story will
+    not demonstrate the `hasOverflow` functionality in browsers without support for ResizeObserver.
   </p>
 );
 
@@ -83,9 +84,8 @@ storiesOf('Watson IoT/Breadcrumb', module)
     }
   )
   .add(
-    'with useResizeObserver',
+    'hasOverflow',
     () => {
-      // const containerWidth = number('container width', 584);
       return (
         <>
           <div style={{ width: '50vw', border: '1px solid', padding: '1rem' }}>
@@ -125,7 +125,7 @@ storiesOf('Watson IoT/Breadcrumb', module)
     {
       info: {
         text: `
-          Breadcrumbs can be automatically collapsed into an overflow menu by toggling 'useResizeObserver'. Note, this requires the containing application to provide a polyfill for ResizeObserver!
+          Breadcrumbs can be automatically collapsed into an overflow menu by toggling 'hasOverflow'. Note, this requires the containing application to provide a polyfill for ResizeObserver!
         `,
       },
     }

--- a/src/components/Breadcrumb/Breadcrumb.test.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BreadcrumbItem } from 'carbon-components-react';
 import { render } from '@testing-library/react';
+import useResizeObserver from 'use-resize-observer';
 
 import Breadcrumb from './Breadcrumb';
 
@@ -12,7 +13,7 @@ const originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototy
 const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollWidth');
 
 describe('Breadcrumb', () => {
-  test('overlows when container is smaller than breadcrumbs', () => {
+  test('overflows when container is smaller than breadcrumbs', () => {
     const { container } = render(
       <Breadcrumb {...commonProps} hasOverflow>
         <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
@@ -43,7 +44,7 @@ describe('Breadcrumb with overflow', () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalOffsetWidth);
   });
 
-  test('overlows when container is smaller than breadcrumbs', () => {
+  test('overflows when container is smaller than breadcrumbs', () => {
     const { container } = render(
       <Breadcrumb {...commonProps} hasOverflow>
         <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
@@ -52,5 +53,36 @@ describe('Breadcrumb with overflow', () => {
       </Breadcrumb>
     );
     expect(container.querySelector('.breadcrumb--overflow')).toBeTruthy();
+  });
+
+  describe('has dev console warning(s)', () => {
+    const originalConsole = console.error;
+    const originalDev = window.__DEV__;
+    const originalResizeObserver = window.ResizeObserver;
+
+    // Applies only to tests in this describe block
+    beforeEach(() => {
+      window.__DEV__ = true;
+      window.ResizeObserver = undefined;
+      console.error = jest.fn();
+    });
+
+    test('when ResizeObserver is not supported in the current environment', () => {
+      render(
+        <Breadcrumb {...commonProps} hasOverflow>
+          <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
+          <BreadcrumbItem href="#">Breadcrumb 2</BreadcrumbItem>
+          <BreadcrumbItem href="#">Breadcrumb 3</BreadcrumbItem>
+        </Breadcrumb>
+      );
+      expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    afterEach(() => {
+      // restore to original values
+      window.__DEV__ = originalDev;
+      window.ResizeObserver = originalResizeObserver;
+      console.error = originalConsole;
+    });
   });
 });

--- a/src/components/Breadcrumb/Breadcrumb.test.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { BreadcrumbItem } from 'carbon-components-react';
 import { render } from '@testing-library/react';
-import useResizeObserver from 'use-resize-observer';
 
 import Breadcrumb from './Breadcrumb';
 

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.story.storyshot
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.story.storyshot
@@ -167,77 +167,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Bread
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Breadcrumb skeleton 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      className="bx--breadcrumb bx--skeleton"
-    >
-      <div
-        className="bx--breadcrumb-item"
-      >
-        <span
-          className="bx--link"
-        >
-           
-        </span>
-      </div>
-      <div
-        className="bx--breadcrumb-item"
-      >
-        <span
-          className="bx--link"
-        >
-           
-        </span>
-      </div>
-      <div
-        className="bx--breadcrumb-item"
-      >
-        <span
-          className="bx--link"
-        >
-           
-        </span>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Breadcrumb with useResizeObserver 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Breadcrumb hasOverflow 1`] = `
 <div
   className="storybook-container"
 >
@@ -336,29 +266,99 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Bread
         }
       }
     >
-      Note: This prop utilizes a
+      Note: \`hasOverflow\` utilizes a
        
       <a
         href="https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver"
       >
         ResizeObserver
       </a>
-       to detect changes to the container width. A
+       to detect changes to the container width. This library does not provide a
        
       <a
         href="https://www.npmjs.com/package/resize-observer-polyfill"
       >
         polyfill
       </a>
-       will likely need to be added to your application due to
+      , it will likely need to be added to your application due to
        
       <a
         href="https://caniuse.com/#feat=resizeobserver"
       >
         current browser support
       </a>
-      .
+      . This story will not demonstrate the \`hasOverflow\` functionality in browsers without support for ResizeObserver.
     </p>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Breadcrumb skeleton 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="bx--breadcrumb bx--skeleton"
+    >
+      <div
+        className="bx--breadcrumb-item"
+      >
+        <span
+          className="bx--link"
+        >
+           
+        </span>
+      </div>
+      <div
+        className="bx--breadcrumb-item"
+      >
+        <span
+          className="bx--link"
+        >
+           
+        </span>
+      </div>
+      <div
+        className="bx--breadcrumb-item"
+      >
+        <span
+          className="bx--link"
+        >
+           
+        </span>
+      </div>
+    </div>
   </div>
   <button
     className="info__show-button"

--- a/src/utils/componentUtilityFunctions.js
+++ b/src/utils/componentUtilityFunctions.js
@@ -304,3 +304,18 @@ export const filterValidAttributes = props =>
       filteredProps[propName] = props[propName];
       return filteredProps;
     }, {});
+
+/**
+ * Detect browser support for a given API
+ * @param {Array<string>} api the API to be tested
+ * @returns {Boolean} return true if browser has support
+ */
+export const browserSupports = api => {
+  switch (api) {
+    case 'ResizeObserver':
+      return typeof ResizeObserver !== 'undefined';
+    default:
+      // There is no assigned value by default, so return undefined
+      return undefined;
+  }
+};


### PR DESCRIPTION
Closes #1017

**Summary**

- Breadcrumb stories weren't rendering at all in Safari because we don't polyfill ResizeObserver and we also weren't disabling `hasOverflow` in environments with no ResizeObserver support

**Change List (commits, features, bugs, etc)**

- Conditionally assign the ref used for `hasOverflow` based on ResizeObserver support
- In documentation, refactor usage of `useResizeObserver` prop to `hasOverflow`
- Add dev warning for no ResizeObserver support when using `hasOverflow`
- Add test, Update snapshot

**Acceptance Test (how to verify the PR)**

- Breadcrumb stories don't work in Safari here (existing previous build): 
  - https://deploy-preview-1008--carbon-addons-iot-react.netlify.com/?path=/story/watson-iot-breadcrumb--default
- Whereas now this should work in Safari (new build of this PR):
  -  https://deploy-preview-1020--carbon-addons-iot-react.netlify.com/?path=/story/watson-iot-breadcrumb--default
