### PR TITLE
fix(tablecard): thresholds render regardless of order

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -365,33 +365,44 @@ const TableCard = ({
   // filter to get the indexes for each one
   const columnsUpdated = cloneDeep(columns);
 
-  const generateThresholdColumn = (columnId, index) => ({
-    id: `iconColumn-${columnId}`,
-    label: uniqueThresholds[index].label
-      ? uniqueThresholds[index].label
-      : `${capitalize(columnId)} ${strings.severityLabel}`,
-    width: uniqueThresholds[index].width,
-    isSortable: true,
-    renderDataFunction: renderThresholdIcon,
-    priority: 1,
-    filter: {
-      placeholderText: strings.selectSeverityPlaceholder,
-      options: [
-        {
-          id: 1,
-          text: strings.criticalLabel,
-        },
-        {
-          id: 2,
-          text: strings.moderateLabel,
-        },
-        {
-          id: 3,
-          text: strings.lowLabel,
-        },
-      ],
-    },
-  });
+  /**
+   * Generates a threshold column based off the uniqueThreshold's value
+   * @param {string} columnId AKA dataSourceId
+   * @returns {Object} new threshold column
+   */
+  const generateThresholdColumn = columnId => {
+    // Need to find the index of the dataSource regardless of uniqueThresholds ordering
+    const thresholdIndex = uniqueThresholds.findIndex(
+      threshold => threshold.dataSourceId === columnId
+    );
+    return {
+      id: `iconColumn-${columnId}`,
+      label: uniqueThresholds[thresholdIndex].label
+        ? uniqueThresholds[thresholdIndex].label
+        : `${capitalize(columnId)} ${strings.severityLabel}`,
+      width: uniqueThresholds[thresholdIndex].width,
+      isSortable: true,
+      renderDataFunction: renderThresholdIcon,
+      priority: 1,
+      filter: {
+        placeholderText: strings.selectSeverityPlaceholder,
+        options: [
+          {
+            id: 1,
+            text: strings.criticalLabel,
+          },
+          {
+            id: 2,
+            text: strings.moderateLabel,
+          },
+          {
+            id: 3,
+            text: strings.lowLabel,
+          },
+        ],
+      },
+    };
+  };
 
   // Don't add the icon column in sample mode
   if (!isEditable) {
@@ -402,9 +413,9 @@ const TableCard = ({
           : null
       )
       .filter(i => !isNil(i));
-    indexes.forEach(({ i, columnId }, index) =>
-      columnsUpdated.splice(index !== 0 ? i + 1 : i, 0, generateThresholdColumn(columnId, index))
-    );
+    indexes.forEach(({ i, columnId }, index) => {
+      columnsUpdated.splice(index !== 0 ? i + 1 : i, 0, generateThresholdColumn(columnId));
+    });
     // Check for any threshold columns that weren't matched (if the column was hidden) and add to the end of the array
     const missingThresholdColumns = uniqueThresholds.filter(
       threshold => !find(columnsUpdated, column => threshold.dataSourceId === column.dataSourceId)
@@ -412,9 +423,7 @@ const TableCard = ({
     columnsUpdated.splice(
       columnsUpdated.length,
       0,
-      ...missingThresholdColumns.map(({ dataSourceId }, index) =>
-        generateThresholdColumn(dataSourceId, index)
-      )
+      ...missingThresholdColumns.map(({ dataSourceId }) => generateThresholdColumn(dataSourceId))
     );
   }
 

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -102,7 +102,15 @@ storiesOf('Watson IoT/TableCard', module)
     const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
     const thresholds = [
-      // this threshold is applied to the whole row, not a particular attribute
+      {
+        dataSourceId: 'pressure',
+        comparison: '>=',
+        value: 10,
+        severity: 1,
+        icon: 'bee',
+        color: 'black',
+        label: 'Pressure Sev',
+      },
       {
         dataSourceId: 'count',
         comparison: '<',
@@ -120,15 +128,6 @@ storiesOf('Watson IoT/TableCard', module)
         comparison: '=',
         value: 7,
         severity: 2, // High threshold, medium, or low used for sorting and defined filtration
-      },
-      {
-        dataSourceId: 'pressure',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-        icon: 'bee',
-        color: 'black',
-        label: 'Pressure Sev',
       },
     ];
 
@@ -180,56 +179,78 @@ storiesOf('Watson IoT/TableCard', module)
       </div>
     );
   })
-  .add('table with thresholds', () => {
-    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
+  .add(
+    'table with thresholds',
+    () => {
+      const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
-    const thresholds = [
-      // this threshold is applied to the whole row, not a particular attribute
-      {
-        dataSourceId: 'count',
-        comparison: '<',
-        value: 5,
-        severity: 3, // High threshold, medium, or low used for sorting and defined filtration
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '>=',
-        value: 10,
-        severity: 1, // High threshold, medium, or low used for sorting and defined filtration
-        label: 'Count Sev',
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '=',
-        value: 7,
-        severity: 2, // High threshold, medium, or low used for sorting and defined filtration
-      },
-      {
-        dataSourceId: 'pressure',
-        comparison: '>=',
-        value: 10,
-        severity: 1,
-        label: 'Pressure Sev',
-      },
-    ];
+      const thresholds = [
+        // this threshold is applied to the whole row, not a particular attribute
+        {
+          dataSourceId: 'count',
+          comparison: '<',
+          value: 5,
+          severity: 3, // High threshold, medium, or low used for sorting and defined filtration
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '>=',
+          value: 10,
+          severity: 1, // High threshold, medium, or low used for sorting and defined filtration
+          label: 'Count Sev',
+        },
+        {
+          dataSourceId: 'count',
+          comparison: '=',
+          value: 7,
+          severity: 2, // High threshold, medium, or low used for sorting and defined filtration
+        },
+        {
+          dataSourceId: 'pressure',
+          comparison: '>=',
+          value: 10,
+          severity: 1,
+          label: 'Pressure Sev',
+        },
+      ];
 
-    return (
-      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
-        <TableCard
-          title={text('title', 'Open Alerts')}
-          id="table-list"
-          tooltip={text('Tooltip text', "Here's a Tooltip")}
-          content={{
-            columns: tableColumns,
-            thresholds,
-          }}
-          values={tableData}
-          onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
-          size={size}
-        />
-      </div>
-    );
-  })
+      return (
+        <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+          <TableCard
+            title={text('title', 'Open Alerts')}
+            id="table-list"
+            tooltip={text('Tooltip text', "Here's a Tooltip")}
+            content={{
+              columns: tableColumns,
+              thresholds,
+            }}
+            values={tableData}
+            onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
+            size={size}
+          />
+        </div>
+      );
+    },
+    {
+      info: {
+        text: `
+       Thresholds can be based off 1 specific data source with the unique key: dataSourceId . 
+
+       Comparisons can then be added by defined the comparison key with one of the following: <,<=,=,>,>= .
+
+       Severity has 3 possible settings, 1 (high), 2 (medium), 3 (low).
+
+       Value is the number limit being compared in the comparison that was defined.
+
+       Label is a custom label that can be defined and displayed in the column. If a custom label is not set, 
+       the label will default to '<dataSourceId> Severity'
+
+       In addition, if the dataSourceId does not have a column displayed, a new column will be added at the end
+       of the table.
+      `,
+      },
+    }
+  )
   .add(
     'table with thresholds only with icon',
     () => {


### PR DESCRIPTION
Closes #1021 

**Summary**

- Threshold columns were being render based off the `uniqueThreshold` array's index, rather than the values within. This meant that if the thresholds were defined in the wrong order, the columns would render in the incorrect position which was extremely fragile

**With Bug**
![Screen Shot 2020-03-19 at 5 43 25 PM](https://user-images.githubusercontent.com/25177649/77121489-4dc18700-6a09-11ea-8f91-ded132246d85.png)


**With Fix**
![image](https://user-images.githubusercontent.com/3360588/77117568-48137380-6a00-11ea-9059-1abaab29759b.png)

**Change List (commits, features, bugs, etc)**

- Changed `generateThresholdColumn` to return based on dataSourceId index
- Added more comments and documentation to story and code
- Re-ordered the thresholds in the story to show that it can be done
- Added a test for this bug

**Acceptance Test (how to verify the PR)**

1. Go to https://deploy-preview-1022--carbon-addons-iot-react.netlify.com/?path=/story/watson-iot-tablecard--table-with-thresholds-precision-and-expanded-rows
2. See that the columns are correctly rendered. ('Count Severity' and 'Pressure Sev' column exists, but 'Pressure Severity' column does not exist)
