### PR TITLE
feat(timepicker): add spinner support for TimePicker

### DIFF
--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -4548,107 +4548,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -4784,6 +4683,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={5}
+                        >
+                          5
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
                         </span>
                       </span>
                     </td>
@@ -5284,6 +5284,199 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={3}
+                        >
+                          3
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -5666,199 +5859,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={3}
-                        >
-                          3
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
                         </span>
                       </span>
                     </td>
@@ -6894,65 +6894,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -6999,6 +6940,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
                         </span>
                       </span>
                     </td>
@@ -7189,6 +7189,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -7353,65 +7412,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
                         </span>
                       </span>
                     </td>
@@ -8663,83 +8663,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -8804,6 +8727,83 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={5}
+                        >
+                          5
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
                         </span>
                       </span>
                     </td>
@@ -9956,65 +9956,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -10061,6 +10002,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
                         </span>
                       </span>
                     </td>
@@ -10251,6 +10251,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -10415,65 +10474,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
                         </span>
                       </span>
                     </td>
@@ -11400,7 +11400,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
+                      id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
                       <span
@@ -11418,7 +11418,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
+                      id="cell-table-for-card-table-list-row-10-hour"
                       offset={0}
                     >
                       <span
@@ -11436,16 +11436,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
+                      id="cell-table-for-card-table-list-row-10-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={1}
+                          title={0}
                         >
-                          1
+                          0
                         </span>
                       </span>
                     </td>
@@ -11454,7 +11454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="actionColumn"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-actionColumn"
+                      id="cell-table-for-card-table-list-row-10-actionColumn"
                       offset={0}
                     >
                       <span
@@ -11516,7 +11516,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
+                      id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
                       <span
@@ -11534,7 +11534,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
+                      id="cell-table-for-card-table-list-row-11-hour"
                       offset={0}
                     >
                       <span
@@ -11552,16 +11552,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
+                      id="cell-table-for-card-table-list-row-11-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={0}
+                          title={1}
                         >
-                          0
+                          1
                         </span>
                       </span>
                     </td>
@@ -11570,7 +11570,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="actionColumn"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-actionColumn"
+                      id="cell-table-for-card-table-list-row-11-actionColumn"
                       offset={0}
                     >
                       <span
@@ -11980,6 +11980,122 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                          floatingMenu={true}
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="#5a6872"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            style={
+                              Object {
+                                "willChange": "transform",
+                              }
+                            }
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <circle
+                              cx="16"
+                              cy="6"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="26"
+                              r="2"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -12267,122 +12383,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="actionColumn"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-9-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                          floatingMenu={true}
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            style={
-                              Object {
-                                "willChange": "transform",
-                              }
-                            }
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <circle
-                              cx="16"
-                              cy="6"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="26"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-actionColumn"
                       offset={0}
                     >
                       <span
@@ -13431,7 +13431,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
+                      id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
                       <span
@@ -13449,7 +13449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
+                      id="cell-table-for-card-table-list-row-10-hour"
                       offset={0}
                     >
                       <span
@@ -13467,16 +13467,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
+                      id="cell-table-for-card-table-list-row-10-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={1}
+                          title={0}
                         >
-                          1
+                          0
                         </span>
                       </span>
                     </td>
@@ -13526,7 +13526,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
+                      id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
                       <span
@@ -13544,7 +13544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
+                      id="cell-table-for-card-table-list-row-11-hour"
                       offset={0}
                     >
                       <span
@@ -13562,16 +13562,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
+                      id="cell-table-for-card-table-list-row-11-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={0}
+                          title={1}
                         >
-                          0
+                          1
                         </span>
                       </span>
                     </td>
@@ -13906,6 +13906,101 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -14142,101 +14237,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
                         </span>
                       </span>
                     </td>
@@ -15199,95 +15199,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -15343,6 +15254,95 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="actionColumn"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-10-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-actionColumn"
                       offset={0}
                     >
                       <span
@@ -15644,6 +15644,95 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -15877,95 +15966,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="actionColumn"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-9-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-actionColumn"
                       offset={0}
                     >
                       <span
@@ -17098,107 +17098,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -17334,6 +17233,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={5}
+                        >
+                          5
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
                         </span>
                       </span>
                     </td>
@@ -17834,6 +17834,199 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={3}
+                        >
+                          3
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -18216,199 +18409,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={3}
-                        >
-                          3
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
                         </span>
                       </span>
                     </td>
@@ -19484,71 +19484,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -19645,6 +19580,71 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="iconColumn-pressure"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-10-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
                       offset={0}
                     >
                       <span
@@ -20040,6 +20040,163 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -20316,163 +20473,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       />
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
                     </td>
                   </tr>
                   <tr
@@ -21688,143 +21688,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="5"
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -21913,6 +21776,143 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="5"
+                        >
+                          5
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
                         </span>
                       </span>
                     </td>
@@ -22453,6 +22453,178 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="3"
+                        >
+                          3
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            fill="black"
+                            focusable="true"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            style={
+                              Object {
+                                "willChange": "transform",
+                              }
+                            }
+                            tabIndex="0"
+                            title="pressure: 10 >= 10"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                            />
+                            <title>
+                              pressure: 10 &gt;= 10
+                            </title>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -22860,178 +23032,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="3"
-                        >
-                          3
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            fill="black"
-                            focusable="true"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            style={
-                              Object {
-                                "willChange": "transform",
-                              }
-                            }
-                            tabIndex="0"
-                            title="pressure: 10 >= 10"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
-                            />
-                            <title>
-                              pressure: 10 &gt;= 10
-                            </title>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
                         </span>
                       </span>
                     </td>
@@ -24202,158 +24202,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 5 > 2"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -24459,6 +24307,158 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 5 > 2"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
                         </span>
                       </span>
                     </td>
@@ -24968,6 +24968,158 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 > 2"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -25330,158 +25482,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 > 2"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
                         </span>
                       </span>
                     </td>

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -4548,6 +4548,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={5}
+                        >
+                          5
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -4683,107 +4784,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
                         </span>
                       </span>
                     </td>
@@ -5284,199 +5284,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={3}
-                        >
-                          3
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -5859,6 +5666,199 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={3}
+                        >
+                          3
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
                         </span>
                       </span>
                     </td>
@@ -6894,65 +6894,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
@@ -6999,6 +6940,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={1}
                         >
                           1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={0}
+                        >
+                          0
                         </span>
                       </span>
                     </td>
@@ -7189,65 +7189,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -7412,6 +7353,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
                         </span>
                       </span>
                     </td>
@@ -8663,83 +8663,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
@@ -8804,6 +8727,83 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={1}
                         >
                           1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={5}
+                        >
+                          5
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={0}
+                        >
+                          0
                         </span>
                       </span>
                     </td>
@@ -9956,65 +9956,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
@@ -10061,6 +10002,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={1}
                         >
                           1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={0}
+                        >
+                          0
                         </span>
                       </span>
                     </td>
@@ -10251,65 +10251,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -10474,6 +10415,65 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
                         </span>
                       </span>
                     </td>
@@ -11400,7 +11400,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
+                      id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
                       <span
@@ -11418,7 +11418,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
+                      id="cell-table-for-card-table-list-row-11-hour"
                       offset={0}
                     >
                       <span
@@ -11436,16 +11436,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
+                      id="cell-table-for-card-table-list-row-11-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={0}
+                          title={1}
                         >
-                          0
+                          1
                         </span>
                       </span>
                     </td>
@@ -11454,7 +11454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="actionColumn"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-actionColumn"
+                      id="cell-table-for-card-table-list-row-11-actionColumn"
                       offset={0}
                     >
                       <span
@@ -11516,7 +11516,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
+                      id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
                       <span
@@ -11534,7 +11534,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
+                      id="cell-table-for-card-table-list-row-10-hour"
                       offset={0}
                     >
                       <span
@@ -11552,16 +11552,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
+                      id="cell-table-for-card-table-list-row-10-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={1}
+                          title={0}
                         >
-                          1
+                          0
                         </span>
                       </span>
                     </td>
@@ -11570,7 +11570,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="actionColumn"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-actionColumn"
+                      id="cell-table-for-card-table-list-row-10-actionColumn"
                       offset={0}
                     >
                       <span
@@ -11980,122 +11980,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
-                          floatingMenu={true}
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={20}
-                            preserveAspectRatio="xMidYMid meet"
-                            style={
-                              Object {
-                                "willChange": "transform",
-                              }
-                            }
-                            viewBox="0 0 32 32"
-                            width={20}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <circle
-                              cx="16"
-                              cy="6"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="26"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -12383,6 +12267,122 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="actionColumn"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-9-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          aria-label="Menu"
+                          className="TableCard__StyledOverflowMenu-q9l5bz-0 ibUtEL bx--overflow-menu"
+                          floatingMenu={true}
+                          onClick={[Function]}
+                          onClose={[Function]}
+                          onKeyDown={[Function]}
+                          open={false}
+                          tabIndex={0}
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="#5a6872"
+                            focusable="false"
+                            height={20}
+                            preserveAspectRatio="xMidYMid meet"
+                            style={
+                              Object {
+                                "willChange": "transform",
+                              }
+                            }
+                            viewBox="0 0 32 32"
+                            width={20}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <circle
+                              cx="16"
+                              cy="6"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="2"
+                            />
+                            <circle
+                              cx="16"
+                              cy="26"
+                              r="2"
+                            />
+                          </svg>
+                        </button>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-actionColumn"
                       offset={0}
                     >
                       <span
@@ -13431,7 +13431,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
+                      id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
                       <span
@@ -13449,7 +13449,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
+                      id="cell-table-for-card-table-list-row-11-hour"
                       offset={0}
                     >
                       <span
@@ -13467,16 +13467,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
+                      id="cell-table-for-card-table-list-row-11-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={0}
+                          title={1}
                         >
-                          0
+                          1
                         </span>
                       </span>
                     </td>
@@ -13526,7 +13526,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
+                      id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
                       <span
@@ -13544,7 +13544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="hour"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
+                      id="cell-table-for-card-table-list-row-10-hour"
                       offset={0}
                     >
                       <span
@@ -13562,16 +13562,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="pressure"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
+                      id="cell-table-for-card-table-list-row-10-pressure"
                       offset={0}
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <span
-                          title={1}
+                          title={0}
                         >
-                          1
+                          0
                         </span>
                       </span>
                     </td>
@@ -13906,101 +13906,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -14237,6 +14142,101 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
                         </span>
                       </span>
                     </td>
@@ -15199,95 +15199,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
@@ -15343,6 +15254,95 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="actionColumn"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-11-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={0}
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-actionColumn"
                       offset={0}
                     >
                       <span
@@ -15644,95 +15644,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="actionColumn"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-actionColumn"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <svg
-                          aria-label="open"
-                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
-                          fillRule="evenodd"
-                          height="16"
-                          onClick={[Function]}
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                        >
-                          <title>
-                            open
-                          </title>
-                          <path
-                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
-                          />
-                        </svg>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -15966,6 +15877,95 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="actionColumn"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-9-actionColumn"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <svg
+                          aria-label="open"
+                          className="TableCard__StyledActionIcon-q9l5bz-1 dhEjJn"
+                          fillRule="evenodd"
+                          height="16"
+                          onClick={[Function]}
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <title>
+                            open
+                          </title>
+                          <path
+                            d="M7.926 3.38L1.002 9.72V12h2.304l6.926-6.316L7.926 3.38zm.738-.675l2.308 2.304 1.451-1.324-2.308-2.309-1.451 1.329zM.002 9.28L9.439.639a1 1 0 0 1 1.383.03l2.309 2.309a1 1 0 0 1-.034 1.446L3.694 13H.002V9.28zM0 16.013v-1h16v1z"
+                          />
+                        </svg>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="actionColumn"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-actionColumn"
                       offset={0}
                     >
                       <span
@@ -17098,6 +17098,107 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={5}
+                        >
+                          5
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -17233,107 +17334,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
                         </span>
                       </span>
                     </td>
@@ -17834,199 +17834,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={3}
-                        >
-                          3
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -18409,6 +18216,199 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={3}
+                        >
+                          3
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
                         </span>
                       </span>
                     </td>
@@ -19484,6 +19484,71 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -19580,71 +19645,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="iconColumn-pressure"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-10-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
                       offset={0}
                     >
                       <span
@@ -20040,163 +20040,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -20473,6 +20316,163 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       />
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -21688,143 +21688,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="2"
-                        >
-                          2
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-11-alert"
                       offset={0}
                     >
@@ -21913,6 +21776,143 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={1}
                         >
                           1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="2"
+                        >
+                          2
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={0}
+                        >
+                          0
                         </span>
                       </span>
                     </td>
@@ -22453,178 +22453,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      />
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="3"
-                        >
-                          3
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
-                        >
-                          <svg
-                            fill="black"
-                            focusable="true"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            style={
-                              Object {
-                                "willChange": "transform",
-                              }
-                            }
-                            tabIndex="0"
-                            title="pressure: 10 >= 10"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
-                            />
-                            <title>
-                              pressure: 10 &gt;= 10
-                            </title>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -23032,6 +22860,178 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="3"
+                        >
+                          3
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="pressure: 10 >= 10"
+                        >
+                          <svg
+                            fill="black"
+                            focusable="true"
+                            height={16}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            style={
+                              Object {
+                                "willChange": "transform",
+                              }
+                            }
+                            tabIndex="0"
+                            title="pressure: 10 >= 10"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                            />
+                            <title>
+                              pressure: 10 &gt;= 10
+                            </title>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
                         </span>
                       </span>
                     </td>
@@ -24202,6 +24202,158 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 5 > 2"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={1}
+                        >
+                          1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
                       id="cell-table-for-card-table-list-row-10-alert"
                       offset={0}
                     >
@@ -24307,158 +24459,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 5 > 2"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
                         </span>
                       </span>
                     </td>
@@ -24968,158 +24968,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
                       data-column="alert"
                       data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="iconColumn-count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 > 2"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
-                    data-child-count={0}
-                    data-nesting-offset={0}
-                    data-parent-row={true}
-                    data-row-nesting={false}
-                    onClick={[Function]}
-                  >
-                    <td
-                      className="bx--table-expand"
-                      headers="expand"
-                    >
-                      <button
-                        aria-label="Click to expand content"
-                        className="bx--table-expand__button"
-                        onClick={[Function]}
-                        title="Click to expand content"
-                      >
-                        <svg
-                          aria-label="Click to expand content"
-                          className="bx--table-expand__svg"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
-                          />
-                        </svg>
-                      </button>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
                       id="cell-table-for-card-table-list-row-4-alert"
                       offset={0}
                     >
@@ -25482,6 +25330,158 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           title={0}
                         >
                           0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row TableBodyRow__StyledTableExpandRow-sc-103itxu-2 iObQTv"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          style={
+                            Object {
+                              "willChange": "transform",
+                            }
+                          }
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 3 > 2"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy-2"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                  fill="#DA1E28"
+                                  id="background-color"
+                                />
+                                <polygon
+                                  fill="#FFFFFF"
+                                  id="icon-color"
+                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Critical
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title={10}
+                        >
+                          10
                         </span>
                       </span>
                     </td>

--- a/src/components/TimePickerSpinner/TimePickerSpinner.jsx
+++ b/src/components/TimePickerSpinner/TimePickerSpinner.jsx
@@ -1,0 +1,233 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { TimePicker } from 'carbon-components-react';
+import { CaretDownGlyph, CaretUpGlyph } from '@carbon/icons-react';
+import classnames from 'classnames';
+
+import { settings } from '../../constants/Settings';
+import { keyCodes } from '../../constants/KeyCodeConstants';
+
+const { iotPrefix } = settings;
+
+export const TIMEGROUPS = {
+  HOURS: 'HOURS',
+  MINUTES: 'MINUTES',
+};
+
+const propTypes = {
+  /** renders the up/down buttons  */
+  spinner: PropTypes.bool,
+  /** a default value for the input  */
+  value: PropTypes.string,
+  /** a list of children to pass to the Carbon TimePicker component  */
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+  /** triggered on input click  */
+  onClick: PropTypes.func,
+  /** triggered on value change  */
+  onChange: PropTypes.func,
+  /** disable the input  */
+  disabled: PropTypes.bool,
+  /** set a 12-hour timepicker instead of the default 24-hour  */
+  is12hour: PropTypes.bool,
+  /** the default selected timegroup (hours, minutes) */
+  defaultTimegroup: PropTypes.oneOf([TIMEGROUPS.HOURS, TIMEGROUPS.MINUTES]),
+};
+
+const defaultProps = {
+  spinner: false,
+  value: '',
+  children: null,
+  onClick: null,
+  onChange: null,
+  disabled: false,
+  is12hour: false,
+  defaultTimegroup: TIMEGROUPS.HOURS,
+};
+
+const TimePickerSpinner = ({
+  spinner,
+  value,
+  children,
+  onClick,
+  onChange,
+  disabled,
+  is12hour,
+  defaultTimegroup,
+  ...others
+}) => {
+  const [pickerValue, setPickerValue] = useState(value || '');
+  const [currentTimeGroup, setCurrentTimeGroup] = useState(
+    defaultTimegroup === TIMEGROUPS.MINUTES ? 1 : 0
+  );
+
+  const [isInteractingWithSpinner, setIsInteractingWithSpinner] = useState(false);
+  const [isSpinnerFocused, setIsSpinnerFocused] = useState(false);
+  const [keyUpOrDownPosition, setKeyUpOrDownPosition] = useState(-1);
+  const [focusTarget, setFocusTarget] = useState(null);
+
+  const timePickerRef = React.createRef();
+
+  const handleArrowClick = direction => {
+    const timeGroups = pickerValue.split(':');
+    if (timeGroups.length === 1) {
+      timeGroups.push('00');
+    }
+    let groupValue = Number(timeGroups[currentTimeGroup]);
+    if (Number.isNaN(groupValue)) {
+      groupValue = 0;
+    }
+
+    const maxForGroup = currentTimeGroup === 0 ? (is12hour ? 12 : 23) : 59;
+
+    if (direction === 'down') {
+      groupValue = groupValue - 1 < 0 ? maxForGroup : groupValue - 1;
+    } else {
+      groupValue = groupValue + 1 > maxForGroup ? 0 : groupValue + 1;
+    }
+
+    timeGroups[currentTimeGroup] = groupValue.toString().padStart(2, '0');
+    setPickerValue(timeGroups.join(':'));
+    window.setTimeout(() => {
+      if (focusTarget) {
+        focusTarget.selectionStart = keyUpOrDownPosition;
+        focusTarget.selectionEnd = keyUpOrDownPosition;
+        setKeyUpOrDownPosition(-1);
+      }
+    }, 0);
+  };
+
+  const onInputClick = e => {
+    const target = e.currentTarget;
+    setFocusTarget(target);
+    setCurrentTimeGroup(target.selectionStart <= 2 ? 0 : 1);
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
+  const onInputChange = e => {
+    setPickerValue(e.currentTarget.value);
+    if (onChange) {
+      onChange(e);
+    }
+  };
+
+  const onInputKeyDown = e => {
+    const target = e.currentTarget;
+    setFocusTarget(target);
+    switch (e.keyCode) {
+      case keyCodes.UP:
+      case keyCodes.DOWN:
+        setKeyUpOrDownPosition(target.selectionStart);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const onInputKeyUp = e => {
+    switch (e.keyCode) {
+      case keyCodes.LEFT:
+      case keyCodes.RIGHT:
+        setCurrentTimeGroup(e.currentTarget.selectionStart <= 2 ? 0 : 1);
+        break;
+      case keyCodes.UP:
+        handleArrowClick('up');
+        break;
+      case keyCodes.DOWN:
+        handleArrowClick('down');
+        break;
+      default:
+        break;
+    }
+  };
+
+  const onArrowClick = direction => {
+    setIsInteractingWithSpinner(true);
+    handleArrowClick(direction);
+  };
+
+  const onArrowInteract = fromFocus => {
+    if (!isSpinnerFocused) {
+      setIsSpinnerFocused(fromFocus);
+    }
+    setIsInteractingWithSpinner(true);
+  };
+
+  const onArrowStopInteract = fromBlur => {
+    if (fromBlur) {
+      setIsSpinnerFocused(false);
+      setIsInteractingWithSpinner(false);
+    }
+    if (!isSpinnerFocused) {
+      setIsInteractingWithSpinner(false);
+    }
+  };
+
+  const timeGroupForLabel = currentTimeGroup === 0 ? 'hours' : 'minutes';
+
+  return (
+    <div
+      className={classnames(`${iotPrefix}--time-picker__wrapper`, {
+        [`${iotPrefix}--time-picker__wrapper--with-spinner`]: spinner,
+        [`${iotPrefix}--time-picker__wrapper--updown`]: keyUpOrDownPosition > -1,
+        [`${iotPrefix}--time-picker__wrapper--show-underline`]: isInteractingWithSpinner,
+        [`${iotPrefix}--time-picker__wrapper--show-underline-minutes`]: currentTimeGroup === 1,
+      })}
+    >
+      <TimePicker
+        ref={timePickerRef}
+        onClick={onInputClick}
+        onChange={onInputChange}
+        value={pickerValue}
+        onKeyDown={onInputKeyDown}
+        onKeyUp={onInputKeyUp}
+        disabled={disabled}
+        {...others}
+      >
+        {children}
+        {spinner ? (
+          <div className={`${iotPrefix}--time-picker__controls`}>
+            <button
+              type="button"
+              className={`${iotPrefix}--time-picker__controls--btn up-icon`}
+              onClick={() => onArrowClick('up')}
+              onMouseOver={() => onArrowInteract(false)}
+              onMouseOut={() => onArrowStopInteract(false)}
+              onFocus={() => onArrowInteract(true)}
+              onBlur={() => onArrowStopInteract(true)}
+              aria-live="polite"
+              aria-atomic="true"
+              title={`Increment ${timeGroupForLabel}`}
+              aria-label={`Increment ${timeGroupForLabel}`}
+              disabled={disabled}
+            >
+              <CaretUpGlyph className="up-icon" />
+            </button>
+            <button
+              type="button"
+              className={`${iotPrefix}--time-picker__controls--btn down-icon`}
+              onClick={() => onArrowClick('down')}
+              onMouseOver={() => onArrowInteract(false)}
+              onMouseOut={() => onArrowStopInteract(false)}
+              onFocus={() => onArrowInteract(true)}
+              onBlur={() => onArrowStopInteract(true)}
+              aria-live="polite"
+              aria-atomic="true"
+              title={`Decrement ${timeGroupForLabel}`}
+              aria-label={`Decrement ${timeGroupForLabel}`}
+              disabled={disabled}
+            >
+              <CaretDownGlyph className="down-icon" />
+            </button>
+          </div>
+        ) : null}
+      </TimePicker>
+    </div>
+  );
+};
+
+TimePickerSpinner.propTypes = propTypes;
+TimePickerSpinner.defaultProps = defaultProps;
+
+export default TimePickerSpinner;

--- a/src/components/TimePickerSpinner/TimePickerSpinner.story.jsx
+++ b/src/components/TimePickerSpinner/TimePickerSpinner.story.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { boolean } from '@storybook/addon-knobs';
+
+import TimePickerSpinner, { TIMEGROUPS } from './TimePickerSpinner';
+
+export {
+  default as TimePickerStory,
+} from 'carbon-components-react/lib/components/TimePicker/TimePicker-story';
+
+storiesOf('Watson IoT Experimental/TimePickerSpinner', module)
+  .add('With spinner', () => {
+    return (
+      <div style={{ margin: 20 }}>
+        <TimePickerSpinner
+          id="timepicker"
+          value="19:33"
+          aria-label="Pick a time"
+          disabled={boolean('Disable input', false)}
+          spinner={boolean('Enable spinner', true)}
+          is12hour={boolean('12-hour format', false)}
+        />
+      </div>
+    );
+  })
+  .add('Default timeGroup to minutes', () => {
+    return (
+      <div style={{ margin: 20 }}>
+        <TimePickerSpinner
+          id="timepicker"
+          value="19:33"
+          aria-label="Pick a time"
+          spinner
+          defaultTimegroup={TIMEGROUPS.MINUTES}
+        />
+      </div>
+    );
+  });

--- a/src/components/TimePickerSpinner/TimePickerSpinner.test.jsx
+++ b/src/components/TimePickerSpinner/TimePickerSpinner.test.jsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { keyCodes } from '../../constants/KeyCodeConstants';
+
+import TimePickerSpinner, { TIMEGROUPS } from './TimePickerSpinner';
+
+const timePickerProps = {
+  id: 'timepickerspinner',
+  onClick: jest.fn(),
+  onChange: jest.fn(),
+};
+
+describe('TimePicker tests', () => {
+  jest.useFakeTimers();
+
+  test('show/hide spinner', () => {
+    let wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
+    expect(wrapper.find('.iot--time-picker__controls--btn')).toHaveLength(2);
+
+    wrapper = mount(<TimePickerSpinner {...timePickerProps} />);
+    expect(wrapper.find('.iot--time-picker__controls--btn')).toHaveLength(0);
+  });
+
+  test('increment/decrement value', () => {
+    const wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
+
+    wrapper
+      .find('.iot--time-picker__controls--btn.up-icon')
+      .first()
+      .simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('01:00');
+
+    wrapper
+      .find('.iot--time-picker__controls--btn.down-icon')
+      .first()
+      .simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('00:00');
+
+    wrapper.find('input').simulate('focus');
+    wrapper.find('input').simulate('keyup', { keyCode: keyCodes.LEFT });
+    wrapper.find('input').simulate('keyup', { keyCode: keyCodes.UP });
+    wrapper.find('input').simulate('keyup', { keyCode: keyCodes.ESC });
+    expect(wrapper.find('input').props().value).toEqual('01:00');
+
+    wrapper.find('input').simulate('keyup', { keyCode: keyCodes.DOWN });
+    expect(wrapper.find('input').props().value).toEqual('00:00');
+
+    wrapper
+      .find('input')
+      .simulate('keyup', { keyCode: keyCodes.RIGHT, currentTarget: { selectionStart: 3 } });
+    wrapper.find('input').simulate('keyup', { keyCode: keyCodes.UP });
+    expect(wrapper.find('input').props().value).toEqual('01:00');
+  });
+
+  test('work with strings', () => {
+    const wrapper = mount(<TimePickerSpinner {...timePickerProps} value="xyz" spinner />);
+
+    wrapper
+      .find('.iot--time-picker__controls--btn.down-icon')
+      .first()
+      .simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('23:00');
+  });
+
+  test('show indicator', () => {
+    const wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
+
+    const upButton = wrapper.find('.iot--time-picker__controls--btn.up-icon').first();
+    const downButton = wrapper.find('.iot--time-picker__controls--btn.down-icon').first();
+
+    upButton.simulate('focus');
+    upButton.simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('01:00');
+    expect(
+      wrapper
+        .find('.iot--time-picker__wrapper')
+        .hasClass('iot--time-picker__wrapper--show-underline')
+    ).toEqual(true);
+    upButton.simulate('mouseover');
+    upButton.simulate('mouseout');
+    upButton.simulate('blur');
+    expect(
+      wrapper
+        .find('.iot--time-picker__wrapper')
+        .hasClass('iot--time-picker__wrapper--show-underline')
+    ).toEqual(false);
+
+    wrapper.find('input').simulate('keydown', { keyCode: keyCodes.DOWN });
+    wrapper.find('input').simulate('keydown', { keyCode: keyCodes.UP });
+    wrapper.find('input').simulate('keydown', { keyCode: keyCodes.ESC });
+    expect(wrapper.find('input').props().value).toEqual('01:00');
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 0);
+
+    downButton.simulate('focus');
+    downButton.simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('00:00');
+    downButton.simulate('mouseover');
+    downButton.simulate('mouseout');
+    downButton.simulate('blur');
+  });
+
+  test('onClick should be called', () => {
+    const wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
+    wrapper.find('input').simulate('click');
+    expect(timePickerProps.onClick).toHaveBeenCalled();
+  });
+
+  test('onChange should be called', () => {
+    const wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
+    wrapper.find('input').simulate('change');
+    expect(timePickerProps.onChange).toHaveBeenCalled();
+  });
+
+  test('12-hour picker', () => {
+    const wrapper = mount(
+      <TimePickerSpinner {...timePickerProps} value="12:00" spinner is12hour />
+    );
+    wrapper
+      .find('.iot--time-picker__controls--btn.up-icon')
+      .first()
+      .simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('00:00');
+  });
+
+  test('default timeGroup to minutes', () => {
+    const wrapper = mount(
+      <TimePickerSpinner
+        {...timePickerProps}
+        value="12:00"
+        spinner
+        defaultTimegroup={TIMEGROUPS.MINUTES}
+      />
+    );
+    wrapper
+      .find('.iot--time-picker__controls--btn.up-icon')
+      .first()
+      .simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('12:01');
+  });
+
+  test('flip minutes back to 59 after hitting 0', () => {
+    const wrapper = mount(
+      <TimePickerSpinner
+        {...timePickerProps}
+        value="12:00"
+        spinner
+        defaultTimegroup={TIMEGROUPS.MINUTES}
+      />
+    );
+    wrapper
+      .find('.iot--time-picker__controls--btn.down-icon')
+      .first()
+      .simulate('click');
+    expect(wrapper.find('input').props().value).toEqual('12:59');
+  });
+});

--- a/src/components/TimePickerSpinner/_time-picker-spinner.scss
+++ b/src/components/TimePickerSpinner/_time-picker-spinner.scss
@@ -1,0 +1,105 @@
+@import '../../globals/vars';
+
+.#{$iot-prefix}--time-picker__wrapper {
+  position: relative;
+
+  &.#{$iot-prefix}--time-picker__wrapper--with-spinner {
+    .bx--time-picker__input-field {
+      width: 5.875rem;
+      padding-right: 2rem;
+    }
+  }
+
+  &.#{$iot-prefix}--time-picker__wrapper--updown {
+    .bx--time-picker__input-field {
+      caret-color: transparent;
+    }
+  }
+
+  &.#{$iot-prefix}--time-picker__wrapper--show-underline {
+    .bx--time-picker__input:before {
+      content: '__';
+      position: absolute;
+      bottom: 0.365rem;
+      left: 1rem;
+    }
+    &.#{$iot-prefix}--time-picker__wrapper--show-underline-minutes {
+      .bx--time-picker__input:before {
+        left: 2.7rem;
+      }
+    }
+  }
+
+  .#{$iot-prefix}--time-picker__controls {
+    position: absolute;
+    left: 4rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    // vertically center controls within parent container on IE11
+    top: 50%;
+    transform: translateY(-50%);
+
+    .#{$iot-prefix}--time-picker__controls--btn {
+      border: none;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      padding: 0;
+      width: 1.7rem;
+      height: rem(18px);
+
+      svg {
+        fill: currentColor;
+        position: relative;
+      }
+
+      &.up-icon svg {
+        top: rem(4px);
+      }
+
+      &.down-icon svg {
+        top: rem(-4px);
+      }
+
+      &:focus {
+        @include focus-outline;
+        outline-width: 2px;
+        outline-offset: -2px;
+      }
+
+      &:hover {
+        cursor: pointer;
+        color: $icon-01;
+      }
+
+      &:disabled {
+        cursor: not-allowed;
+        color: $disabled;
+      }
+    }
+  }
+}
+
+html[dir='rtl'] {
+  .#{$iot-prefix}--time-picker__wrapper {
+    &.#{$iot-prefix}--time-picker__wrapper--show-underline {
+      .bx--time-picker__input:before {
+        left: unset;
+        right: 3.7rem;
+      }
+      &.#{$iot-prefix}--time-picker__wrapper--show-underline-minutes {
+        .bx--time-picker__input:before {
+          left: unset;
+          right: 2rem;
+        }
+      }
+    }
+
+    .#{$iot-prefix}--time-picker__controls {
+      left: unset;
+      right: 2px;
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export PageTitleBar from './components/PageTitleBar/PageTitleBar';
 export HierarchyList from './components/List/HierarchyList';
 export BarChartCard from './components/BarChartCard/BarChartCard';
 export TileCatalogNew from './components/TileCatalogNew/TileCatalogNew';
+export TimePickerSpinner from './components/TimePickerSpinner/TimePickerSpinner';
 
 // reusable reducers
 export { baseTableReducer } from './components/Table/baseTableReducer';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -243,3 +243,4 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/TileCatalogNew/tile-catalog';
 @import 'components/TileCatalog/tile-catalog';
 @import 'components/ValueCard/value-card';
+@import 'components/TimePickerSpinner/time-picker-spinner';

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4187,6 +4187,65 @@ Map {
       },
     },
   },
+  "TimePickerSpinner" => Object {
+    "defaultProps": Object {
+      "children": null,
+      "defaultTimegroup": "HOURS",
+      "disabled": false,
+      "is12hour": false,
+      "onChange": null,
+      "onClick": null,
+      "spinner": false,
+      "value": "",
+    },
+    "propTypes": Object {
+      "children": Object {
+        "args": Array [
+          Array [
+            Object {
+              "args": Array [
+                Object {
+                  "type": "node",
+                },
+              ],
+              "type": "arrayOf",
+            },
+            Object {
+              "type": "node",
+            },
+          ],
+        ],
+        "type": "oneOfType",
+      },
+      "defaultTimegroup": Object {
+        "args": Array [
+          Array [
+            "HOURS",
+            "MINUTES",
+          ],
+        ],
+        "type": "oneOf",
+      },
+      "disabled": Object {
+        "type": "bool",
+      },
+      "is12hour": Object {
+        "type": "bool",
+      },
+      "onChange": Object {
+        "type": "func",
+      },
+      "onClick": Object {
+        "type": "func",
+      },
+      "spinner": Object {
+        "type": "bool",
+      },
+      "value": Object {
+        "type": "string",
+      },
+    },
+  },
   "baseTableReducer" => Object {},
   "tableReducer" => Object {},
   "tileCatalogReducer" => Object {},


### PR DESCRIPTION
Needed for #854 

**Summary**

- The new DateTimePicker component requested on #854 needs some new components, like an inline calendar and a TimePicker with a numeric spinner. This PR takes care of the latter.

**Change List (commits, features, bugs, etc)**

- Overridden and extended TimePicker so we can increment hours and minutes with the spinner buttons and/or keyboard
- Works with RTL
- Doesn't throw any a11y error

![image](https://user-images.githubusercontent.com/751894/77172188-e0236280-6abd-11ea-8fc4-221fd99d47ba.png)

**Acceptance Test (how to verify the PR)**

- new basic test suite available here: ?path=/story/watson-iot-experimental-timepicker--with-spinner
