### PR TITLE
fix(table): show toolbar if has custom content

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -339,6 +339,7 @@ const Table = props => {
       options.hasColumnSelection ||
       actions.toolbar.onDownloadCSV ||
       secondaryTitle ||
+      view.toolbar.customToolbarContent ||
       tooltip ? (
         <TableToolbar
           tableId={id}


### PR DESCRIPTION
Closes #

**Summary**

- show table toolbar when there is custom content but no other options

**Change List (commits, features, bugs, etc)**

- Table Toolbar

**Acceptance Test (how to verify the PR)**

- table with custom content in toolbar and no other options
- toolbar should be rendered
