### PR TITLE
[TableCard] Thresholds labels are customizable and optionally hidden

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -332,7 +332,8 @@ const TableCard = ({
         } ${matchingThresholdValue.value}`}
         {...matchingThresholdValue}
         strings={strings}
-        showLabel={matchingThresholdValue.showLabel}
+        showSeverityLabel={matchingThresholdValue.showSeverityLabel}
+        severityLabel={matchingThresholdValue.severityLabel}
         renderIconByName={others.renderIconByName}
       />
     ) : null;

--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -332,6 +332,7 @@ const TableCard = ({
         } ${matchingThresholdValue.value}`}
         {...matchingThresholdValue}
         strings={strings}
+        showLabel={matchingThresholdValue.showLabel}
         renderIconByName={others.renderIconByName}
       />
     ) : null;

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text, select } from '@storybook/addon-knobs';
+import { text, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { Bee16 } from '@carbon/icons-react';
 
@@ -11,43 +11,6 @@ import { tableColumns, tableData, actions1, actions2 } from '../../utils/sample'
 import TableCard from './TableCard';
 
 storiesOf('Watson IoT/TableCard', module)
-  .add('size - large', () => {
-    const size = CARD_SIZES.LARGE;
-    return (
-      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
-        <TableCard
-          title={text('title', 'Open Alerts')}
-          id="table-list"
-          tooltip={text('Tooltip text', "Here's a Tooltip")}
-          content={{
-            columns: tableColumns,
-            sort: 'DESC',
-          }}
-          values={tableData}
-          onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
-          size={size}
-        />
-      </div>
-    );
-  })
-  .add('size - large-wide with tooltip', () => {
-    const size = CARD_SIZES.LARGEWIDE;
-    return (
-      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
-        <TableCard
-          title={text('title', 'Open Alerts')}
-          id="table-list"
-          tooltip={text('Tooltip text', "X-Large Card's Tooltip")}
-          content={{
-            columns: tableColumns,
-          }}
-          values={tableData}
-          onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
-          size={size}
-        />
-      </div>
-    );
-  })
   .add('table with multiple actions', () => {
     const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
@@ -110,24 +73,28 @@ storiesOf('Watson IoT/TableCard', module)
         icon: 'bee',
         color: 'black',
         label: 'Pressure Sev',
+        showLabel: boolean('Show Pressure Threshold Label', true),
       },
       {
         dataSourceId: 'count',
         comparison: '<',
         value: 5,
         severity: 3, // High threshold, medium, or low used for sorting and defined filtration
+        showLabel: boolean('Show Count Threshold Labels', true),
       },
       {
         dataSourceId: 'count',
         comparison: '>=',
         value: 10,
         severity: 1, // High threshold, medium, or low used for sorting and defined filtration
+        showLabel: boolean('Show Count Threshold Labels', true),
       },
       {
         dataSourceId: 'count',
         comparison: '=',
         value: 7,
         severity: 2, // High threshold, medium, or low used for sorting and defined filtration
+        showLabel: boolean('Show Count Threshold Labels', true),
       },
     ];
 
@@ -175,6 +142,11 @@ storiesOf('Watson IoT/TableCard', module)
               <span>Unknown</span>
             )
           }
+          i18n={{
+            criticalLabel: text('Critical Label', 'Critical'),
+            moderateLabel: text('Moderate Label', 'Moderate'),
+            lowLabel: text('Low Label', 'Low'),
+          }}
         />
       </div>
     );
@@ -191,6 +163,7 @@ storiesOf('Watson IoT/TableCard', module)
           comparison: '<',
           value: 5,
           severity: 3, // High threshold, medium, or low used for sorting and defined filtration
+          showLabel: boolean('Show Count Threshold Labels', true),
         },
         {
           dataSourceId: 'count',
@@ -198,12 +171,14 @@ storiesOf('Watson IoT/TableCard', module)
           value: 10,
           severity: 1, // High threshold, medium, or low used for sorting and defined filtration
           label: 'Count Sev',
+          showLabel: boolean('Show Count Threshold Labels', true),
         },
         {
           dataSourceId: 'count',
           comparison: '=',
           value: 7,
           severity: 2, // High threshold, medium, or low used for sorting and defined filtration
+          showLabel: boolean('Show Count Threshold Labels', true),
         },
         {
           dataSourceId: 'pressure',
@@ -211,6 +186,7 @@ storiesOf('Watson IoT/TableCard', module)
           value: 10,
           severity: 1,
           label: 'Pressure Sev',
+          showLabel: boolean('Show Pressure Threshold Label', true),
         },
       ];
 
@@ -227,6 +203,11 @@ storiesOf('Watson IoT/TableCard', module)
             values={tableData}
             onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
             size={size}
+            i18n={{
+              criticalLabel: text('Critical Label', 'Critical'),
+              moderateLabel: text('Moderate Label', 'Moderate'),
+              lowLabel: text('Low Label', 'Low'),
+            }}
           />
         </div>
       );
@@ -263,6 +244,7 @@ storiesOf('Watson IoT/TableCard', module)
           comparison: '<',
           value: 5,
           severity: 3, // High threshold, medium, or low used for sorting and defined filtration
+          showLabel: boolean('Show Count Threshold Labels', true),
         },
         {
           dataSourceId: 'count',
@@ -270,12 +252,14 @@ storiesOf('Watson IoT/TableCard', module)
           value: 10,
           severity: 1, // High threshold, medium, or low used for sorting and defined filtration
           label: 'Count Sev',
+          showLabel: boolean('Show Count Threshold Labels', true),
         },
         {
           dataSourceId: 'count',
           comparison: '=',
           value: 7,
           severity: 2, // High threshold, medium, or low used for sorting and defined filtration
+          showLabel: boolean('Show Count Threshold Labels', true),
         },
         {
           dataSourceId: 'pressure',
@@ -284,6 +268,7 @@ storiesOf('Watson IoT/TableCard', module)
           severity: 1,
           label: 'Pressure Sev',
           showOnContent: true,
+          showLabel: boolean('Show Pressure Threshold Label', true),
         },
       ];
 
@@ -300,6 +285,11 @@ storiesOf('Watson IoT/TableCard', module)
             values={tableData}
             onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
             size={size}
+            i18n={{
+              criticalLabel: text('Critical Label', 'Critical'),
+              moderateLabel: text('Moderate Label', 'Moderate'),
+              lowLabel: text('Low Label', 'Low'),
+            }}
           />
         </div>
       );
@@ -312,6 +302,48 @@ storiesOf('Watson IoT/TableCard', module)
       },
     }
   )
+  .add('with matching thresholds', () => {
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
+    return (
+      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+        <TableCard
+          title={text('title', 'Open Alerts')}
+          id="table-list"
+          tooltip={text('Tooltip text', "Here's a Tooltip")}
+          content={{
+            columns: tableColumns,
+            expandedRows: [{}],
+            thresholds: [
+              {
+                dataSourceId: 'count',
+                comparison: '>',
+                value: 0,
+                severity: 3,
+                label: 'Severity',
+                showLabel: boolean('Show Count Threshold Labels', true),
+              },
+              {
+                dataSourceId: 'count',
+                comparison: '>',
+                value: 2,
+                severity: 1,
+                label: 'Severity',
+                showLabel: boolean('Show Count Threshold Labels', true),
+              },
+            ],
+          }}
+          values={tableData.map(i => ({ id: i.id, values: i.values }))}
+          onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
+          size={size}
+          i18n={{
+            criticalLabel: text('Critical Label', 'Critical'),
+            moderateLabel: text('Moderate Label', 'Moderate'),
+            lowLabel: text('Low Label', 'Low'),
+          }}
+        />
+      </div>
+    );
+  })
   .add('table with custom column sort', () => {
     const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 
@@ -388,7 +420,7 @@ storiesOf('Watson IoT/TableCard', module)
     );
   })
   .add('no row actions', () => {
-    const size = CARD_SIZES.LARGE;
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -407,7 +439,7 @@ storiesOf('Watson IoT/TableCard', module)
     );
   })
   .add('empty table', () => {
-    const size = CARD_SIZES.LARGE;
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -425,7 +457,7 @@ storiesOf('Watson IoT/TableCard', module)
     );
   })
   .add('editable', () => {
-    const size = CARD_SIZES.LARGE;
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -445,7 +477,7 @@ storiesOf('Watson IoT/TableCard', module)
     );
   })
   .add('editable with expanded rows', () => {
-    const size = CARD_SIZES.LARGE;
+    const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 
     return (
       <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
@@ -465,29 +497,7 @@ storiesOf('Watson IoT/TableCard', module)
       </div>
     );
   })
-  .add('with matching thresholds', () => {
-    const size = CARD_SIZES.LARGE;
-    return (
-      <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
-        <TableCard
-          title={text('title', 'Open Alerts')}
-          id="table-list"
-          tooltip={text('Tooltip text', "Here's a Tooltip")}
-          content={{
-            columns: tableColumns,
-            expandedRows: [{}],
-            thresholds: [
-              { dataSourceId: 'count', comparison: '>', value: 0, severity: 3, label: 'Severity' },
-              { dataSourceId: 'count', comparison: '>', value: 2, severity: 1, label: 'Severity' },
-            ],
-          }}
-          values={tableData.map(i => ({ id: i.id, values: i.values }))}
-          onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
-          size={size}
-        />
-      </div>
-    );
-  })
+
   .add('i18n', () => {
     const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGEWIDE);
 

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -72,29 +72,35 @@ storiesOf('Watson IoT/TableCard', module)
         severity: 1,
         icon: 'bee',
         color: 'black',
-        label: 'Pressure Sev',
-        showLabel: boolean('Show Pressure Threshold Label', true),
-      },
-      {
-        dataSourceId: 'count',
-        comparison: '<',
-        value: 5,
-        severity: 3, // High threshold, medium, or low used for sorting and defined filtration
-        showLabel: boolean('Show Count Threshold Labels', true),
+        label: text('Custom Pressure Severity Header', 'Custom Pressure Severity Header'),
+        showSeverityLabel: boolean('Show Pressure Threshold Label', true),
+        severityLabel: text('Custom Pressure Critical Label', null),
       },
       {
         dataSourceId: 'count',
         comparison: '>=',
         value: 10,
         severity: 1, // High threshold, medium, or low used for sorting and defined filtration
-        showLabel: boolean('Show Count Threshold Labels', true),
+        label: text('Custom Count Severity Header', null),
+        showSeverityLabel: boolean('Show Count Threshold Labels', true),
+        severityLabel: text('Custom Count Critical Label', 'Custom Critical'),
       },
       {
         dataSourceId: 'count',
         comparison: '=',
         value: 7,
         severity: 2, // High threshold, medium, or low used for sorting and defined filtration
-        showLabel: boolean('Show Count Threshold Labels', true),
+        showSeverityLabel: boolean('Show Count Threshold Labels', true),
+        severityLabel: text('Custom Count Moderate Label', null),
+      },
+      {
+        dataSourceId: 'pressure',
+        comparison: '>=',
+        value: 10,
+        severity: 1,
+        label: 'Custom Pressure Severity Header',
+        showSeverityLabel: boolean('Show Pressure Threshold Label', true),
+        severityLabel: text('Custom Pressure Critical Label', null),
       },
     ];
 
@@ -142,11 +148,6 @@ storiesOf('Watson IoT/TableCard', module)
               <span>Unknown</span>
             )
           }
-          i18n={{
-            criticalLabel: text('Critical Label', 'Critical'),
-            moderateLabel: text('Moderate Label', 'Moderate'),
-            lowLabel: text('Low Label', 'Low'),
-          }}
         />
       </div>
     );
@@ -163,30 +164,34 @@ storiesOf('Watson IoT/TableCard', module)
           comparison: '<',
           value: 5,
           severity: 3, // High threshold, medium, or low used for sorting and defined filtration
-          showLabel: boolean('Show Count Threshold Labels', true),
+          label: text('Custom Count Severity Header', null),
+          showSeverityLabel: boolean('Show Count Threshold Labels', true),
+          severityLabel: text('Custom Count Low Label', null),
         },
         {
           dataSourceId: 'count',
           comparison: '>=',
           value: 10,
           severity: 1, // High threshold, medium, or low used for sorting and defined filtration
-          label: 'Count Sev',
-          showLabel: boolean('Show Count Threshold Labels', true),
+          showSeverityLabel: boolean('Show Count Threshold Labels', true),
+          severityLabel: text('Custom Count Critical Label', 'Custom Critical'),
         },
         {
           dataSourceId: 'count',
           comparison: '=',
           value: 7,
           severity: 2, // High threshold, medium, or low used for sorting and defined filtration
-          showLabel: boolean('Show Count Threshold Labels', true),
+          showSeverityLabel: boolean('Show Count Threshold Labels', true),
+          severityLabel: text('Custom Count Moderate Label', null),
         },
         {
           dataSourceId: 'pressure',
           comparison: '>=',
           value: 10,
           severity: 1,
-          label: 'Pressure Sev',
-          showLabel: boolean('Show Pressure Threshold Label', true),
+          label: text('Custom Pressure Severity Header', 'Custom Pressure Severity Header'),
+          showSeverityLabel: boolean('Show Pressure Threshold Label', true),
+          severityLabel: text('Custom Pressure Critical Label', null),
         },
       ];
 
@@ -203,11 +208,6 @@ storiesOf('Watson IoT/TableCard', module)
             values={tableData}
             onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
             size={size}
-            i18n={{
-              criticalLabel: text('Critical Label', 'Critical'),
-              moderateLabel: text('Moderate Label', 'Moderate'),
-              lowLabel: text('Low Label', 'Low'),
-            }}
           />
         </div>
       );
@@ -244,31 +244,34 @@ storiesOf('Watson IoT/TableCard', module)
           comparison: '<',
           value: 5,
           severity: 3, // High threshold, medium, or low used for sorting and defined filtration
-          showLabel: boolean('Show Count Threshold Labels', true),
+          label: text('Custom Count Severity Header', null),
+          showSeverityLabel: boolean('Show Count Threshold Labels', true),
+          severityLabel: text('Custom Count Low Label', null),
         },
         {
           dataSourceId: 'count',
           comparison: '>=',
           value: 10,
           severity: 1, // High threshold, medium, or low used for sorting and defined filtration
-          label: 'Count Sev',
-          showLabel: boolean('Show Count Threshold Labels', true),
+          showSeverityLabel: boolean('Show Count Threshold Labels', true),
+          severityLabel: text('Custom Count Critical Label', 'Custom Critical'),
         },
         {
           dataSourceId: 'count',
           comparison: '=',
           value: 7,
           severity: 2, // High threshold, medium, or low used for sorting and defined filtration
-          showLabel: boolean('Show Count Threshold Labels', true),
+          showSeverityLabel: boolean('Show Count Threshold Labels', true),
+          severityLabel: text('Custom Count Moderate Label', null),
         },
         {
           dataSourceId: 'pressure',
           comparison: '>=',
           value: 10,
           severity: 1,
-          label: 'Pressure Sev',
-          showOnContent: true,
-          showLabel: boolean('Show Pressure Threshold Label', true),
+          label: text('Custom Pressure Severity Header', null),
+          showSeverityLabel: boolean('Show Pressure Threshold Label', true),
+          severityLabel: text('Custom Pressure Critical Label', null),
         },
       ];
 
@@ -285,11 +288,6 @@ storiesOf('Watson IoT/TableCard', module)
             values={tableData}
             onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
             size={size}
-            i18n={{
-              criticalLabel: text('Critical Label', 'Critical'),
-              moderateLabel: text('Moderate Label', 'Moderate'),
-              lowLabel: text('Low Label', 'Low'),
-            }}
           />
         </div>
       );
@@ -319,27 +317,23 @@ storiesOf('Watson IoT/TableCard', module)
                 comparison: '>',
                 value: 0,
                 severity: 3,
-                label: 'Severity',
-                showLabel: boolean('Show Count Threshold Labels', true),
+                label: text('Custom Count Severity Header', null),
+                showSeverityLabel: boolean('Show Count Threshold Labels', true),
+                severityLabel: text('Custom Count Low Label', null),
               },
               {
                 dataSourceId: 'count',
                 comparison: '>',
                 value: 2,
                 severity: 1,
-                label: 'Severity',
-                showLabel: boolean('Show Count Threshold Labels', true),
+                showSeverityLabel: boolean('Show Count Threshold Labels', true),
+                severityLabel: text('Custom Count Critical Label', null),
               },
             ],
           }}
           values={tableData.map(i => ({ id: i.id, values: i.values }))}
           onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
           size={size}
-          i18n={{
-            criticalLabel: text('Critical Label', 'Critical'),
-            moderateLabel: text('Moderate Label', 'Moderate'),
-            lowLabel: text('Low Label', 'Low'),
-          }}
         />
       </div>
     );
@@ -514,7 +508,6 @@ storiesOf('Watson IoT/TableCard', module)
         comparison: '>=',
         value: 10,
         severity: 1, // High threshold, medium, or low used for sorting and defined filtration
-        label: 'Count Sev',
       },
       {
         dataSourceId: 'count',
@@ -527,7 +520,6 @@ storiesOf('Watson IoT/TableCard', module)
         comparison: '>=',
         value: 10,
         severity: 1,
-        label: 'Pressure Sev',
       },
     ];
 

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -74,14 +74,14 @@ storiesOf('Watson IoT/TableCard', module)
         color: 'black',
         label: text('Custom Pressure Severity Header', 'Custom Pressure Severity Header'),
         showSeverityLabel: boolean('Show Pressure Threshold Label', true),
-        severityLabel: text('Custom Pressure Critical Label', null),
+        severityLabel: text('Custom Pressure Critical Label', ''),
       },
       {
         dataSourceId: 'count',
         comparison: '>=',
         value: 10,
         severity: 1, // High threshold, medium, or low used for sorting and defined filtration
-        label: text('Custom Count Severity Header', null),
+        label: text('Custom Count Severity Header', ''),
         showSeverityLabel: boolean('Show Count Threshold Labels', true),
         severityLabel: text('Custom Count Critical Label', 'Custom Critical'),
       },
@@ -91,7 +91,7 @@ storiesOf('Watson IoT/TableCard', module)
         value: 7,
         severity: 2, // High threshold, medium, or low used for sorting and defined filtration
         showSeverityLabel: boolean('Show Count Threshold Labels', true),
-        severityLabel: text('Custom Count Moderate Label', null),
+        severityLabel: text('Custom Count Moderate Label', ''),
       },
       {
         dataSourceId: 'pressure',
@@ -100,7 +100,7 @@ storiesOf('Watson IoT/TableCard', module)
         severity: 1,
         label: 'Custom Pressure Severity Header',
         showSeverityLabel: boolean('Show Pressure Threshold Label', true),
-        severityLabel: text('Custom Pressure Critical Label', null),
+        severityLabel: text('Custom Pressure Critical Label', ''),
       },
     ];
 
@@ -164,9 +164,9 @@ storiesOf('Watson IoT/TableCard', module)
           comparison: '<',
           value: 5,
           severity: 3, // High threshold, medium, or low used for sorting and defined filtration
-          label: text('Custom Count Severity Header', null),
+          label: text('Custom Count Severity Header', ''),
           showSeverityLabel: boolean('Show Count Threshold Labels', true),
-          severityLabel: text('Custom Count Low Label', null),
+          severityLabel: text('Custom Count Low Label', ''),
         },
         {
           dataSourceId: 'count',
@@ -182,7 +182,7 @@ storiesOf('Watson IoT/TableCard', module)
           value: 7,
           severity: 2, // High threshold, medium, or low used for sorting and defined filtration
           showSeverityLabel: boolean('Show Count Threshold Labels', true),
-          severityLabel: text('Custom Count Moderate Label', null),
+          severityLabel: text('Custom Count Moderate Label', ''),
         },
         {
           dataSourceId: 'pressure',
@@ -191,7 +191,7 @@ storiesOf('Watson IoT/TableCard', module)
           severity: 1,
           label: text('Custom Pressure Severity Header', 'Custom Pressure Severity Header'),
           showSeverityLabel: boolean('Show Pressure Threshold Label', true),
-          severityLabel: text('Custom Pressure Critical Label', null),
+          severityLabel: text('Custom Pressure Critical Label', ''),
         },
       ];
 
@@ -244,9 +244,9 @@ storiesOf('Watson IoT/TableCard', module)
           comparison: '<',
           value: 5,
           severity: 3, // High threshold, medium, or low used for sorting and defined filtration
-          label: text('Custom Count Severity Header', null),
+          label: text('Custom Count Severity Header', ''),
           showSeverityLabel: boolean('Show Count Threshold Labels', true),
-          severityLabel: text('Custom Count Low Label', null),
+          severityLabel: text('Custom Count Low Label', ''),
         },
         {
           dataSourceId: 'count',
@@ -262,16 +262,16 @@ storiesOf('Watson IoT/TableCard', module)
           value: 7,
           severity: 2, // High threshold, medium, or low used for sorting and defined filtration
           showSeverityLabel: boolean('Show Count Threshold Labels', true),
-          severityLabel: text('Custom Count Moderate Label', null),
+          severityLabel: text('Custom Count Moderate Label', ''),
         },
         {
           dataSourceId: 'pressure',
           comparison: '>=',
           value: 10,
           severity: 1,
-          label: text('Custom Pressure Severity Header', null),
+          label: text('Custom Pressure Severity Header', ''),
           showSeverityLabel: boolean('Show Pressure Threshold Label', true),
-          severityLabel: text('Custom Pressure Critical Label', null),
+          severityLabel: text('Custom Pressure Critical Label', ''),
         },
       ];
 
@@ -317,9 +317,9 @@ storiesOf('Watson IoT/TableCard', module)
                 comparison: '>',
                 value: 0,
                 severity: 3,
-                label: text('Custom Count Severity Header', null),
+                label: text('Custom Count Severity Header', ''),
                 showSeverityLabel: boolean('Show Count Threshold Labels', true),
-                severityLabel: text('Custom Count Low Label', null),
+                severityLabel: text('Custom Count Low Label', ''),
               },
               {
                 dataSourceId: 'count',
@@ -327,7 +327,7 @@ storiesOf('Watson IoT/TableCard', module)
                 value: 2,
                 severity: 1,
                 showSeverityLabel: boolean('Show Count Threshold Labels', true),
-                severityLabel: text('Custom Count Critical Label', null),
+                severityLabel: text('Custom Count Critical Label', ''),
               },
             ],
           }}

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -189,10 +189,6 @@ describe('TableCard', () => {
     expect(wrapper2.find('TableCell .myCustomRenderedCell').length).toBe(0);
   });
   test('threshold colums should render in correct column regardless of order', () => {
-    const tableCustomColumns = tableColumns.map(item =>
-      item.dataSourceId === 'count' ? { ...item, precision: 1 } : { ...item }
-    );
-
     // The pressure header comes after the count header, but the ordering should not matter when
     // it comes to rendering the threshold columns
     const customThresholds = [
@@ -209,19 +205,19 @@ describe('TableCard', () => {
         dataSourceId: 'count',
         comparison: '<',
         value: 5,
-        severity: 3, // High threshold, medium, or low used for sorting and defined filtration
+        severity: 3,
       },
       {
         dataSourceId: 'count',
         comparison: '>=',
         value: 10,
-        severity: 1, // High threshold, medium, or low used for sorting and defined filtration
+        severity: 1,
       },
       {
         dataSourceId: 'count',
         comparison: '=',
         value: 7,
-        severity: 2, // High threshold, medium, or low used for sorting and defined filtration
+        severity: 2,
       },
     ];
     const { getByTitle, queryByTitle } = render(
@@ -229,26 +225,8 @@ describe('TableCard', () => {
         id="table-list"
         title="Open Alerts"
         content={{
-          columns: tableCustomColumns,
+          columns: tableColumns,
           thresholds: customThresholds,
-          expandedRows: [
-            {
-              id: 'long_description',
-              label: 'Description',
-            },
-            {
-              id: 'other_description',
-              label: 'Other Description',
-            },
-            {
-              id: 'pressure',
-              label: 'Pressure',
-            },
-            {
-              id: 'temperature',
-              label: 'Temperature',
-            },
-          ],
         }}
         values={tableData}
         size={CARD_SIZES.LARGEWIDE}
@@ -259,5 +237,47 @@ describe('TableCard', () => {
     expect(getByTitle('Count Severity')).toBeInTheDocument();
     expect(queryByTitle('Pressure Severity')).not.toBeInTheDocument();
     expect(getByTitle('Pressure Sev')).toBeInTheDocument();
+  });
+  test('threshold icon labels should not display when showLabel is false', () => {
+    const customThresholds = [
+      {
+        dataSourceId: 'pressure',
+        comparison: '>=',
+        value: 10,
+        severity: 1,
+      },
+      {
+        dataSourceId: 'count',
+        comparison: '<',
+        value: 5,
+        severity: 3,
+        showLabel: false,
+      },
+      {
+        dataSourceId: 'count',
+        comparison: '=',
+        value: 7,
+        severity: 2,
+        showLabel: false,
+      },
+    ];
+    const { queryByText, queryAllByText } = render(
+      <TableCard
+        id="table-list"
+        title="Open Alerts"
+        content={{
+          columns: tableColumns,
+          thresholds: customThresholds,
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGEWIDE}
+      />
+    );
+
+    // The Pressure threshold is the only threshold that has a 'Critical' severity
+    // and doesn't have showLabel: false, so it should be the only severity text to appear
+    expect(queryAllByText(/Critical/g)).toHaveLength(3);
+    expect(queryByText(/Moderate/g)).not.toBeInTheDocument();
+    expect(queryByText(/Low/g)).not.toBeInTheDocument();
   });
 });

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -238,7 +238,7 @@ describe('TableCard', () => {
     expect(queryByTitle('Pressure Severity')).not.toBeInTheDocument();
     expect(getByTitle('Pressure Sev')).toBeInTheDocument();
   });
-  test('threshold icon labels should not display when showLabel is false', () => {
+  test('threshold icon labels should not display when showSeverityLabel is false', () => {
     const customThresholds = [
       {
         dataSourceId: 'pressure',
@@ -251,14 +251,62 @@ describe('TableCard', () => {
         comparison: '<',
         value: 5,
         severity: 3,
-        showLabel: false,
+        showSeverityLabel: false,
       },
       {
         dataSourceId: 'count',
         comparison: '=',
         value: 7,
         severity: 2,
-        showLabel: false,
+        showSeverityLabel: false,
+      },
+    ];
+    const { queryByText, queryAllByText } = render(
+      <TableCard
+        id="table-list"
+        title="Open Alerts"
+        content={{
+          columns: tableColumns,
+          thresholds: customThresholds,
+          expandedRows: [
+            {
+              id: 'pressure',
+              label: 'Pressure',
+            },
+          ],
+        }}
+        values={tableData}
+        size={CARD_SIZES.LARGEWIDE}
+      />
+    );
+
+    // The Pressure threshold is the only threshold that has a 'Critical' severity
+    // and doesn't have showSeverityLabel: false, so it should be the only severity text to appear
+    expect(queryAllByText(/Critical/g)).toHaveLength(3);
+    expect(queryByText(/Moderate/g)).not.toBeInTheDocument();
+    expect(queryByText(/Low/g)).not.toBeInTheDocument();
+  });
+  test('threshold icon label should not display default strings', () => {
+    const customThresholds = [
+      {
+        dataSourceId: 'pressure',
+        comparison: '>=',
+        value: 10,
+        severity: 1,
+      },
+      {
+        dataSourceId: 'count',
+        comparison: '<',
+        value: 5,
+        severity: 3,
+        severityLabel: 'Lowest',
+      },
+      {
+        dataSourceId: 'count',
+        comparison: '=',
+        value: 7,
+        severity: 2,
+        severityLabel: 'Medium',
       },
     ];
     const { queryByText, queryAllByText } = render(
@@ -270,14 +318,17 @@ describe('TableCard', () => {
           thresholds: customThresholds,
         }}
         values={tableData}
-        size={CARD_SIZES.LARGEWIDE}
+        size={CARD_SIZES.LARGETHIN}
       />
     );
 
-    // The Pressure threshold is the only threshold that has a 'Critical' severity
-    // and doesn't have showLabel: false, so it should be the only severity text to appear
-    expect(queryAllByText(/Critical/g)).toHaveLength(3);
-    expect(queryByText(/Moderate/g)).not.toBeInTheDocument();
-    expect(queryByText(/Low/g)).not.toBeInTheDocument();
+    // Critical should exist as that is the only threshold that doesn't have custom label text
+    expect(queryAllByText(/^Critical$/g)).toHaveLength(3);
+    // These are default labels, so they should not exist
+    expect(queryByText(/^Moderate$/g)).not.toBeInTheDocument();
+    expect(queryByText(/^Low$/g)).not.toBeInTheDocument();
+    // These are the custom labels that should appear instead of the defaults above
+    expect(queryAllByText(/^Medium$/g)).toHaveLength(1);
+    expect(queryAllByText(/^Lowest$/g)).toHaveLength(5);
   });
 });

--- a/src/components/TableCard/ThresholdIcon.jsx
+++ b/src/components/TableCard/ThresholdIcon.jsx
@@ -21,8 +21,10 @@ const propTypes = {
     moderateLabel: PropTypes.string,
     lowLabel: PropTypes.string,
   }).isRequired,
-  /** Optionally hides the threshold's label */
-  showLabel: PropTypes.bool,
+  /** Optionally shows threshold severity label text. Shows by default */
+  showSeverityLabel: PropTypes.bool,
+  /** Optionally changes threshold severity label text */
+  severityLabel: PropTypes.string,
   /** optional function that returns an icon node for an icon name */
   renderIconByName: PropTypes.func,
 };
@@ -32,11 +34,21 @@ const defaultProps = {
   title: null,
   icon: null,
   color: null,
-  showLabel: true,
+  showSeverityLabel: true,
+  severityLabel: null,
   renderIconByName: null,
 };
 
-const ThresholdIcon = ({ severity, strings, title, icon, color, showLabel, renderIconByName }) => {
+const ThresholdIcon = ({
+  severity,
+  strings,
+  title,
+  icon,
+  color,
+  showSeverityLabel,
+  severityLabel,
+  renderIconByName,
+}) => {
   let iconToRender;
   let stringToRender = '';
 
@@ -131,8 +143,10 @@ const ThresholdIcon = ({ severity, strings, title, icon, color, showLabel, rende
   return (
     <div className={`${iotPrefix}--threshold-icon--wrapper`} title={title}>
       {iconToRender}
-      {showLabel ? (
-        <span className={`${iotPrefix}--threshold-icon--text`}>{stringToRender}</span>
+      {showSeverityLabel ? (
+        <span className={`${iotPrefix}--threshold-icon--text`}>
+          {severityLabel || stringToRender}
+        </span>
       ) : null}
     </div>
   );

--- a/src/components/TableCard/ThresholdIcon.jsx
+++ b/src/components/TableCard/ThresholdIcon.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
+import { settings } from '../../constants/Settings';
 import CardIcon from '../ImageCard/CardIcon';
 
-const StyledIconDiv = styled.div`
-  display: flex;
-`;
-
-const StyledSpan = styled.span`
-  margin-left: 5px;
-`;
+const { iotPrefix } = settings;
 
 const propTypes = {
   /** severities will determine which default icon to use if another icon name isn't provided */
@@ -27,6 +21,8 @@ const propTypes = {
     moderateLabel: PropTypes.string,
     lowLabel: PropTypes.string,
   }).isRequired,
+  /** Optionally hides the threshold's label */
+  showLabel: PropTypes.bool,
   /** optional function that returns an icon node for an icon name */
   renderIconByName: PropTypes.func,
 };
@@ -36,10 +32,11 @@ const defaultProps = {
   title: null,
   icon: null,
   color: null,
+  showLabel: true,
   renderIconByName: null,
 };
 
-const ThresholdIcon = ({ severity, strings, title, icon, color, renderIconByName }) => {
+const ThresholdIcon = ({ severity, strings, title, icon, color, showLabel, renderIconByName }) => {
   let iconToRender;
   let stringToRender = '';
 
@@ -132,10 +129,12 @@ const ThresholdIcon = ({ severity, strings, title, icon, color, renderIconByName
     default:
   }
   return (
-    <StyledIconDiv title={title}>
+    <div className={`${iotPrefix}--threshold-icon--wrapper`} title={title}>
       {iconToRender}
-      <StyledSpan>{stringToRender}</StyledSpan>
-    </StyledIconDiv>
+      {showLabel ? (
+        <span className={`${iotPrefix}--threshold-icon--text`}>{stringToRender}</span>
+      ) : null}
+    </div>
   );
 };
 

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -4418,9 +4418,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           className="bx--table-header-label"
                         >
                           <span
-                            title="Pressure Sev"
+                            title="Pressure __Severity__"
                           >
-                            Pressure Sev
+                            Pressure __Severity__
                           </span>
                         </span>
                         <svg
@@ -16620,6 +16620,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
+                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -16967,9 +16968,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           className="bx--table-header-label"
                         >
                           <span
-                            title="Pressure Sev"
+                            title="Custom Pressure Severity Header"
                           >
-                            Pressure Sev
+                            Custom Pressure Severity Header
                           </span>
                         </span>
                         <svg
@@ -17707,7 +17708,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           <span
                             className="iot--threshold-icon--text"
                           >
-                            Critical
+                            Custom Critical
                           </span>
                         </div>
                       </span>
@@ -18486,7 +18487,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           <span
                             className="iot--threshold-icon--text"
                           >
-                            Critical
+                            Custom Critical
                           </span>
                         </div>
                       </span>
@@ -19143,6 +19144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
+                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -19421,9 +19423,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           className="bx--table-header-label"
                         >
                           <span
-                            title="Pressure Sev"
+                            title="Pressure Severity"
                           >
-                            Pressure Sev
+                            Pressure Severity
                           </span>
                         </span>
                         <svg
@@ -19531,6 +19533,230 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       data-column="iconColumn-pressure"
                       data-offset={0}
                       id="cell-table-for-card-table-list-row-11-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 2 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI005 Asset failure"
+                        >
+                          AHI005 Asset failure
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 1.2039201932 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-iconColumn-pressure"
                       offset={0}
                     >
                       <span
@@ -19742,7 +19968,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           <span
                             className="iot--threshold-icon--text"
                           >
-                            Critical
+                            Custom Critical
                           </span>
                         </div>
                       </span>
@@ -19803,6 +20029,293 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           </span>
                         </div>
                       </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 7 = 7"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <path
+                                  d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
+                                  fill="#FC7B1E"
+                                  id="background-color"
+                                />
+                                <path
+                                  d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Moderate
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
+                    </td>
+                  </tr>
+                  <tr
+                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
+                    onClick={[Function]}
+                  >
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-alert"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-hour"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <span
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-count"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-iconColumn-count"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      >
+                        <div
+                          className="iot--threshold-icon--wrapper"
+                          title="count: 0 < 5"
+                        >
+                          <svg
+                            height="16px"
+                            version="1.1"
+                            viewBox="0 0 16 16"
+                            width="16px"
+                          >
+                            <g
+                              fill="none"
+                              fillRule="evenodd"
+                              id="Artboard-Copy"
+                              stroke="none"
+                              strokeWidth="1"
+                            >
+                              <g
+                                id="Group"
+                              >
+                                <path
+                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                  fill="#FFFFFF"
+                                  id="outline-color"
+                                />
+                                <circle
+                                  cx="8"
+                                  cy="8"
+                                  fill="#FDD13A"
+                                  id="background-color"
+                                  r="7"
+                                />
+                                <path
+                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                  fill="#FFFFFF"
+                                  id="symbol-color"
+                                />
+                              </g>
+                            </g>
+                          </svg>
+                          <span
+                            className="iot--threshold-icon--text"
+                          >
+                            Low
+                          </span>
+                        </div>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
+                      data-column="iconColumn-pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-iconColumn-pressure"
+                      offset={0}
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
+                      />
                     </td>
                   </tr>
                   <tr
@@ -20054,7 +20567,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           <span
                             className="iot--threshold-icon--text"
                           >
-                            Critical
+                            Custom Critical
                           </span>
                         </div>
                       </span>
@@ -20209,7 +20722,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <span
                   className="bx--pagination__text"
                 >
-                  1–5 of 5 items
+                  1–10 of 11 items
                 </span>
               </div>
               <div
@@ -20225,7 +20738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       className="bx--label bx--visually-hidden"
                       htmlFor="bx-pagination-select-25"
                     >
-                      Page number, of 1 pages
+                      Page number, of 2 pages
                     </label>
                     <div
                       className="bx--select-input--inline__wrapper"
@@ -20247,6 +20760,14 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             value={1}
                           >
                             1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
                           </option>
                         </select>
                         <svg
@@ -20275,7 +20796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 <span
                   className="bx--pagination__text"
                 >
-                  1 of 1 pages
+                  1 of 2 pages
                 </span>
                 <button
                   aria-label="Previous page"
@@ -20305,8 +20826,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                 </button>
                 <button
                   aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward bx--pagination__button--no-index"
-                  disabled={true}
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
                   onClick={[Function]}
                   type="button"
                 >
@@ -20649,6 +21170,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
+                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -21000,9 +21522,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           className="bx--table-header-label"
                         >
                           <span
-                            title="Pressure Sev"
+                            title="Custom Pressure Severity Header"
                           >
-                            Pressure Sev
+                            Custom Pressure Severity Header
                           </span>
                         </span>
                         <svg
@@ -21326,54 +21848,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 2 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
+                      />
                     </td>
                     <td
                       align="start"
@@ -21510,54 +21985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.2 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
+                      />
                     </td>
                     <td
                       align="start"
@@ -21694,54 +22122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.1 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
+                      />
                     </td>
                     <td
                       align="start"
@@ -21920,7 +22301,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           <span
                             className="iot--threshold-icon--text"
                           >
-                            Critical
+                            Custom Critical
                           </span>
                         </div>
                       </span>
@@ -22414,54 +22795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 0 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
+                      />
                     </td>
                     <td
                       align="start"
@@ -22598,54 +22932,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
-                        >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
-                          >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
-                            >
-                              <g
-                                id="Group"
-                              >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
-                              </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
-                      </span>
+                      />
                     </td>
                     <td
                       align="start"
@@ -22859,7 +23146,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           <span
                             className="iot--threshold-icon--text"
                           >
-                            Critical
+                            Custom Critical
                           </span>
                         </div>
                       </span>
@@ -23506,6 +23793,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
+                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -23546,15 +23834,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     type="button"
                   >
                     <svg
-                      aria-hidden={true}
+                      description="Expand to fullscreen"
                       focusable="false"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
+                      role="img"
                       style={
                         Object {
                           "willChange": "transform",
                         }
                       }
+                      title="Expand to fullscreen"
                       viewBox="0 0 32 32"
                       width={20}
                       xmlns="http://www.w3.org/2000/svg"
@@ -23677,9 +23967,9 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           className="bx--table-header-label"
                         >
                           <span
-                            title="Severity"
+                            title="Count Severity"
                           >
-                            Severity
+                            Count Severity
                           </span>
                         </span>
                         <svg

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -1159,8 +1159,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-30"
-                  id="bx-pagination-select-30-count-label"
+                  htmlFor="bx-pagination-select-29"
+                  id="bx-pagination-select-29-count-label"
                 >
                   Items per page:
                 </label>
@@ -1179,7 +1179,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={10}
                         >
@@ -1248,7 +1248,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-32"
+                      htmlFor="bx-pagination-select-31"
                     >
                       Page number, of 1 pages
                     </label>
@@ -1261,7 +1261,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-31"
                           onChange={[Function]}
                           value={1}
                         >
@@ -2910,8 +2910,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-31"
-                  id="bx-pagination-select-31-count-label"
+                  htmlFor="bx-pagination-select-30"
+                  id="bx-pagination-select-30-count-label"
                 >
                   Items per page:
                 </label>
@@ -2930,7 +2930,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
+                          id="bx-pagination-select-30"
                           onChange={[Function]}
                           value={10}
                         >
@@ -2999,7 +2999,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-33"
+                      htmlFor="bx-pagination-select-32"
                     >
                       Page number, of 1 pages
                     </label>
@@ -3012,7 +3012,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33"
+                          id="bx-pagination-select-32"
                           onChange={[Function]}
                           value={1}
                         >
@@ -4674,7 +4674,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 2 < 5"
                         >
                           <svg
@@ -4714,7 +4714,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -4822,7 +4822,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.2039201932 < 5"
                         >
                           <svg
@@ -4862,7 +4862,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -4970,7 +4970,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.10329291 < 5"
                         >
                           <svg
@@ -5010,7 +5010,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -5118,7 +5118,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 30 >= 10"
                         >
                           <svg
@@ -5156,7 +5156,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -5211,7 +5211,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 68 >= 10"
                         >
                           <svg
@@ -5249,7 +5249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -5410,7 +5410,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 7 = 7"
                         >
                           <svg
@@ -5448,7 +5448,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Moderate
                           </span>
@@ -5556,7 +5556,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 0 < 5"
                         >
                           <svg
@@ -5596,7 +5596,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -5704,7 +5704,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 3 < 5"
                         >
                           <svg
@@ -5744,7 +5744,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -5799,7 +5799,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -5837,7 +5837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -5897,7 +5897,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 10 >= 10"
                         >
                           <svg
@@ -5935,7 +5935,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -5990,7 +5990,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -6028,7 +6028,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -6071,8 +6071,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-33"
-                  id="bx-pagination-select-33-count-label"
+                  htmlFor="bx-pagination-select-31"
+                  id="bx-pagination-select-31-count-label"
                 >
                   Items per page:
                 </label>
@@ -6091,7 +6091,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33"
+                          id="bx-pagination-select-31"
                           onChange={[Function]}
                           value={10}
                         >
@@ -6160,7 +6160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-35"
+                      htmlFor="bx-pagination-select-33"
                     >
                       Page number, of 2 pages
                     </label>
@@ -6173,7 +6173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-35"
+                          id="bx-pagination-select-33"
                           onChange={[Function]}
                           value={1}
                         >
@@ -7492,8 +7492,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-29"
-                  id="bx-pagination-select-29-count-label"
+                  htmlFor="bx-pagination-select-28"
+                  id="bx-pagination-select-28-count-label"
                 >
                   Items per page:
                 </label>
@@ -7512,7 +7512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7581,7 +7581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-31"
+                      htmlFor="bx-pagination-select-30"
                     >
                       Page number, of 2 pages
                     </label>
@@ -7594,3069 +7594,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23L11 16 19 9 19 23z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9L21 16 13 23 13 9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard size - large 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "520px",
-        }
-      }
-    >
-      <div
-        className="iot--card--wrapper"
-        data-testid="Card"
-        id="table-list"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "624px",
-          }
-        }
-      >
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "576px",
-            }
-          }
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions iot--table-batch-actions"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-table-for-card-table-list"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-              >
-                <div
-                  className="iot--table-toolbar-search"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex="-1"
-                >
-                  <div
-                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    role="search"
-                    tabIndex="0"
-                  >
-                    <div
-                      className="bx--search bx--search--sm table-toolbar-search"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="bx--search-magnifier"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                        />
-                      </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="table-for-card-table-list-toolbar-search"
-                      >
-                        Search
-                      </label>
-                      <input
-                        aria-hidden={true}
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="table-for-card-table-list-toolbar-search"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        placeholder="Search"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="download-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Download table content"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
-                    />
-                    <path
-                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="filter-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="iot--card--toolbar"
-                >
-                  <div
-                    className="iot--card--toolbar-date-range-wrapper"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="iot--card--toolbar-action iot--card--toolbar-date-range-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
-                      title="Open and close list of options"
-                    >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={20}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                        />
-                        <path
-                          d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                  <button
-                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <svg
-                      description="Expand to fullscreen"
-                      focusable="false"
-                      height={20}
-                      preserveAspectRatio="xMidYMid meet"
-                      role="img"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      title="Expand to fullscreen"
-                      viewBox="0 0 32 32"
-                      width={20}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M28 4H10a2.006 2.006 0 0 0-2 2v14a2.006 2.006 0 0 0 2 2h18a2.006 2.006 0 0 0 2-2V6a2.006 2.006 0 0 0-2-2zm0 16H10V6h18z"
-                      />
-                      <path
-                        d="M18 26H4V16h2v-2H4a2.006 2.006 0 0 0-2 2v10a2.006 2.006 0 0 0 2 2h14a2.006 2.006 0 0 0 2-2v-2h-2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <table
-                className="bx--data-table bx--data-table--no-border"
-                title={null}
-              >
-                <thead
-                  onMouseMove={null}
-                  onMouseUp={null}
-                >
-                  <tr>
-                    <th
-                      aria-sort="descending"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort bx--table-sort--active bx--table-sort--ascending"
-                        data-column="alert"
-                        id="column-alert"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Alert"
-                          >
-                            Alert
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Unsort rows by this header"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Unsort rows by this header"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="hour"
-                        id="column-hour"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Hour"
-                          >
-                            Hour
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="pressure"
-                        id="column-pressure"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Pressure"
-                          >
-                            Pressure
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody
-                  aria-live="polite"
-                >
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI005 Asset failure"
-                        >
-                          AHI005 Asset failure
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI003 process need to optimize adjust X variables"
-                        >
-                          AHI003 process need to optimize adjust X variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={2}
-                        >
-                          2
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize."
-                        >
-                          AHI001 proccess need to optimize.
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={68}
-                        >
-                          68
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize"
-                        >
-                          AHI001 proccess need to optimize
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              disabled={false}
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-19"
-                  id="bx-pagination-select-19-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-19"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-21"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-21"
-                          onChange={[Function]}
-                          value={1}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={1}
-                          >
-                            1
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={2}
-                          >
-                            2
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1 of 2 pages
-                </span>
-                <button
-                  aria-label="Previous page"
-                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
-                  disabled={true}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M19 23L11 16 19 9 19 23z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Next page"
-                  className="bx--pagination__button bx--pagination__button--forward"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    focusable="false"
-                    height={24}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={24}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 9L21 16 13 23 13 9z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard size - large-wide with tooltip 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "1056px",
-        }
-      }
-    >
-      <div
-        className="iot--card--wrapper"
-        data-testid="Card"
-        id="table-list"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "624px",
-          }
-        }
-      >
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "576px",
-            }
-          }
-        >
-          <div
-            className="TableCard__StyledStatefulTable-q9l5bz-2 iOfQgZ iot--table-container bx--data-table-container"
-          >
-            <section
-              aria-label="data table toolbar"
-              className="bx--table-toolbar"
-            >
-              <div
-                className="bx--batch-actions iot--table-batch-actions"
-              >
-                <div
-                  className="bx--action-list"
-                >
-                  <button
-                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-                <div
-                  className="bx--batch-summary"
-                >
-                  <p
-                    className="bx--batch-summary__para"
-                  >
-                    <span>
-                      0 item selected
-                    </span>
-                  </p>
-                </div>
-              </div>
-              <label
-                className="iot--table-toolbar-secondary-title"
-              >
-                Open Alerts
-              </label>
-              <div
-                className="iot--table-tooltip-container"
-              >
-                <div
-                  className="bx--tooltip__label"
-                  id="card-tooltip-trigger-table-for-card-table-list"
-                >
-                  
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    className="bx--tooltip__trigger"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      description={null}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      role={null}
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
-                      }
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
-                      />
-                      <path
-                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="bx--toolbar-content iot--table-toolbar-content"
-              >
-                <div
-                  className="iot--table-toolbar-search"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex="-1"
-                >
-                  <div
-                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    role="search"
-                    tabIndex="0"
-                  >
-                    <div
-                      className="bx--search bx--search--sm table-toolbar-search"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="bx--search-magnifier"
-                        focusable="false"
-                        height={16}
-                        preserveAspectRatio="xMidYMid meet"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
-                        />
-                      </svg>
-                      <label
-                        className="bx--label"
-                        htmlFor="table-for-card-table-list-toolbar-search"
-                      >
-                        Search
-                      </label>
-                      <input
-                        aria-hidden={true}
-                        autoComplete="off"
-                        className="bx--search-input"
-                        id="table-for-card-table-list-toolbar-search"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        placeholder="Search"
-                        role="searchbox"
-                        type="text"
-                        value=""
-                      />
-                      <button
-                        aria-label="Clear search input"
-                        className="bx--search-close bx--search-close--hidden"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M12 4.7L11.3 4 8 7.3 4.7 4 4 4.7 7.3 8 4 11.3 4.7 12 8 8.7 11.3 12 12 11.3 8.7 8z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="download-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Download table content"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M26 15l-1.41-1.41L17 21.17V2h-2v19.17l-7.59-7.58L6 15l10 10 10-10z"
-                    />
-                    <path
-                      d="M26 24v4H6v-4H4v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="iot--tooltip-svg-wrapper"
-                  data-testid="filter-button"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                  tabIndex={0}
-                >
-                  <svg
-                    aria-hidden={true}
-                    description="Filters"
-                    focusable="false"
-                    height={20}
-                    preserveAspectRatio="xMidYMid meet"
-                    style={
-                      Object {
-                        "willChange": "transform",
-                      }
-                    }
-                    viewBox="0 0 32 32"
-                    width={20}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M18 28h-4a2 2 0 0 1-2-2v-7.59L4.59 11A2 2 0 0 1 4 9.59V6a2 2 0 0 1 2-2h20a2 2 0 0 1 2 2v3.59a2 2 0 0 1-.59 1.41L20 18.41V26a2 2 0 0 1-2 2zM6 6v3.59l8 8V26h4v-8.41l8-8V6z"
-                    />
-                  </svg>
-                </div>
-                <div
-                  className="iot--card--toolbar"
-                >
-                  <div
-                    className="iot--card--toolbar-date-range-wrapper"
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      aria-label="Menu"
-                      className="iot--card--toolbar-action iot--card--toolbar-date-range-action bx--overflow-menu"
-                      onClick={[Function]}
-                      onClose={[Function]}
-                      onKeyDown={[Function]}
-                      open={false}
-                      tabIndex={0}
-                      title="Open and close list of options"
-                    >
-                      <svg
-                        aria-label="open and close list of options"
-                        className="bx--overflow-menu__icon"
-                        focusable="false"
-                        height={20}
-                        onClick={[Function]}
-                        onKeyDown={[Function]}
-                        preserveAspectRatio="xMidYMid meet"
-                        role="img"
-                        style={
-                          Object {
-                            "willChange": "transform",
-                          }
-                        }
-                        viewBox="0 0 32 32"
-                        width={20}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M21 30a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm0-14a6 6 0 1 0 6 6 6 6 0 0 0-6-6z"
-                        />
-                        <path
-                          d="M22.59 25L20 22.41V18h2v3.59l2 2L22.59 25z"
-                        />
-                        <path
-                          d="M28 6a2 2 0 0 0-2-2h-4V2h-2v2h-8V2h-2v2H6a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h4v-2H6V6h4v2h2V6h8v2h2V6h4v6h2z"
-                        />
-                        <title>
-                          open and close list of options
-                        </title>
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </section>
-            <div
-              className="addons-iot-table-container"
-            >
-              <table
-                className="bx--data-table bx--data-table--no-border"
-                title={null}
-              >
-                <thead
-                  onMouseMove={null}
-                  onMouseUp={null}
-                >
-                  <tr>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="alert"
-                        id="column-alert"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Alert"
-                          >
-                            Alert
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="count"
-                        id="column-count"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Count"
-                          >
-                            Count
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="hour"
-                        id="column-hour"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Hour"
-                          >
-                            Hour
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                    <th
-                      aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
-                      scope="col"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
-                    >
-                      <button
-                        align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
-                        data-column="pressure"
-                        id="column-pressure"
-                        onClick={[Function]}
-                        width=""
-                      >
-                        <span
-                          className="bx--table-header-label"
-                        >
-                          <span
-                            title="Pressure"
-                          >
-                            Pressure
-                          </span>
-                        </span>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M16 4L6 14l1.41 1.41L15 7.83V30h2V7.83l7.59 7.58L26 14 16 4z"
-                          />
-                        </svg>
-                        <svg
-                          aria-label="Sort rows by this header in ascending order"
-                          className="bx--table-sort__icon-unsorted"
-                          focusable="false"
-                          height={20}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 32 32"
-                          width={20}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M26.59 20.59L23 24.17V4h-2v20.17l-3.59-3.58L16 22l6 6 6-6-1.41-1.41zM10 4l-6 6 1.41 1.41L9 7.83V28h2V7.83l3.59 3.58L16 10l-6-6z"
-                          />
-                        </svg>
-                      </button>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody
-                  aria-live="polite"
-                >
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-11-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1}
-                        >
-                          1
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI010 proccess need to optimize adjust Y variables"
-                        >
-                          AHI010 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={2}
-                        >
-                          2
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-10-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI005 Asset failure"
-                        >
-                          AHI005 Asset failure
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1.2039201932}
-                        >
-                          1.2039201932
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-1-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI003 process need to optimize adjust X variables"
-                        >
-                          AHI003 process need to optimize adjust X variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={1.10329291}
-                        >
-                          1.10329291
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-2-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={2}
-                        >
-                          2
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize."
-                        >
-                          AHI001 proccess need to optimize.
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={30}
-                        >
-                          30
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-6-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={68}
-                        >
-                          68
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={5}
-                        >
-                          5
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-4-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={7}
-                        >
-                          7
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-8-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-9-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={0}
-                        >
-                          0
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize adjust Y variables"
-                        >
-                          AHI001 proccess need to optimize adjust Y variables
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={3}
-                        >
-                          3
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-3-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr
-                    className="TableBodyRow__StyledTableRow-sc-103itxu-0 isjrOb"
-                    onClick={[Function]}
-                  >
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="alert"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-alert"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="AHI001 proccess need to optimize"
-                        >
-                          AHI001 proccess need to optimize
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="count"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-count"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="hour"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-hour"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title="10/28/2018 07:34"
-                        >
-                          10/28/2018 07:34
-                        </span>
-                      </span>
-                    </td>
-                    <td
-                      align="start"
-                      className="data-table-start TableBodyRow__StyledTableCellRow-sc-103itxu-5 jsPLxS"
-                      data-column="pressure"
-                      data-offset={0}
-                      id="cell-table-for-card-table-list-row-5-pressure"
-                      offset={0}
-                    >
-                      <span
-                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
-                      >
-                        <span
-                          title={10}
-                        >
-                          10
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div
-              className="bx--pagination iot--pagination iot--pagination--hide-page"
-              disabled={false}
-              style={
-                Object {
-                  "--pagination-text-display": "flex",
-                }
-              }
-            >
-              <div
-                className="bx--pagination__left"
-              >
-                <label
-                  className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-20"
-                  id="bx-pagination-select-20-count-label"
-                >
-                  Items per page:
-                </label>
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__item-count"
-                  >
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-20"
-                          onChange={[Function]}
-                          value={10}
-                        >
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={10}
-                          >
-                            10
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={25}
-                          >
-                            25
-                          </option>
-                          <option
-                            className="bx--select-option"
-                            disabled={false}
-                            hidden={false}
-                            value={100}
-                          >
-                            100
-                          </option>
-                        </select>
-                        <svg
-                          aria-hidden={true}
-                          className="bx--select__arrow"
-                          focusable="false"
-                          height={16}
-                          preserveAspectRatio="xMidYMid meet"
-                          style={
-                            Object {
-                              "willChange": "transform",
-                            }
-                          }
-                          viewBox="0 0 16 16"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <span
-                  className="bx--pagination__text"
-                >
-                  1–10 of 11 items
-                </span>
-              </div>
-              <div
-                className="bx--pagination__right"
-              >
-                <div
-                  className="bx--form-item"
-                >
-                  <div
-                    className="bx--select bx--select--inline bx--select__page-number"
-                  >
-                    <label
-                      className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-22"
-                    >
-                      Page number, of 2 pages
-                    </label>
-                    <div
-                      className="bx--select-input--inline__wrapper"
-                    >
-                      <div
-                        className="bx--select-input__wrapper"
-                        data-invalid={null}
-                      >
-                        <select
-                          className="bx--select-input"
-                          id="bx-pagination-select-22"
+                          id="bx-pagination-select-30"
                           onChange={[Function]}
                           value={1}
                         >
@@ -12195,8 +9133,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-26"
-                  id="bx-pagination-select-26-count-label"
+                  htmlFor="bx-pagination-select-25"
+                  id="bx-pagination-select-25-count-label"
                 >
                   Items per page:
                 </label>
@@ -12215,7 +9153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={10}
                         >
@@ -12284,7 +9222,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-28"
+                      htmlFor="bx-pagination-select-27"
                     >
                       Page number, of 2 pages
                     </label>
@@ -12297,7 +9235,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={1}
                         >
@@ -13616,8 +10554,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-27"
-                  id="bx-pagination-select-27-count-label"
+                  htmlFor="bx-pagination-select-26"
+                  id="bx-pagination-select-26-count-label"
                 >
                   Items per page:
                 </label>
@@ -13636,7 +10574,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13705,7 +10643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-29"
+                      htmlFor="bx-pagination-select-28"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13718,7 +10656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-29"
+                          id="bx-pagination-select-28"
                           onChange={[Function]}
                           value={1}
                         >
@@ -15630,8 +12568,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-21"
-                  id="bx-pagination-select-21-count-label"
+                  htmlFor="bx-pagination-select-19"
+                  id="bx-pagination-select-19-count-label"
                 >
                   Items per page:
                 </label>
@@ -15650,7 +12588,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-21"
+                          id="bx-pagination-select-19"
                           onChange={[Function]}
                           value={10}
                         >
@@ -15719,7 +12657,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-23"
+                      htmlFor="bx-pagination-select-21"
                     >
                       Page number, of 2 pages
                     </label>
@@ -15732,7 +12670,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23"
+                          id="bx-pagination-select-21"
                           onChange={[Function]}
                           value={1}
                         >
@@ -17415,8 +14353,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-28"
-                  id="bx-pagination-select-28-count-label"
+                  htmlFor="bx-pagination-select-27"
+                  id="bx-pagination-select-27-count-label"
                 >
                   Items per page:
                 </label>
@@ -17435,7 +14373,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-28"
+                          id="bx-pagination-select-27"
                           onChange={[Function]}
                           value={10}
                         >
@@ -17504,7 +14442,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-30"
+                      htmlFor="bx-pagination-select-29"
                     >
                       Page number, of 2 pages
                     </label>
@@ -17517,7 +14455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-30"
+                          id="bx-pagination-select-29"
                           onChange={[Function]}
                           value={1}
                         >
@@ -19159,8 +16097,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-22"
-                  id="bx-pagination-select-22-count-label"
+                  htmlFor="bx-pagination-select-20"
+                  id="bx-pagination-select-20-count-label"
                 >
                   Items per page:
                 </label>
@@ -19179,7 +16117,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-22"
+                          id="bx-pagination-select-20"
                           onChange={[Function]}
                           value={10}
                         >
@@ -19248,7 +16186,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-24"
+                      htmlFor="bx-pagination-select-22"
                     >
                       Page number, of 2 pages
                     </label>
@@ -19261,7 +16199,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-22"
                           onChange={[Function]}
                           value={1}
                         >
@@ -19682,7 +16620,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
-                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -20286,7 +17223,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 2 < 5"
                         >
                           <svg
@@ -20326,7 +17263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -20434,7 +17371,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.2039201932 < 5"
                         >
                           <svg
@@ -20474,7 +17411,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -20582,7 +17519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.10329291 < 5"
                         >
                           <svg
@@ -20622,7 +17559,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -20730,7 +17667,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 30 >= 10"
                         >
                           <svg
@@ -20768,7 +17705,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -20823,7 +17760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 68 >= 10"
                         >
                           <svg
@@ -20861,7 +17798,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -21022,7 +17959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 7 = 7"
                         >
                           <svg
@@ -21060,7 +17997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Moderate
                           </span>
@@ -21168,7 +18105,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 0 < 5"
                         >
                           <svg
@@ -21208,7 +18145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -21316,7 +18253,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 3 < 5"
                         >
                           <svg
@@ -21356,7 +18293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -21411,7 +18348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -21449,7 +18386,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -21509,7 +18446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 10 >= 10"
                         >
                           <svg
@@ -21547,7 +18484,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -21602,7 +18539,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -21640,7 +18577,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -21683,8 +18620,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-24"
-                  id="bx-pagination-select-24-count-label"
+                  htmlFor="bx-pagination-select-22"
+                  id="bx-pagination-select-22-count-label"
                 >
                   Items per page:
                 </label>
@@ -21703,7 +18640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-24"
+                          id="bx-pagination-select-22"
                           onChange={[Function]}
                           value={10}
                         >
@@ -21772,7 +18709,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-26"
+                      htmlFor="bx-pagination-select-24"
                     >
                       Page number, of 2 pages
                     </label>
@@ -21785,7 +18722,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-26"
+                          id="bx-pagination-select-24"
                           onChange={[Function]}
                           value={1}
                         >
@@ -22206,7 +19143,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
-                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -22654,7 +19590,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.10329291 < 5"
                         >
                           <svg
@@ -22694,7 +19630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -22766,7 +19702,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 30 >= 10"
                         >
                           <svg
@@ -22804,7 +19740,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -22823,7 +19759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 68 >= 10"
                         >
                           <svg
@@ -22861,7 +19797,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -22921,7 +19857,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 3 < 5"
                         >
                           <svg
@@ -22961,7 +19897,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -22980,7 +19916,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -23018,7 +19954,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -23078,7 +20014,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 10 >= 10"
                         >
                           <svg
@@ -23116,7 +20052,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -23135,7 +20071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -23173,7 +20109,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -23198,8 +20134,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-25"
-                  id="bx-pagination-select-25-count-label"
+                  htmlFor="bx-pagination-select-23"
+                  id="bx-pagination-select-23-count-label"
                 >
                   Items per page:
                 </label>
@@ -23218,7 +20154,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-23"
                           onChange={[Function]}
                           value={10}
                         >
@@ -23287,7 +20223,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-27"
+                      htmlFor="bx-pagination-select-25"
                     >
                       Page number, of 1 pages
                     </label>
@@ -23300,7 +20236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-27"
+                          id="bx-pagination-select-25"
                           onChange={[Function]}
                           value={1}
                         >
@@ -23713,7 +20649,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
-                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -24393,7 +21328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 2 < 5"
                         >
                           <svg
@@ -24433,7 +21368,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -24577,7 +21512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.2 < 5"
                         >
                           <svg
@@ -24617,7 +21552,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -24761,7 +21696,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.1 < 5"
                         >
                           <svg
@@ -24801,7 +21736,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -24945,7 +21880,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 30 >= 10"
                         >
                           <svg
@@ -24983,7 +21918,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -25038,7 +21973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 68 >= 10"
                         >
                           <svg
@@ -25066,7 +22001,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </title>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -25299,7 +22234,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 7 = 7"
                         >
                           <svg
@@ -25337,7 +22272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Moderate
                           </span>
@@ -25481,7 +22416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 0 < 5"
                         >
                           <svg
@@ -25521,7 +22456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -25665,7 +22600,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 3 < 5"
                         >
                           <svg
@@ -25705,7 +22640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -25760,7 +22695,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -25788,7 +22723,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </title>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -25884,7 +22819,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 10 >= 10"
                         >
                           <svg
@@ -25922,7 +22857,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -25977,7 +22912,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="pressure: 10 >= 10"
                         >
                           <svg
@@ -26005,7 +22940,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </title>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -26048,8 +22983,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-23"
-                  id="bx-pagination-select-23-count-label"
+                  htmlFor="bx-pagination-select-21"
+                  id="bx-pagination-select-21-count-label"
                 >
                   Items per page:
                 </label>
@@ -26068,7 +23003,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-23"
+                          id="bx-pagination-select-21"
                           onChange={[Function]}
                           value={10}
                         >
@@ -26137,7 +23072,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-25"
+                      htmlFor="bx-pagination-select-23"
                     >
                       Page number, of 2 pages
                     </label>
@@ -26150,7 +23085,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-25"
+                          id="bx-pagination-select-23"
                           onChange={[Function]}
                           value={1}
                         >
@@ -26571,7 +23506,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       onKeyDown={[Function]}
                       open={false}
                       tabIndex={0}
-                      title="Open and close list of options"
                     >
                       <svg
                         aria-label="open and close list of options"
@@ -26612,17 +23546,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     type="button"
                   >
                     <svg
-                      description="Expand to fullscreen"
+                      aria-hidden={true}
                       focusable="false"
                       height={20}
                       preserveAspectRatio="xMidYMid meet"
-                      role="img"
                       style={
                         Object {
                           "willChange": "transform",
                         }
                       }
-                      title="Expand to fullscreen"
                       viewBox="0 0 32 32"
                       width={20}
                       xmlns="http://www.w3.org/2000/svg"
@@ -27005,7 +23937,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 5 > 2"
                         >
                           <svg
@@ -27043,7 +23975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -27157,7 +24089,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 2 > 0"
                         >
                           <svg
@@ -27197,7 +24129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -27311,7 +24243,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.2039201932 > 0"
                         >
                           <svg
@@ -27351,7 +24283,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -27465,7 +24397,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 1.10329291 > 0"
                         >
                           <svg
@@ -27505,7 +24437,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Low
                           </span>
@@ -27619,7 +24551,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 30 > 2"
                         >
                           <svg
@@ -27657,7 +24589,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -27771,7 +24703,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 5 > 2"
                         >
                           <svg
@@ -27809,7 +24741,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -27923,7 +24855,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 7 > 2"
                         >
                           <svg
@@ -27961,7 +24893,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -28182,7 +25114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 3 > 2"
                         >
                           <svg
@@ -28220,7 +25152,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -28334,7 +25266,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-6 NDiCc"
                       >
                         <div
-                          className="ThresholdIcon__StyledIconDiv-b3qqh-0 bmeCxW"
+                          className="iot--threshold-icon--wrapper"
                           title="count: 10 > 2"
                         >
                           <svg
@@ -28372,7 +25304,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             </g>
                           </svg>
                           <span
-                            className="ThresholdIcon__StyledSpan-b3qqh-1 MyTmw"
+                            className="iot--threshold-icon--text"
                           >
                             Critical
                           </span>
@@ -28433,8 +25365,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-32"
-                  id="bx-pagination-select-32-count-label"
+                  htmlFor="bx-pagination-select-24"
+                  id="bx-pagination-select-24-count-label"
                 >
                   Items per page:
                 </label>
@@ -28453,7 +25385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-24"
                           onChange={[Function]}
                           value={10}
                         >
@@ -28522,7 +25454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-34"
+                      htmlFor="bx-pagination-select-26"
                     >
                       Page number, of 2 pages
                     </label>
@@ -28535,7 +25467,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34"
+                          id="bx-pagination-select-26"
                           onChange={[Function]}
                           value={1}
                         >

--- a/src/components/TableCard/_threshold-icon.scss
+++ b/src/components/TableCard/_threshold-icon.scss
@@ -1,0 +1,10 @@
+@import '~carbon-components/scss/globals/scss/vars';
+@import '../../globals/vars';
+
+.#{$iot-prefix}--threshold-icon--wrapper {
+  display: flex;
+}
+
+.#{$iot-prefix}--threshold-icon--text {
+  margin-left: $spacing-02;
+}

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -136,8 +136,13 @@ export const TableCardPropTypes = {
         severity: PropTypes.oneOf([1, 2, 3]),
         /** optional overrides for color and icon */
         color: PropTypes.string,
+        /** Custom threshold icon name */
         icon: PropTypes.string,
+        /** Custom threshold label text */
         label: PropTypes.string,
+        /** Shows threshold label next to icon */
+        showLabel: PropTypes.bool,
+        /** Shows column when there is no data */
         showOnContent: PropTypes.bool,
       })
     ),

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -140,8 +140,10 @@ export const TableCardPropTypes = {
         icon: PropTypes.string,
         /** Custom threshold label text */
         label: PropTypes.string,
-        /** Shows threshold label next to icon */
-        showLabel: PropTypes.bool,
+        /** Optionally shows threshold severity label text. Shows by default */
+        showSeverityLabel: PropTypes.bool,
+        /** Optionally changes threshold severity label text */
+        severityLabel: PropTypes.string,
         /** Shows column when there is no data */
         showOnContent: PropTypes.bool,
       })

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -231,6 +231,7 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/Table/pagination';
 @import 'components/Table/TableToolbarSearch/table-toolbar-search';
 @import 'components/Table/table';
+@import 'components/TableCard/threshold-icon';
 @import 'components/Button/button';
 @import 'components/SimplePagination/simple-pagination';
 @import 'components/GaugeCard/gauge-card';

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9524,10 +9524,13 @@ Map {
                         ],
                         "type": "oneOf",
                       },
-                      "showLabel": Object {
-                        "type": "bool",
+                      "severityLabel": Object {
+                        "type": "string",
                       },
                       "showOnContent": Object {
+                        "type": "bool",
+                      },
+                      "showSeverityLabel": Object {
                         "type": "bool",
                       },
                       "value": Object {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -9524,6 +9524,9 @@ Map {
                         ],
                         "type": "oneOf",
                       },
+                      "showLabel": Object {
+                        "type": "bool",
+                      },
                       "showOnContent": Object {
                         "type": "bool",
                       },


### PR DESCRIPTION
Closes #1032 

**Summary**

- There was previously no way to customize the label strings or hide the label strings completely. This PR enables both of those use-cases

![Screen Shot 2020-03-23 at 1 19 58 PM](https://user-images.githubusercontent.com/25177649/77349473-10127600-6d09-11ea-909b-c0c8b94676cd.png)

**Change List (commits, features, bugs, etc)**

- added `showSeverityLabel` boolean prop that optionally hides the label text
- added `severityLabel` string prop that allows for custom strings to be rendered in place of the default *Critical, Moderate, Low* labels
- added tests for each use case
- added knobs for both props to all threshold stories
- added universal knobs to all TableCard stories
- removed 2 redundant stories
- converted `ThresholdIcons` styled-component to scss

**Acceptance Test (how to verify the PR)**

- Go to each threshold story and use the knobs to verify that both use-cases work
