### PR TITLE
fix(table): column ordering slow

### DIFF
--- a/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
@@ -44,7 +44,7 @@ describe('TableHead', () => {
     const dropTarget = wrapper.find("DropTarget(ColumnHeaderSelect)[columnId='col2']").instance();
     backend.simulateBeginDrag([dragSource.getHandlerId()]);
     backend.simulateHover([dropTarget.getHandlerId()]);
-    backend.simulateEndDrag();
+    backend.simulateDrop();
     expect(commonTableHeadProps.onChangeOrdering).toHaveBeenCalled();
   });
   it('does not reorder columns when placed upon themselves', () => {
@@ -54,7 +54,7 @@ describe('TableHead', () => {
     const dropTarget = wrapper.find("DropTarget(ColumnHeaderSelect)[columnId='col1']").instance();
     backend.simulateBeginDrag([dragSource.getHandlerId()]);
     backend.simulateHover([dropTarget.getHandlerId()]);
-    backend.simulateEndDrag();
+    backend.simulateDrop();
     expect(commonTableHeadProps.onChangeOrdering).toHaveBeenCalledWith([
       { columnId: 'col2', isHidden: false },
       { columnId: 'col1', isHidden: false },

--- a/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
@@ -12,11 +12,13 @@ const ColumnHeaderSelect = ({
   isHidden,
   children,
   onClick,
+  isOver,
 }) => {
   return (
     <Button
       className={classNames('column-header__btn', 'column-header__select', {
         'column-header__select--hidden': isHidden,
+        'column-header__select--isOver': isOver,
       })}
       kind="secondary"
       key={columnId}

--- a/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
@@ -66,7 +66,7 @@ const cardSource = {
 };
 
 const cardTarget = {
-  hover(props, monitor) {
+  drop(props, monitor) {
     const dragIndex = monitor.getItem().index;
     const hoverIndex = props.index;
     // Don't replace items with themselves

--- a/src/components/Table/TableHead/_table-head.scss
+++ b/src/components/Table/TableHead/_table-head.scss
@@ -25,6 +25,11 @@
     opacity: 0.5;
   }
 
+  .column-header__select--isOver {
+    border-color: $focus;
+    box-shadow: inset 0 0 0 1px $gray-10;
+  }
+
   .lightweight {
     tr:last-of-type {
       th {


### PR DESCRIPTION
Closes #1006

**Summary**
The table updates “realtime” while the user is dragging a column and it can cause sluggish and buggy behaviour because of all the processing that is going on per render.

**Change List (commits, features, bugs, etc)**
- Update the columns on drop instead of hover
- Updated unit tests

**Acceptance Test (how to verify the PR)**
- Try to reorder columns and verify that nothing changes (visually nor onChangeOrdering) until the column is dropped.
