### PR TITLE
Migrate TileCatalog to scss

### DIFF
--- a/src/components/TileCatalog/TileCatalog.jsx
+++ b/src/components/TileCatalog/TileCatalog.jsx
@@ -92,7 +92,7 @@ const TileCatalog = ({
   const totalTiles = pagination && pagination.totalItems ? pagination.totalItems : 10;
 
   return (
-    <div className={classNames(`${iotPrefix}--tile-catalog`, className)}>
+    <div className={classNames(className, `${iotPrefix}--tile-catalog`)}>
       <div className={`${iotPrefix}--tile-catalog--header`}>
         {search && search.placeHolderText ? (
           <TableToolbarSearch

--- a/src/components/TileCatalog/TileCatalog.jsx
+++ b/src/components/TileCatalog/TileCatalog.jsx
@@ -1,53 +1,17 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 import { RadioTile, Tile, SkeletonText, DataTable } from 'carbon-components-react';
 import Bee32 from '@carbon/icons-react/lib/bee/32';
+import classNames from 'classnames';
 
 import SimplePagination from '../SimplePagination/SimplePagination';
-import { COLORS } from '../../styles/styles';
+import { settings } from '../../constants/Settings';
 
 import TileGroup from './TileGroup';
 
+const { iotPrefix } = settings;
+
 const { TableToolbarSearch } = DataTable;
-
-const StyledContainerDiv = styled.div`
-  display: flex;
-  flex-flow: column nowrap;
-`;
-
-const StyledCatalogHeader = styled.div`
-  background: ${COLORS.gray10};
-
-  display: flex;
-  height: 3rem;
-
-  .bx--toolbar-action:active:not([disabled]) {
-    outline-color: transparent;
-  }
-
-  .bx--toolbar-search-container-expandable {
-    max-width: 40%;
-    padding: 0;
-    width: auto;
-  }
-
-  .bx--search-input:focus {
-    width: 100%;
-  }
-`;
-
-const StyledEmptyTile = styled(Tile)`
-  &&& {
-    display: flex;
-    flex-flow: column nowrap;
-    align-items: center;
-    justify-content: center;
-    > * {
-      padding-bottom: 0.5rem;
-    }
-  }
-`;
 
 export const propTypes = {
   /** Is the data actively loading? */
@@ -128,8 +92,8 @@ const TileCatalog = ({
   const totalTiles = pagination && pagination.totalItems ? pagination.totalItems : 10;
 
   return (
-    <StyledContainerDiv className={className}>
-      <StyledCatalogHeader>
+    <div className={classNames(`${iotPrefix}--tile-catalog`, className)}>
+      <div className={`${iotPrefix}--tile-catalog--header`}>
         {search && search.placeHolderText ? (
           <TableToolbarSearch
             size="sm"
@@ -140,13 +104,13 @@ const TileCatalog = ({
             id={`${id}-searchbox`}
           />
         ) : null}
-      </StyledCatalogHeader>
+      </div>
       {isLoading ? ( // generate empty tiles for first page
         <TileGroup
           tiles={[...Array(pageSize)].map((val, index) => (
-            <StyledEmptyTile key={`emptytile-${index}`}>
+            <Tile className={`${iotPrefix}--tile-catalog--empty-tile`} key={`emptytile-${index}`}>
               <SkeletonText />
-            </StyledEmptyTile>
+            </Tile>
           ))}
           totalTiles={totalTiles}
         />
@@ -169,19 +133,19 @@ const TileCatalog = ({
           ))}
         />
       ) : (
-        <StyledEmptyTile>
+        <Tile className={`${iotPrefix}--tile-catalog--empty-tile`}>
           {error || (
             <Fragment>
               <Bee32 />
               <p>{(search && search.noMatchesFoundText) || 'No matches found'}</p>
             </Fragment>
           )}
-        </StyledEmptyTile>
+        </Tile>
       )}
       {!isLoading && tiles.length > 0 && !error && pagination ? (
         <SimplePagination {...pagination} maxPage={Math.ceil(totalTiles / pageSize)} />
       ) : null}
-    </StyledContainerDiv>
+    </div>
   );
 };
 TileCatalog.propTypes = propTypes;

--- a/src/components/TileCatalog/TileCatalog.test.jsx
+++ b/src/components/TileCatalog/TileCatalog.test.jsx
@@ -8,11 +8,11 @@ describe('TileCatalog tests', () => {
   test('error prop', () => {
     // If we have data, never show the error state
     const wrapper = shallow(<TileCatalog {...commonTileCatalogProps} error="In error state" />);
-    expect(wrapper.find('TileCatalog__StyledEmptyTile')).toHaveLength(0);
+    expect(wrapper.find('.iot--tile-catalog--empty-tile')).toHaveLength(0);
     // If we have empty data then show the error state
     const wrapper2 = shallow(
       <TileCatalog {...commonTileCatalogProps} tiles={[]} error="In error state" />
     );
-    expect(wrapper2.find('TileCatalog__StyledEmptyTile')).toHaveLength(1);
+    expect(wrapper2.find('.iot--tile-catalog--empty-tile')).toHaveLength(1);
   });
 });

--- a/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
+++ b/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
@@ -13,16 +13,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
     }
   >
     <div
-      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+      className="iot--tile-catalog"
     >
       <div
-        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+        className="iot--tile-catalog--header"
       />
       <div
         className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
       >
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -34,7 +34,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -46,7 +46,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -58,7 +58,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -70,7 +70,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -82,7 +82,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -94,7 +94,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -106,7 +106,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -118,7 +118,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -130,7 +130,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -186,10 +186,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
     }
   >
     <div
-      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+      className="iot--tile-catalog"
     >
       <div
-        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+        className="iot--tile-catalog--header"
       />
       <div
         className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
@@ -928,13 +928,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
       }
     >
       <div
-        className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+        className="iot--tile-catalog"
       >
         <div
-          className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+          className="iot--tile-catalog--header"
         />
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           In error state
         </div>
@@ -980,10 +980,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
     }
   >
     <div
-      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+      className="iot--tile-catalog"
     >
       <div
-        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+        className="iot--tile-catalog--header"
       />
       <div
         className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
@@ -1715,16 +1715,16 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
     }
   >
     <div
-      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+      className="iot--tile-catalog"
     >
       <div
-        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+        className="iot--tile-catalog--header"
       />
       <div
         className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
       >
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1736,7 +1736,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1748,7 +1748,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1760,7 +1760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1772,7 +1772,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1784,7 +1784,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1796,7 +1796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1808,7 +1808,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1820,7 +1820,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1832,7 +1832,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
           />
         </div>
         <div
-          className="bx--tile TileCatalog__StyledEmptyTile-sc-1rp8b9f-2 bhInDp"
+          className="bx--tile iot--tile-catalog--empty-tile"
         >
           <p
             className="bx--skeleton__text"
@@ -1888,10 +1888,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
     }
   >
     <div
-      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+      className="iot--tile-catalog"
     >
       <div
-        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+        className="iot--tile-catalog--header"
       />
       <div
         className="TileGroup__StyledTiles-eak4ed-0 bztVSF"
@@ -2581,10 +2581,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
     }
   >
     <div
-      className="TileCatalog__StyledContainerDiv-sc-1rp8b9f-0 gnhFOD"
+      className="iot--tile-catalog"
     >
       <div
-        className="TileCatalog__StyledCatalogHeader-sc-1rp8b9f-1 fcqrLo"
+        className="iot--tile-catalog--header"
       >
         <div
           className="bx--toolbar-action bx--toolbar-search-container-expandable"

--- a/src/components/TileCatalog/_tile-catalog.scss
+++ b/src/components/TileCatalog/_tile-catalog.scss
@@ -1,0 +1,38 @@
+@import '~carbon-components/scss/globals/scss/vars';
+@import '../../globals/vars';
+
+.#{$iot-prefix}--tile-catalog {
+  display: flex;
+  flex-flow: column nowrap;
+}
+
+.#{$iot-prefix}--tile-catalog--header {
+  background: $ui-02;
+
+  display: flex;
+  height: 3rem;
+
+  .bx--toolbar-action:active:not([disabled]) {
+    outline-color: transparent;
+  }
+
+  .bx--toolbar-search-container-expandable {
+    max-width: 40%;
+    padding: 0;
+    width: auto;
+  }
+
+  .bx--search-input:focus {
+    width: 100%;
+  }
+}
+
+.#{$iot-prefix}--tile-catalog--empty-tile {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: center;
+  > * {
+    padding-bottom: 0.5rem;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -241,4 +241,5 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/List/ListItem/list-item';
 @import 'components/List/ListHeader/list-header';
 @import 'components/TileCatalogNew/tile-catalog';
+@import 'components/TileCatalog/tile-catalog';
 @import 'components/ValueCard/value-card';


### PR DESCRIPTION
**Summary**

Migrate TileCatalog to scss from styled components.

**Change List (commits, features, bugs, etc)**

Created an scss file for TileCatalog
Removed StyledComonents from TileCatalog
Updated test to accommodate for new className.

**Acceptance Test (how to verify the PR)**

See that TileCatalog is still styled as expected.
