### PR TITLE
fix(valuecard): data state tooltip opens behind other cards

### DIFF
--- a/src/components/Dashboard/Dashboard.story.jsx
+++ b/src/components/Dashboard/Dashboard.story.jsx
@@ -707,6 +707,14 @@ storiesOf('Watson IoT/Dashboard', module)
             attributes: [{ dataSourceId: 'v', unit: v[2] }],
           },
           values: { v: v[1] },
+          dataState:
+            idx === 5
+              ? {
+                  type: 'NO_DATA',
+                  label: 'No data available for this score at this time',
+                  description: 'The last successful score was 68',
+                }
+              : undefined,
         }))}
       />,
       <Dashboard

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -12114,7 +12114,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   </div>
                 </div>
                 <div
-                  className="react-grid-item cssTransforms iot--card--wrapper"
+                  className="react-grid-item cssTransforms iot--card--wrapper iot--card--wrapper--overflowing"
                   data-testid="Card"
                   id="xsmall-number-5"
                   role="presentation"
@@ -12159,44 +12159,63 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                        size="SMALL"
+                        className="iot--data-state-container"
+                        style={
+                          Object {
+                            "--container-padding": "16px",
+                          }
+                        }
                       >
+                        <p
+                          className="iot--data-state-dashes"
+                        >
+                          --
+                        </p>
                         <div
-                          className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                          label={null}
-                          size="SMALL"
+                          className="iot--data-state-grid"
                         >
                           <div
-                            className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                            color={null}
+                            aria-describedby={null}
+                            aria-haspopup="true"
+                            aria-labelledby="iot--data-state-grid__icon-xsmall-number-5"
+                            className="bx--tooltip__label"
+                            id="iot--data-state-grid__icon-xsmall-number-5"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
-                            <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                              size="SMALL"
-                              title="false "
-                              value={false}
-                            >
-                              <span
-                                className="ValueRenderer__StyledBoolean-f4stpz-2 jHJBse"
-                              >
-                                false
-                              </span>
-                            </span>
-                          </div>
-                          <span
-                            className="iot--value-card__attribute-unit"
-                            style={
-                              Object {
-                                "--default-font-size": "1.25rem",
+                            <svg
+                              aria-hidden={true}
+                              className="iot--data-state-default-warning-icon"
+                              focusable="false"
+                              height={24}
+                              preserveAspectRatio="xMidYMid meet"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
                               }
-                            }
-                          />
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm-.9 5h1.8v8h-1.8V6zm.9 13.2c-.7 0-1.2-.6-1.2-1.2s.6-1.2 1.2-1.2 1.2.6 1.2 1.2-.5 1.2-1.2 1.2z"
+                              />
+                              <path
+                                d="M13.2 18c0 .7-.6 1.2-1.2 1.2s-1.2-.6-1.2-1.2.6-1.2 1.2-1.2 1.2.5 1.2 1.2zm-.3-12h-1.8v8h1.8V6z"
+                                data-icon-path="inner-path"
+                                fill="none"
+                                opacity="0"
+                              />
+                            </svg>
+                          </div>
                         </div>
-                        <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                          size="SMALL"
-                        />
                       </div>
                     </div>
                   </div>
@@ -12783,7 +12802,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                   </div>
                 </div>
                 <div
-                  className="react-grid-item cssTransforms iot--card--wrapper"
+                  className="react-grid-item cssTransforms iot--card--wrapper iot--card--wrapper--overflowing"
                   data-testid="Card"
                   id="xsmall-number-5"
                   role="presentation"
@@ -12828,44 +12847,63 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-                        size="SMALL"
+                        className="iot--data-state-container"
+                        style={
+                          Object {
+                            "--container-padding": "16px",
+                          }
+                        }
                       >
+                        <p
+                          className="iot--data-state-dashes"
+                        >
+                          --
+                        </p>
                         <div
-                          className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                          label={null}
-                          size="SMALL"
+                          className="iot--data-state-grid"
                         >
                           <div
-                            className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
-                            color={null}
+                            aria-describedby={null}
+                            aria-haspopup="true"
+                            aria-labelledby="iot--data-state-grid__icon-xsmall-number-5"
+                            className="bx--tooltip__label"
+                            id="iot--data-state-grid__icon-xsmall-number-5"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            role="button"
+                            tabIndex={0}
                           >
-                            <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                              size="SMALL"
-                              title="false "
-                              value={false}
-                            >
-                              <span
-                                className="ValueRenderer__StyledBoolean-f4stpz-2 jHJBse"
-                              >
-                                false
-                              </span>
-                            </span>
-                          </div>
-                          <span
-                            className="iot--value-card__attribute-unit"
-                            style={
-                              Object {
-                                "--default-font-size": "1.25rem",
+                            <svg
+                              aria-hidden={true}
+                              className="iot--data-state-default-warning-icon"
+                              focusable="false"
+                              height={24}
+                              preserveAspectRatio="xMidYMid meet"
+                              style={
+                                Object {
+                                  "willChange": "transform",
+                                }
                               }
-                            }
-                          />
+                              viewBox="0 0 24 24"
+                              width={24}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm-.9 5h1.8v8h-1.8V6zm.9 13.2c-.7 0-1.2-.6-1.2-1.2s.6-1.2 1.2-1.2 1.2.6 1.2 1.2-.5 1.2-1.2 1.2z"
+                              />
+                              <path
+                                d="M13.2 18c0 .7-.6 1.2-1.2 1.2s-1.2-.6-1.2-1.2.6-1.2 1.2-1.2 1.2.5 1.2 1.2zm-.3-12h-1.8v8h1.8V6z"
+                                data-icon-path="inner-path"
+                                fill="none"
+                                opacity="0"
+                              />
+                            </svg>
+                          </div>
                         </div>
-                        <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                          size="SMALL"
-                        />
                       </div>
                     </div>
                   </div>

--- a/src/components/ValueCard/DataStateRenderer.jsx
+++ b/src/components/ValueCard/DataStateRenderer.jsx
@@ -35,23 +35,14 @@ const DataStateRenderer = ({ dataState, size, id }) => {
 
   const withTooltip = (element, triggerId) => {
     return (
-      <div style={{ position: 'relative' }} data-floating-menu-container>
-        <Tooltip
-          showIcon={false}
-          triggerText={element}
-          triggerId={triggerId}
-          tooltipId={`${triggerId}-tooltip`}
-          menuOffset={menuBody => {
-            const container = menuBody.closest('[data-floating-menu-container]');
-            return {
-              top: -container.getBoundingClientRect().y - window.pageYOffset + 7,
-              left: -container.getBoundingClientRect().x - window.pageXOffset,
-            };
-          }}
-        >
-          <TooltipContent tooltipContent={dataState} />
-        </Tooltip>
-      </div>
+      <Tooltip
+        showIcon={false}
+        triggerText={element}
+        triggerId={triggerId}
+        tooltipId={`${triggerId}-tooltip`}
+      >
+        <TooltipContent tooltipContent={dataState} />
+      </Tooltip>
     );
   };
 

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -73,114 +73,87 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 className="iot--data-state-grid"
               >
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__icon-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__icon-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__icon-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__icon-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="iot--data-state-default-error-icon"
-                      focusable="false"
-                      height={24}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
+                  <svg
+                    aria-hidden={true}
+                    className="iot--data-state-default-error-icon"
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
                       }
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm4.3 16.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
-                      />
-                      <path
-                        d="M16.3 17.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
-                        data-icon-path="inner-path"
-                        fill="none"
-                        opacity="0"
-                      />
-                    </svg>
-                  </div>
+                    }
+                    viewBox="0 0 24 24"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm4.3 16.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
+                    />
+                    <path
+                      d="M16.3 17.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
+                      data-icon-path="inner-path"
+                      fill="none"
+                      opacity="0"
+                    />
+                  </svg>
                 </div>
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__label-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__label-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__label-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__label-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
+                  <span
+                    className="iot--data-state-grid__label"
                   >
-                    <span
-                      className="iot--data-state-grid__label"
-                    >
-                      No data available for this score at this time
-                    </span>
-                  </div>
+                    No data available for this score at this time
+                  </span>
                 </div>
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__description-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__description-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__description-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__description-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
+                  <p
+                    className="iot--data-state-grid__description"
                   >
-                    <p
-                      className="iot--data-state-grid__description"
-                    >
-                      The last successful score was 68 at 13:21 - 10/21/2019 but wait, there is more, according to the latest test results this line is too long.
-                    </p>
-                  </div>
+                    The last successful score was 68 at 13:21 - 10/21/2019 but wait, there is more, according to the latest test results this line is too long.
+                  </p>
                 </div>
               </div>
             </div>
@@ -288,54 +261,45 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 className="iot--data-state-grid"
               >
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__icon-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__icon-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__icon-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__icon-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="iot--data-state-default-error-icon"
-                      focusable="false"
-                      height={24}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
+                  <svg
+                    aria-hidden={true}
+                    className="iot--data-state-default-error-icon"
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
                       }
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm4.3 16.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
-                      />
-                      <path
-                        d="M16.3 17.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
-                        data-icon-path="inner-path"
-                        fill="none"
-                        opacity="0"
-                      />
-                    </svg>
-                  </div>
+                    }
+                    viewBox="0 0 24 24"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm4.3 16.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
+                    />
+                    <path
+                      d="M16.3 17.5L6.5 7.7l1.2-1.2 9.8 9.8-1.2 1.2z"
+                      data-icon-path="inner-path"
+                      fill="none"
+                      opacity="0"
+                    />
+                  </svg>
                 </div>
               </div>
             </div>
@@ -443,111 +407,84 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 className="iot--data-state-grid"
               >
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__icon-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__icon-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__icon-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__icon-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "fill": "orange",
-                          "willChange": "transform",
-                        }
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "fill": "orange",
+                        "willChange": "transform",
                       }
-                      viewBox="0 0 32 32"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
-                      />
-                      <title>
-                        App supplied icon
-                      </title>
-                    </svg>
-                  </div>
+                    }
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M16 10a6 6 0 0 0-6 6v8a6 6 0 0 0 12 0v-8a6 6 0 0 0-6-6zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0 1 11.75 24v-.13h8.5V24A4.27 4.27 0 0 1 16 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 0 1 8.5 0zm10.41 3.09L24 13v9.1a4 4 0 0 0 8 0 3.83 3.83 0 0 0-1.34-2.89zM28 24.35a2.25 2.25 0 0 1-2.25-2.25V17l3.72 3.47A2.05 2.05 0 0 1 30.2 22a2.25 2.25 0 0 1-2.2 2.35zM0 22.1a4 4 0 0 0 8 0V13l-6.66 6.21A3.88 3.88 0 0 0 0 22.1zm2.48-1.56L6.25 17v5.1a2.25 2.25 0 0 1-4.5 0 2.05 2.05 0 0 1 .73-1.56zM15 5.5A3.5 3.5 0 1 0 11.5 9 3.5 3.5 0 0 0 15 5.5zm-5.25 0a1.75 1.75 0 1 1 1.75 1.75A1.77 1.77 0 0 1 9.75 5.5zM20.5 2A3.5 3.5 0 1 0 24 5.5 3.5 3.5 0 0 0 20.5 2zm0 5.25a1.75 1.75 0 1 1 1.75-1.75 1.77 1.77 0 0 1-1.75 1.75z"
+                    />
+                    <title>
+                      App supplied icon
+                    </title>
+                  </svg>
                 </div>
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__label-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__label-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__label-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__label-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
+                  <span
+                    className="iot--data-state-grid__label"
                   >
-                    <span
-                      className="iot--data-state-grid__label"
-                    >
-                      No data available for this score at this time
-                    </span>
-                  </div>
+                    No data available for this score at this time
+                  </span>
                 </div>
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__description-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__description-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__description-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__description-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
+                  <p
+                    className="iot--data-state-grid__description"
                   >
-                    <p
-                      className="iot--data-state-grid__description"
-                    >
-                      The last successful score was 68 at 13:21 - 10/21/2019 but wait, there is more, according to the latest test results this line is too long.
-                    </p>
-                  </div>
+                    The last successful score was 68 at 13:21 - 10/21/2019 but wait, there is more, according to the latest test results this line is too long.
+                  </p>
                 </div>
               </div>
             </div>
@@ -649,114 +586,87 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 className="iot--data-state-grid"
               >
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__icon-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__icon-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__icon-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__icon-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="iot--data-state-default-warning-icon"
-                      focusable="false"
-                      height={24}
-                      preserveAspectRatio="xMidYMid meet"
-                      style={
-                        Object {
-                          "willChange": "transform",
-                        }
+                  <svg
+                    aria-hidden={true}
+                    className="iot--data-state-default-warning-icon"
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    style={
+                      Object {
+                        "willChange": "transform",
                       }
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm-.9 5h1.8v8h-1.8V6zm.9 13.2c-.7 0-1.2-.6-1.2-1.2s.6-1.2 1.2-1.2 1.2.6 1.2 1.2-.5 1.2-1.2 1.2z"
-                      />
-                      <path
-                        d="M13.2 18c0 .7-.6 1.2-1.2 1.2s-1.2-.6-1.2-1.2.6-1.2 1.2-1.2 1.2.5 1.2 1.2zm-.3-12h-1.8v8h1.8V6z"
-                        data-icon-path="inner-path"
-                        fill="none"
-                        opacity="0"
-                      />
-                    </svg>
-                  </div>
+                    }
+                    viewBox="0 0 24 24"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zm-.9 5h1.8v8h-1.8V6zm.9 13.2c-.7 0-1.2-.6-1.2-1.2s.6-1.2 1.2-1.2 1.2.6 1.2 1.2-.5 1.2-1.2 1.2z"
+                    />
+                    <path
+                      d="M13.2 18c0 .7-.6 1.2-1.2 1.2s-1.2-.6-1.2-1.2.6-1.2 1.2-1.2 1.2.5 1.2 1.2zm-.3-12h-1.8v8h1.8V6z"
+                      data-icon-path="inner-path"
+                      fill="none"
+                      opacity="0"
+                    />
+                  </svg>
                 </div>
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__label-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__label-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__label-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__label-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
+                  <span
+                    className="iot--data-state-grid__label"
                   >
-                    <span
-                      className="iot--data-state-grid__label"
-                    >
-                      No data available for this score at this time
-                    </span>
-                  </div>
+                    No data available for this score at this time
+                  </span>
                 </div>
                 <div
-                  data-floating-menu-container={true}
-                  style={
-                    Object {
-                      "position": "relative",
-                    }
-                  }
+                  aria-describedby={null}
+                  aria-haspopup="true"
+                  aria-labelledby="iot--data-state-grid__description-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__description-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
-                  <div
-                    aria-describedby={null}
-                    aria-haspopup="true"
-                    aria-labelledby="iot--data-state-grid__description-myStoryId"
-                    className="bx--tooltip__label"
-                    id="iot--data-state-grid__description-myStoryId"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    role="button"
-                    tabIndex={0}
+                  <p
+                    className="iot--data-state-grid__description"
                   >
-                    <p
-                      className="iot--data-state-grid__description"
-                    >
-                      The last successful score was 68 at 13:21 - 10/21/2019 but wait, there is more, according to the latest test results this line is too long.
-                    </p>
-                  </div>
+                    The last successful score was 68 at 13:21 - 10/21/2019 but wait, there is more, according to the latest test results this line is too long.
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Closes #1040

**Summary**
GRAPHITE team has implemented the data-state-error value cards in Reference application Dashboard. Since it has multiple tiles/cards on the page. here if we are clicking on the no data or error icon the tooltip is opening behind other cards. As per discussion with team, they are mentioning that they are not directly using the IOT component and not modifying tooltip in GRAPHITE hence it seems to be fixed in IOT.

![image](https://user-images.githubusercontent.com/5167091/77566892-9de79000-6ec6-11ea-85fc-c9a98828026b.png)


**Change List (commits, features, bugs, etc)**
-Removed the tooltip wrapper which had the 'data-floating-menu-container' attribute. This wrapper was originally added as a fix recommended by carbon to handle the offset when the tooltip container was scrolling and there was a parent with position:fixed. That scenario is considered a corner case and non of the tooltips in our components handle that.
-Modified a card in the story `dashboard -> only value cards` to show the data-state so that the issue and fix could be easily tested

The issue #1040 also requests a fix for better tooltip edge positioning which I believe is outside the scope of this fix. See discussion in the original issue.

**Acceptance Test (how to verify the PR)**
1. Go to the story 'dashboard -> only value cards' in the build for this issue. (https://deploy-preview-1041--carbon-addons-iot-react.netlify.com/?path=/story/watson-iot-dashboard--only-value-cards)
2. Click the data state info icon and make sure it is not hidden by another card
