### PR TITLE
fix(value-card-wrap): wrap long strings to two lines

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -131,7 +131,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -180,7 +180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -229,7 +229,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -321,7 +321,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -410,7 +410,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -538,7 +538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -630,7 +630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -837,7 +837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2407,7 +2407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -2456,7 +2456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -2505,7 +2505,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -2597,7 +2597,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2686,7 +2686,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2814,7 +2814,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2906,7 +2906,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -3113,7 +3113,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -4715,7 +4715,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -4764,7 +4764,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -4813,7 +4813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -4905,7 +4905,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -4994,7 +4994,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5122,7 +5122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5214,7 +5214,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5421,7 +5421,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9474,7 +9474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -9523,7 +9523,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -9572,7 +9572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -9664,7 +9664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9753,7 +9753,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9881,7 +9881,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9973,7 +9973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -10180,7 +10180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -11753,7 +11753,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -11837,7 +11837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -11923,7 +11923,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12009,7 +12009,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12095,7 +12095,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12292,7 +12292,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12441,7 +12441,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12525,7 +12525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12611,7 +12611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12697,7 +12697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12783,7 +12783,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12980,7 +12980,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13129,7 +13129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13215,7 +13215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13304,7 +13304,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13390,7 +13390,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13544,7 +13544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13630,7 +13630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13719,7 +13719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13805,7 +13805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13959,7 +13959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14071,7 +14071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14183,7 +14183,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14295,7 +14295,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14472,7 +14472,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14584,7 +14584,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14696,7 +14696,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14808,7 +14808,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15975,7 +15975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16059,7 +16059,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16145,7 +16145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16231,7 +16231,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16317,7 +16317,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16407,7 +16407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16495,7 +16495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16579,7 +16579,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16665,7 +16665,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16754,7 +16754,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16840,7 +16840,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16929,7 +16929,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17041,7 +17041,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17153,7 +17153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17265,7 +17265,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17872,7 +17872,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17956,7 +17956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18042,7 +18042,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18128,7 +18128,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18214,7 +18214,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18304,7 +18304,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18392,7 +18392,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18476,7 +18476,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18562,7 +18562,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18651,7 +18651,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18737,7 +18737,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18826,7 +18826,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18938,7 +18938,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19050,7 +19050,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19162,7 +19162,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19769,7 +19769,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19810,7 +19810,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19899,7 +19899,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19940,7 +19940,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20027,7 +20027,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20068,7 +20068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20222,7 +20222,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20263,7 +20263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20352,7 +20352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20393,7 +20393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20480,7 +20480,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20521,7 +20521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20675,7 +20675,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20716,7 +20716,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20805,7 +20805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20846,7 +20846,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20933,7 +20933,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20974,7 +20974,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21128,7 +21128,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21169,7 +21169,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21258,7 +21258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21299,7 +21299,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21386,7 +21386,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21427,7 +21427,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21581,7 +21581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21648,7 +21648,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21763,7 +21763,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21830,7 +21830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22010,7 +22010,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22077,7 +22077,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22192,7 +22192,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22259,7 +22259,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22439,7 +22439,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22488,7 +22488,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22537,7 +22537,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22626,7 +22626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22673,7 +22673,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22720,7 +22720,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22807,7 +22807,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22880,7 +22880,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22953,7 +22953,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23131,7 +23131,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23180,7 +23180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23229,7 +23229,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23318,7 +23318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23365,7 +23365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23412,7 +23412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23499,7 +23499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23572,7 +23572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23645,7 +23645,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                            className="iot--value-card__attribute-unit"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23886,7 +23886,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -23935,7 +23935,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -23984,7 +23984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -24076,7 +24076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24165,7 +24165,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24293,7 +24293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24385,7 +24385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24592,7 +24592,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                          className="iot--value-card__attribute-unit"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -122,7 +122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="89 %"
                             value={89}
@@ -131,7 +131,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -171,7 +171,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="76 %"
                             value={76}
@@ -180,7 +180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -220,7 +220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="21.4 mb"
                             value={21.4}
@@ -229,7 +229,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -312,7 +312,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -321,7 +321,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -401,7 +401,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -410,7 +410,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -529,7 +529,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="76 %"
                             value={76}
@@ -538,7 +538,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -621,7 +621,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="35 "
                             value={35}
@@ -630,7 +630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -700,7 +700,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                   >
                     <div
-                      className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                      className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                       size="SMALL"
                     >
                       <div
@@ -713,7 +713,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                             size="SMALL"
                             title="Bad "
                             value="Bad"
@@ -722,7 +722,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -759,7 +759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         </div>
                       </div>
                       <div
-                        className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                        className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                         size="SMALL"
                       />
                     </div>
@@ -828,7 +828,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="13572 "
                             value={13572}
@@ -837,7 +837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -1079,7 +1079,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                             size="SMALLWIDE"
                             title="Healthy "
                             value="Healthy"
@@ -1088,7 +1088,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2398,7 +2398,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="89 %"
                             value={89}
@@ -2407,7 +2407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -2447,7 +2447,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="76 %"
                             value={76}
@@ -2456,7 +2456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -2496,7 +2496,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="21.4 mb"
                             value={21.4}
@@ -2505,7 +2505,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -2588,7 +2588,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -2597,7 +2597,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2677,7 +2677,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -2686,7 +2686,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2805,7 +2805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="76 %"
                             value={76}
@@ -2814,7 +2814,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2897,7 +2897,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="35 "
                             value={35}
@@ -2906,7 +2906,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -2976,7 +2976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                   >
                     <div
-                      className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                      className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                       size="SMALL"
                     >
                       <div
@@ -2989,7 +2989,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                             size="SMALL"
                             title="Bad "
                             value="Bad"
@@ -2998,7 +2998,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -3035,7 +3035,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         </div>
                       </div>
                       <div
-                        className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                        className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                         size="SMALL"
                       />
                     </div>
@@ -3104,7 +3104,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="13572 "
                             value={13572}
@@ -3113,7 +3113,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -3355,7 +3355,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                             size="SMALLWIDE"
                             title="Healthy "
                             value="Healthy"
@@ -3364,7 +3364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -4706,7 +4706,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="89 %"
                             value={89}
@@ -4715,7 +4715,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -4755,7 +4755,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="76 %"
                             value={76}
@@ -4764,7 +4764,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -4804,7 +4804,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="21.4 mb"
                             value={21.4}
@@ -4813,7 +4813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -4896,7 +4896,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -4905,7 +4905,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -4985,7 +4985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -4994,7 +4994,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5113,7 +5113,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="76 %"
                             value={76}
@@ -5122,7 +5122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5205,7 +5205,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="35 "
                             value={35}
@@ -5214,7 +5214,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5284,7 +5284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                   >
                     <div
-                      className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                      className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                       size="SMALL"
                     >
                       <div
@@ -5297,7 +5297,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                             size="SMALL"
                             title="Bad "
                             value="Bad"
@@ -5306,7 +5306,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5343,7 +5343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         </div>
                       </div>
                       <div
-                        className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                        className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                         size="SMALL"
                       />
                     </div>
@@ -5412,7 +5412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="13572 "
                             value={13572}
@@ -5421,7 +5421,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -5663,7 +5663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                             size="SMALLWIDE"
                             title="Healthy "
                             value="Healthy"
@@ -5672,7 +5672,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9465,7 +9465,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="89 %"
                             value={89}
@@ -9474,7 +9474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -9514,7 +9514,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="76 %"
                             value={76}
@@ -9523,7 +9523,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -9563,7 +9563,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="21.4 mb"
                             value={21.4}
@@ -9572,7 +9572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -9655,7 +9655,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -9664,7 +9664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9744,7 +9744,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -9753,7 +9753,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9872,7 +9872,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="76 %"
                             value={76}
@@ -9881,7 +9881,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -9964,7 +9964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="35 "
                             value={35}
@@ -9973,7 +9973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -10043,7 +10043,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                   >
                     <div
-                      className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                      className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                       size="SMALL"
                     >
                       <div
@@ -10056,7 +10056,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                             size="SMALL"
                             title="Bad "
                             value="Bad"
@@ -10065,7 +10065,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -10102,7 +10102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         </div>
                       </div>
                       <div
-                        className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                        className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                         size="SMALL"
                       />
                     </div>
@@ -10171,7 +10171,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="13572 "
                             value={13572}
@@ -10180,7 +10180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -10422,7 +10422,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                             size="SMALLWIDE"
                             title="Healthy "
                             value="Healthy"
@@ -10431,7 +10431,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -11744,7 +11744,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="13 "
                               value={13}
@@ -11753,7 +11753,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -11828,7 +11828,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="1352 steps"
                               value={1352}
@@ -11837,7 +11837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -11914,7 +11914,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="103.2 ˚F"
                               value={103.2}
@@ -11923,7 +11923,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12000,7 +12000,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="107324.3 kJ"
                               value={107324.3}
@@ -12009,7 +12009,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12086,7 +12086,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -12095,7 +12095,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12279,7 +12279,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="true "
                               value={true}
@@ -12292,7 +12292,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12432,7 +12432,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="13 "
                               value={13}
@@ -12441,7 +12441,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12516,7 +12516,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="1352 steps"
                               value={1352}
@@ -12525,7 +12525,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12602,7 +12602,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="103.2 ˚F"
                               value={103.2}
@@ -12611,7 +12611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12688,7 +12688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="107324.3 kJ"
                               value={107324.3}
@@ -12697,7 +12697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12774,7 +12774,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -12783,7 +12783,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -12967,7 +12967,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="true "
                               value={true}
@@ -12980,7 +12980,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13120,7 +13120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="65.3 ˚F"
                               value={65.3}
@@ -13129,7 +13129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13206,7 +13206,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALL"
                               title="48.7 ˚F"
                               value={48.7}
@@ -13215,7 +13215,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13295,7 +13295,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALL"
                               title="88.1 ˚F"
                               value={88.1}
@@ -13304,7 +13304,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13381,7 +13381,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALL"
                               title="103.2 ˚F"
                               value={103.2}
@@ -13390,7 +13390,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13535,7 +13535,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="65.3 ˚F"
                               value={65.3}
@@ -13544,7 +13544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13621,7 +13621,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALL"
                               title="48.7 ˚F"
                               value={48.7}
@@ -13630,7 +13630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13710,7 +13710,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALL"
                               title="88.1 ˚F"
                               value={88.1}
@@ -13719,7 +13719,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13796,7 +13796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALL"
                               title="103.2 ˚F"
                               value={103.2}
@@ -13805,7 +13805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -13950,7 +13950,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="38.2 %"
                               value={38.2}
@@ -13959,7 +13959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14062,7 +14062,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="65.3 %"
                               value={65.3}
@@ -14071,7 +14071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14174,7 +14174,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="77.7 %"
                               value={77.7}
@@ -14183,7 +14183,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14286,7 +14286,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="91 %"
                               value={91}
@@ -14295,7 +14295,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14463,7 +14463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="38.2 %"
                               value={38.2}
@@ -14472,7 +14472,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14575,7 +14575,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="65.3 %"
                               value={65.3}
@@ -14584,7 +14584,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14687,7 +14687,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="77.7 %"
                               value={77.7}
@@ -14696,7 +14696,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14799,7 +14799,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALL"
                               title="91 %"
                               value={91}
@@ -14808,7 +14808,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14963,7 +14963,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -14976,7 +14976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="green"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                               size="SMALL"
                               title="Low "
                               value="Low"
@@ -14985,7 +14985,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -14996,7 +14996,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15049,7 +15049,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15062,7 +15062,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="blue"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kZqfwH"
                               size="SMALL"
                               title="Guarded "
                               value="Guarded"
@@ -15071,7 +15071,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15082,7 +15082,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15135,7 +15135,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15148,7 +15148,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="gold"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kZqfwH"
                               size="SMALL"
                               title="Elevated "
                               value="Elevated"
@@ -15157,7 +15157,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15168,7 +15168,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15221,7 +15221,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15234,7 +15234,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="orange"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                               size="SMALL"
                               title="High "
                               value="High"
@@ -15243,7 +15243,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15254,7 +15254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15307,7 +15307,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15320,7 +15320,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="red"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kZqfwH"
                               size="SMALL"
                               title="Severe "
                               value="Severe"
@@ -15329,7 +15329,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15340,7 +15340,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15458,7 +15458,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15471,7 +15471,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="green"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                               size="SMALL"
                               title="Low "
                               value="Low"
@@ -15480,7 +15480,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15491,7 +15491,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15544,7 +15544,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15557,7 +15557,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="blue"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kZqfwH"
                               size="SMALL"
                               title="Guarded "
                               value="Guarded"
@@ -15566,7 +15566,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15577,7 +15577,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15630,7 +15630,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15643,7 +15643,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="gold"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kZqfwH"
                               size="SMALL"
                               title="Elevated "
                               value="Elevated"
@@ -15652,7 +15652,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15663,7 +15663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15716,7 +15716,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15729,7 +15729,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="orange"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                               size="SMALL"
                               title="High "
                               value="High"
@@ -15738,7 +15738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15749,7 +15749,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15802,7 +15802,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                       className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                     >
                       <div
-                        className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                        className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                         size="SMALL"
                       >
                         <div
@@ -15815,7 +15815,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="red"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kZqfwH"
                               size="SMALL"
                               title="Severe "
                               value="Severe"
@@ -15824,7 +15824,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -15835,7 +15835,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <div
-                          className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                          className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                           size="SMALL"
                         />
                       </div>
@@ -15966,7 +15966,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="13 "
                               value={13}
@@ -15975,7 +15975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16050,7 +16050,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1352 steps"
                               value={1352}
@@ -16059,7 +16059,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16136,7 +16136,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.2 ˚F"
                               value={103.2}
@@ -16145,7 +16145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16222,7 +16222,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="107324.3 kJ"
                               value={107324.3}
@@ -16231,7 +16231,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16308,7 +16308,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -16317,7 +16317,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16394,7 +16394,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="false "
                               value={false}
@@ -16407,7 +16407,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16482,7 +16482,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="true "
                               value={true}
@@ -16495,7 +16495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16570,7 +16570,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="65.3 ˚F"
                               value={65.3}
@@ -16579,7 +16579,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16656,7 +16656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="48.7 ˚F"
                               value={48.7}
@@ -16665,7 +16665,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16745,7 +16745,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="88.1 ˚F"
                               value={88.1}
@@ -16754,7 +16754,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16831,7 +16831,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.2 ˚F"
                               value={103.2}
@@ -16840,7 +16840,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -16920,7 +16920,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="38.2 %"
                               value={38.2}
@@ -16929,7 +16929,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17032,7 +17032,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="65.3 %"
                               value={65.3}
@@ -17041,7 +17041,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17144,7 +17144,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="77.7 %"
                               value={77.7}
@@ -17153,7 +17153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17256,7 +17256,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="91 %"
                               value={91}
@@ -17265,7 +17265,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17368,7 +17368,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="green"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Low "
                               value="Low"
@@ -17377,7 +17377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17454,7 +17454,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="blue"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Guarded "
                               value="Guarded"
@@ -17463,7 +17463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17540,7 +17540,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="gold"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -17549,7 +17549,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17626,7 +17626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="orange"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="High "
                               value="High"
@@ -17635,7 +17635,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17712,7 +17712,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="red"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Severe "
                               value="Severe"
@@ -17721,7 +17721,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17863,7 +17863,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="13 "
                               value={13}
@@ -17872,7 +17872,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -17947,7 +17947,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1352 steps"
                               value={1352}
@@ -17956,7 +17956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18033,7 +18033,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.2 ˚F"
                               value={103.2}
@@ -18042,7 +18042,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18119,7 +18119,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="107324.3 kJ"
                               value={107324.3}
@@ -18128,7 +18128,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18205,7 +18205,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -18214,7 +18214,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18291,7 +18291,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="false "
                               value={false}
@@ -18304,7 +18304,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18379,7 +18379,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="true "
                               value={true}
@@ -18392,7 +18392,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18467,7 +18467,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="65.3 ˚F"
                               value={65.3}
@@ -18476,7 +18476,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18553,7 +18553,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="48.7 ˚F"
                               value={48.7}
@@ -18562,7 +18562,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18642,7 +18642,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="88.1 ˚F"
                               value={88.1}
@@ -18651,7 +18651,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18728,7 +18728,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.2 ˚F"
                               value={103.2}
@@ -18737,7 +18737,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18817,7 +18817,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="38.2 %"
                               value={38.2}
@@ -18826,7 +18826,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -18929,7 +18929,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="65.3 %"
                               value={65.3}
@@ -18938,7 +18938,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19041,7 +19041,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="77.7 %"
                               value={77.7}
@@ -19050,7 +19050,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19153,7 +19153,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="91 %"
                               value={91}
@@ -19162,7 +19162,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19265,7 +19265,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="green"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Low "
                               value="Low"
@@ -19274,7 +19274,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19351,7 +19351,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="blue"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Guarded "
                               value="Guarded"
@@ -19360,7 +19360,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19437,7 +19437,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="gold"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -19446,7 +19446,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19523,7 +19523,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="orange"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="High "
                               value="High"
@@ -19532,7 +19532,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19609,7 +19609,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="red"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Severe "
                               value="Severe"
@@ -19618,7 +19618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19760,7 +19760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -19769,7 +19769,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19801,7 +19801,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -19810,7 +19810,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19890,7 +19890,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -19899,7 +19899,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -19931,7 +19931,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -19940,7 +19940,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20018,7 +20018,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -20027,7 +20027,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20059,7 +20059,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -20068,7 +20068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20213,7 +20213,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -20222,7 +20222,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20254,7 +20254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -20263,7 +20263,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20343,7 +20343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -20352,7 +20352,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20384,7 +20384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -20393,7 +20393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20471,7 +20471,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -20480,7 +20480,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20512,7 +20512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -20521,7 +20521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20666,7 +20666,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -20675,7 +20675,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20707,7 +20707,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -20716,7 +20716,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20796,7 +20796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -20805,7 +20805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20837,7 +20837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -20846,7 +20846,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20924,7 +20924,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -20933,7 +20933,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -20965,7 +20965,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -20974,7 +20974,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21119,7 +21119,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -21128,7 +21128,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21160,7 +21160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -21169,7 +21169,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21249,7 +21249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -21258,7 +21258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21290,7 +21290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -21299,7 +21299,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21377,7 +21377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -21386,7 +21386,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21418,7 +21418,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -21427,7 +21427,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21572,7 +21572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="38.2 %"
                               value={38.2}
@@ -21581,7 +21581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21639,7 +21639,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="65.3 %"
                               value={65.3}
@@ -21648,7 +21648,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21754,7 +21754,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="77.2 ˚F"
                               value={77.2}
@@ -21763,7 +21763,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -21821,7 +21821,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="91.3 ˚F"
                               value={91.3}
@@ -21830,7 +21830,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22001,7 +22001,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="38.2 %"
                               value={38.2}
@@ -22010,7 +22010,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22068,7 +22068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="65.3 %"
                               value={65.3}
@@ -22077,7 +22077,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22183,7 +22183,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="77.2 ˚F"
                               value={77.2}
@@ -22192,7 +22192,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22250,7 +22250,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                               size="SMALLWIDE"
                               title="91.3 ˚F"
                               value={91.3}
@@ -22259,7 +22259,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.25rem",
@@ -22430,7 +22430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="13634.56 MWh"
                               value={13634.56}
@@ -22439,7 +22439,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22479,7 +22479,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="1047.2 MWh"
                               value={1047.2}
@@ -22488,7 +22488,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22528,7 +22528,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="314.5 MWh"
                               value={314.5}
@@ -22537,7 +22537,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22617,7 +22617,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="red"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Severe "
                               value="Severe"
@@ -22626,7 +22626,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22664,7 +22664,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="green"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Low "
                               value="Low"
@@ -22673,7 +22673,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22711,7 +22711,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="orange"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="High "
                               value="High"
@@ -22720,7 +22720,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22798,7 +22798,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Low "
                               value="Low"
@@ -22807,7 +22807,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22871,7 +22871,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Severe "
                               value="Severe"
@@ -22880,7 +22880,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -22944,7 +22944,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Elevated "
                               value="Elevated"
@@ -22953,7 +22953,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23122,7 +23122,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="13634.56 MWh"
                               value={13634.56}
@@ -23131,7 +23131,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23171,7 +23171,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="1047.2 MWh"
                               value={1047.2}
@@ -23180,7 +23180,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23220,7 +23220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="314.5 MWh"
                               value={314.5}
@@ -23229,7 +23229,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23309,7 +23309,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="red"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Severe "
                               value="Severe"
@@ -23318,7 +23318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23356,7 +23356,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="green"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Low "
                               value="Low"
@@ -23365,7 +23365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23403,7 +23403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color="orange"
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="High "
                               value="High"
@@ -23412,7 +23412,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23490,7 +23490,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Low "
                               value="Low"
@@ -23499,7 +23499,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23563,7 +23563,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Severe "
                               value="Severe"
@@ -23572,7 +23572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23636,7 +23636,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                               size="MEDIUM"
                               title="Elevated "
                               value="Elevated"
@@ -23645,7 +23645,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </span>
                           </div>
                           <span
-                            className="iot--value-card__attribute-unit"
+                            className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                             style={
                               Object {
                                 "--default-font-size": "1.5rem",
@@ -23877,7 +23877,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="89 %"
                             value={89}
@@ -23886,7 +23886,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -23926,7 +23926,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="76 %"
                             value={76}
@@ -23935,7 +23935,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -23975,7 +23975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                             size="MEDIUM"
                             title="21.4 mb"
                             value={21.4}
@@ -23984,7 +23984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.5rem",
@@ -24067,7 +24067,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -24076,7 +24076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24156,7 +24156,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color="green"
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                             size="SMALL"
                             title="62.1 %"
                             value={62.1}
@@ -24165,7 +24165,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24284,7 +24284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="76 %"
                             value={76}
@@ -24293,7 +24293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24376,7 +24376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="35 "
                             value={35}
@@ -24385,7 +24385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24455,7 +24455,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                     className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
                   >
                     <div
-                      className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+                      className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
                       size="SMALL"
                     >
                       <div
@@ -24468,7 +24468,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 eZajlg"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 wLszP"
                             size="SMALL"
                             title="Bad "
                             value="Bad"
@@ -24477,7 +24477,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24514,7 +24514,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                         </div>
                       </div>
                       <div
-                        className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                        className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                         size="SMALL"
                       />
                     </div>
@@ -24583,7 +24583,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                             size="SMALL"
                             title="13572 "
                             value={13572}
@@ -24592,7 +24592,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",
@@ -24834,7 +24834,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           color={null}
                         >
                           <span
-                            className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                            className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                             size="SMALLWIDE"
                             title="Healthy "
                             value="Healthy"
@@ -24843,7 +24843,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           </span>
                         </div>
                         <span
-                          className="iot--value-card__attribute-unit"
+                          className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                           style={
                             Object {
                               "--default-font-size": "1.25rem",

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -196,6 +196,7 @@ const Attribute = ({
               isMini={isMini}
               allowedToWrap={allowWrap}
               wrapCompact={wrapCompact}
+              attributeCount={attributeCount}
             />
             {!isNil(secondaryValue) && (!measuredSize || measuredSize.width > 100) ? (
               <AttributeSecondaryValue

--- a/src/components/ValueCard/UnitRenderer.jsx
+++ b/src/components/ValueCard/UnitRenderer.jsx
@@ -31,6 +31,7 @@ const UnitRenderer = ({ unit, layout, isMini, allowedToWrap, wrapCompact }) => {
       style={{ '--default-font-size': layout === CARD_LAYOUTS.HORIZONTAL ? '1.25rem' : '1.5rem' }}
       className={classNames(bemBase, {
         [`${bemBase}--wrappable`]: allowedToWrap,
+        [`${bemBase}--not-wrappable`]: !allowedToWrap,
         [`${bemBase}--wrappable-compact`]: wrapCompact,
         [`${bemBase}--mini`]: isMini,
       })}

--- a/src/components/ValueCard/UnitRenderer.jsx
+++ b/src/components/ValueCard/UnitRenderer.jsx
@@ -24,14 +24,24 @@ const defaultProps = {
 };
 
 /** This components job is determining how to render different kinds units */
-const UnitRenderer = ({ unit, layout, isMini, allowedToWrap, wrapCompact }) => {
+const UnitRenderer = ({
+  value,
+  unit,
+  layout,
+  isMini,
+  allowedToWrap,
+  wrapCompact,
+  attributeCount, // eslint-disable-line
+}) => {
   const bemBase = `${iotPrefix}--value-card__attribute-unit`;
+  const notAllowedToWrap = typeof value === 'string' && !allowedToWrap && attributeCount === 1;
+
   const unitElement = (
     <span
       style={{ '--default-font-size': layout === CARD_LAYOUTS.HORIZONTAL ? '1.25rem' : '1.5rem' }}
       className={classNames(bemBase, {
         [`${bemBase}--wrappable`]: allowedToWrap,
-        [`${bemBase}--not-wrappable`]: !allowedToWrap,
+        [`${bemBase}--not-wrappable`]: notAllowedToWrap,
         [`${bemBase}--wrappable-compact`]: wrapCompact,
         [`${bemBase}--mini`]: isMini,
       })}

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { text, select, object, boolean, number } from '@storybook/addon-knobs';
 import { Bee16, Checkmark16 } from '@carbon/icons-react';
@@ -73,35 +73,12 @@ storiesOf('Watson IoT/ValueCard', module)
     );
   })
 
-  .add('small / wrapping', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
-    return (
-      <div style={{ width: text('cardWidth', '120px'), margin: 20 }}>
-        <ValueCard
-          title={text('title', 'Occupancy')}
-          id="facilitycard"
-          content={{
-            attributes: object('attributes', [
-              {
-                dataSourceId: 'occupancy',
-                unit: '%',
-              },
-            ]),
-          }}
-          breakpoint="lg"
-          size={size}
-          values={{
-            occupancy: text('occupancy', 'Really really busy loong long long long'),
-          }}
-        />
-      </div>
-    );
-  })
-  .add('small / units incl wrapping', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
-    return (
-      <Fragment>
-        <div style={{ width: text('cardWidth', `150px`), margin: 20 }}>
+  .add(
+    'small / wrapping',
+    () => {
+      const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+      return (
+        <div style={{ width: text('cardWidth', '120px'), margin: 20 }}>
           <ValueCard
             title={text('title', 'Occupancy')}
             id="facilitycard"
@@ -115,29 +92,56 @@ storiesOf('Watson IoT/ValueCard', module)
             }}
             breakpoint="lg"
             size={size}
-            values={{ occupancy: number('occupancy', 88) }}
+            values={{
+              occupancy: text('occupancy', 'Really really busy loong long long long'),
+            }}
           />
         </div>
-        <div style={{ width: text('wrappedCardWidth', '120px'), margin: 20 }}>
+      );
+    },
+    {
+      info: {
+        text:
+          'In the case of having a long string value with units, we prioritize seeing the unit. We ellipsis the text while wrapping the unit to display under.',
+      },
+    }
+  )
+  .add(
+    'small / wrapping no units',
+    () => {
+      const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+      return (
+        <div style={{ width: text('cardWidth', `${getCardMinSize('lg', size).x}px`), margin: 20 }}>
           <ValueCard
-            title={text('title', 'Occupancy')}
+            title="Tagpath"
             id="facilitycard"
             content={{
-              attributes: object('attributes', [
+              attributes: [
                 {
-                  dataSourceId: 'occupancy',
-                  unit: '%',
+                  label: 'Tagpath',
+                  dataSourceId: 'footTraffic',
                 },
-              ]),
+              ],
             }}
             breakpoint="lg"
             size={size}
-            values={{ occupancy: text('occupancy', 'A longer value that cause the unit to wrap') }}
+            values={{
+              footTraffic: text(
+                'occupancy',
+                'rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu'
+              ),
+            }}
           />
         </div>
-      </Fragment>
-    );
-  })
+      );
+    },
+    {
+      info: {
+        text:
+          'In the case of having a long string value with no units, there is extra room to wrap the text to two lines. This makes it easier to read without needing to mouse over the text value.',
+      },
+    }
+  )
   .add('small / title', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -67,9 +67,13 @@ const AttributeValue = styled.span`
   padding-bottom: 0.25rem;
   font-weight: ${props => (props.isMini ? 'normal' : 'lighter')};
   ${props => props.layout === CARD_LAYOUTS.VERTICAL && `text-align: left;`};
-  white-space: nowrap;
+  /* autoprefixer: ignore next */
+  ${props =>
+    props.allowedToWrap
+      ? `white-space: nowrap; text-overflow: ellipsis;`
+      : `display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow-wrap: break-word;`};
+  ${props => !props.hasWords && 'word-break: break-all;'}
   overflow: hidden;
-  text-overflow: ellipsis;
 `;
 
 const StyledBoolean = styled.span`
@@ -126,6 +130,11 @@ const ValueRenderer = ({
   } else if (isNil(value)) {
     renderValue = '--';
   }
+
+  const hasWordsCheck = string =>
+    typeof string === 'string' ? string.trim().indexOf(' ') >= 0 : false;
+  const hasWords = hasWordsCheck(renderValue);
+
   return (
     <Attribute
       unit={unit}
@@ -146,6 +155,8 @@ const ValueRenderer = ({
         isSmall={isSmall}
         isMini={isMini}
         value={value}
+        allowedToWrap={allowedToWrap}
+        hasWords={hasWords}
       >
         {renderValue}
       </AttributeValue>

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -778,7 +778,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="100 %"
                     value="100"
@@ -787,7 +787,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -819,7 +819,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="50 %"
                     value="50"
@@ -828,7 +828,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -947,7 +947,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="-- Wh"
                     value="--"
@@ -956,7 +956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -988,7 +988,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="-- Wh"
                     value="--"
@@ -997,7 +997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -1209,7 +1209,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGE"
                     title="89 %"
                     value={89}
@@ -1218,7 +1218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1258,7 +1258,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGE"
                     title="76.7 ˚F"
                     value={76.7}
@@ -1267,7 +1267,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1307,7 +1307,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGE"
                     title="76 %"
                     value={76}
@@ -1316,7 +1316,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1356,7 +1356,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGE"
                     title="50 %"
                     value={50}
@@ -1365,7 +1365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1405,7 +1405,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGE"
                     title="0.567 "
                     value={0.567}
@@ -1414,7 +1414,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1533,7 +1533,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
                     title="89 %"
                     value={89}
@@ -1542,7 +1542,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1582,7 +1582,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
                     title="76.7 ˚F"
                     value={76.7}
@@ -1591,7 +1591,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1631,7 +1631,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
                     title="76 %"
                     value={76}
@@ -1640,7 +1640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1680,7 +1680,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
                     title="76 %"
                     value={76}
@@ -1689,7 +1689,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1729,7 +1729,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
                     title="76 %"
                     value={76}
@@ -1738,7 +1738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1778,7 +1778,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
                     title="76 %"
                     value={76}
@@ -1787,7 +1787,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1827,7 +1827,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
                     title="76 %"
                     value={76}
@@ -1836,7 +1836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1955,7 +1955,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                     size="SMALL"
                     title="20000000000000000 "
                     value={20000000000000000}
@@ -1964,7 +1964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2083,7 +2083,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="100000000 Wh"
                     value={100000000}
@@ -2092,7 +2092,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2124,7 +2124,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="40000000000000 Wh"
                     value={40000000000000}
@@ -2133,7 +2133,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2252,7 +2252,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="89 %"
                     value={89}
@@ -2261,7 +2261,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2293,7 +2293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="76.7 ˚F"
                     value={76.7}
@@ -2302,7 +2302,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2421,7 +2421,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="89 %"
                     value={89}
@@ -2430,7 +2430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2470,7 +2470,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="76.7 ˚F"
                     value={76.7}
@@ -2479,7 +2479,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2519,7 +2519,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="76 %"
                     value={76}
@@ -2528,7 +2528,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2647,7 +2647,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="89 %"
                     value={89}
@@ -2656,7 +2656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2688,7 +2688,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="76.7 ˚F"
                     value={76.7}
@@ -2697,7 +2697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2816,7 +2816,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="345678234234234240 %"
                     value={345678234234234240}
@@ -2825,7 +2825,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2891,7 +2891,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="456778234234234240 ˚F"
                     value={456778234234234240}
@@ -2900,7 +2900,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2966,7 +2966,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="88888678234234240000 ˚F"
                     value={88888678234234240000}
@@ -2975,7 +2975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3120,7 +3120,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="89 %"
                     value={89}
@@ -3129,7 +3129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3169,7 +3169,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="76.7 ˚F"
                     value={76.7}
@@ -3178,7 +3178,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3218,7 +3218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="76 %"
                     value={76}
@@ -3227,7 +3227,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3346,7 +3346,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="MEDIUM"
                     title="89 %"
                     value={89}
@@ -3355,7 +3355,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -3474,7 +3474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUMWIDE"
                     title="89 %"
                     value={89}
@@ -3483,7 +3483,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3523,7 +3523,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUMWIDE"
                     title="76.7 ˚F"
                     value={76.7}
@@ -3532,7 +3532,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3572,7 +3572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 kuugZx"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUMWIDE"
                     title="76 %"
                     value={76}
@@ -3581,7 +3581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3700,7 +3700,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="SMALL"
                     title="88 %"
                     value={88}
@@ -3709,7 +3709,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -3812,7 +3812,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
           >
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
               size="SMALL"
             >
               <div
@@ -3821,11 +3821,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 size="SMALL"
               >
                 <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jMDHdA"
                     size="SMALL"
                     title="Really really busy %"
                     value="Really really busy"
@@ -3834,7 +3834,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -3845,7 +3845,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 </span>
               </div>
               <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                 size="SMALL"
               />
             </div>
@@ -3950,7 +3950,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="SMALL"
                     title="4 "
                     value={4}
@@ -3959,7 +3959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4108,7 +4108,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="SMALL"
                     title="70 "
                     value={70}
@@ -4117,7 +4117,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4259,7 +4259,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color="red"
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
                     size="SMALL"
                     title="35 "
                     value={35}
@@ -4268,7 +4268,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4384,7 +4384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                     size="SMALL"
                     title="13572 "
                     value={13572}
@@ -4393,7 +4393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4512,7 +4512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                     size="SMALL"
                     title="13572 "
                     value={13572}
@@ -4521,7 +4521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4637,7 +4637,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                     size="SMALL"
                     title="35 "
                     value={35}
@@ -4646,7 +4646,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4654,217 +4654,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   }
                 >
                   
-                </span>
-              </div>
-              <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                size="SMALL"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard small / units incl wrapping 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "150px",
-        }
-      }
-    >
-      <div
-        className="iot--card--wrapper"
-        data-testid="Card"
-        id="facilitycard"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "144px",
-          }
-        }
-      >
-        <div
-          className="iot--card--header"
-        >
-          <span
-            className="iot--card--title"
-            title="Occupancy"
-          >
-            <div
-              className="iot--card--title--text"
-            >
-              Occupancy
-            </div>
-          </span>
-        </div>
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "96px",
-            }
-          }
-        >
-          <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-          >
-            <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-              size="SMALL"
-            >
-              <div
-                className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                label={null}
-                size="SMALL"
-              >
-                <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                  color={null}
-                >
-                  <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 iOFzxv"
-                    size="SMALL"
-                    title="88 %"
-                    value={88}
-                  >
-                    88
-                  </span>
-                </div>
-                <span
-                  className="iot--value-card__attribute-unit"
-                  style={
-                    Object {
-                      "--default-font-size": "1.25rem",
-                    }
-                  }
-                >
-                  %
-                </span>
-              </div>
-              <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
-                size="SMALL"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "120px",
-        }
-      }
-    >
-      <div
-        className="iot--card--wrapper"
-        data-testid="Card"
-        id="facilitycard"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "144px",
-          }
-        }
-      >
-        <div
-          className="iot--card--header"
-        >
-          <span
-            className="iot--card--title"
-            title="Occupancy"
-          >
-            <div
-              className="iot--card--title--text"
-            >
-              Occupancy
-            </div>
-          </span>
-        </div>
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "96px",
-            }
-          }
-        >
-          <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-          >
-            <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-              size="SMALL"
-            >
-              <div
-                className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
-                label={null}
-                size="SMALL"
-              >
-                <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                  color={null}
-                >
-                  <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
-                    size="SMALL"
-                    title="A longer value that cause the unit to wrap %"
-                    value="A longer value that cause the unit to wrap"
-                  >
-                    A longer value that cause the unit to wrap
-                  </span>
-                </div>
-                <span
-                  className="iot--value-card__attribute-unit"
-                  style={
-                    Object {
-                      "--default-font-size": "1.25rem",
-                    }
-                  }
-                >
-                  %
                 </span>
               </div>
               <div
@@ -4960,7 +4749,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
           >
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
               size="SMALL"
             >
               <div
@@ -4969,11 +4758,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 size="SMALL"
               >
                 <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 bztBvA"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jMDHdA"
                     size="SMALL"
                     title="Really really busy loong long long long %"
                     value="Really really busy loong long long long"
@@ -4982,7 +4771,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4993,9 +4782,137 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 </span>
               </div>
               <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 cAOhas"
+                className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
                 size="SMALL"
               />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard small / wrapping no units 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "252px",
+        }
+      }
+    >
+      <div
+        className="iot--card--wrapper"
+        data-testid="Card"
+        id="facilitycard"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "144px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Tagpath"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Tagpath
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "96px",
+            }
+          }
+        >
+          <div
+            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+          >
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
+              size="SMALL"
+            >
+              <div
+                className="Attribute__StyledAttribute-dhraql-0 eCIOAU"
+                label="Tagpath"
+                size="SMALL"
+              >
+                <div
+                  className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
+                  color={null}
+                >
+                  <span
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jvpWcr"
+                    size="SMALL"
+                    title="rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu "
+                    value="rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu"
+                  >
+                    rutherford/rooms/northadd/ah2/ft_supflow/eurutherford/rooms/northadd/ah2/ft_supflow/eu
+                  </span>
+                </div>
+                <span
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  style={
+                    Object {
+                      "--default-font-size": "1.25rem",
+                    }
+                  }
+                >
+                  
+                </span>
+              </div>
+              <div
+                className="ValueCard__AttributeLabel-hyxf2q-4 iJHIKN"
+                size="SMALL"
+                title="Tagpath"
+              >
+                Tagpath
+              </div>
             </div>
           </div>
         </div>
@@ -5098,7 +5015,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                     size="SMALLWIDE"
                     title="Problem "
                     value="Problem"
@@ -5107,7 +5024,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5139,7 +5056,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                     size="SMALLWIDE"
                     title="Healthy feels"
                     value="Healthy"
@@ -5148,7 +5065,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5267,7 +5184,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                     size="SMALLWIDE"
                     title="Unhealthy "
                     value="Unhealthy"
@@ -5276,7 +5193,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5418,7 +5335,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                     size="SMALLWIDE"
                     title="Good "
                     value="Good"
@@ -5427,7 +5344,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5459,7 +5376,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 fgQTCd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
                     size="SMALLWIDE"
                     title="Healthy "
                     value="Healthy"
@@ -5468,7 +5385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5587,7 +5504,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 hbzXyh"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                     size="SMALL"
                     title="false "
                     value={false}
@@ -5600,7 +5517,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit"
+                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -787,7 +787,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -828,7 +828,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -956,7 +956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -997,7 +997,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -1218,7 +1218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1267,7 +1267,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1316,7 +1316,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1365,7 +1365,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1414,7 +1414,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1542,7 +1542,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1591,7 +1591,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1640,7 +1640,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1689,7 +1689,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1738,7 +1738,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1787,7 +1787,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1836,7 +1836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -1964,7 +1964,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2092,7 +2092,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2133,7 +2133,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2261,7 +2261,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2302,7 +2302,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2430,7 +2430,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2479,7 +2479,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2528,7 +2528,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2656,7 +2656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2697,7 +2697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -2825,7 +2825,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2900,7 +2900,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -2975,7 +2975,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3129,7 +3129,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3178,7 +3178,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3227,7 +3227,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3355,7 +3355,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -3483,7 +3483,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3532,7 +3532,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3581,7 +3581,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.5rem",
@@ -3709,7 +3709,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -3959,7 +3959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4117,7 +4117,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4268,7 +4268,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4393,7 +4393,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4521,7 +4521,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -4646,7 +4646,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5024,7 +5024,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5065,7 +5065,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5344,7 +5344,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5385,7 +5385,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",
@@ -5517,7 +5517,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   </span>
                 </div>
                 <span
-                  className="iot--value-card__attribute-unit iot--value-card__attribute-unit--not-wrappable"
+                  className="iot--value-card__attribute-unit"
                   style={
                     Object {
                       "--default-font-size": "1.25rem",

--- a/src/components/ValueCard/_unit-renderer.scss
+++ b/src/components/ValueCard/_unit-renderer.scss
@@ -20,6 +20,13 @@
   margin-right: $carbon--spacing-02;
 }
 
+.#{$iot-prefix}--value-card__attribute-unit--not-wrappable {
+  padding-left: 0.25rem;
+  padding-bottom: 0.8rem;
+  align-self: flex-end;
+  margin-right: $carbon--spacing-02;
+}
+
 .#{$iot-prefix}--value-card__attribute-unit--wrappable-compact {
   font-size: $carbon--spacing-05;
 }


### PR DESCRIPTION
Summary

This PR references these issues:

https://github.ibm.com/wiotp/monitoring-dashboard/issues/693

#1027

The original, closed PR can be found here: https://github.com/IBM/carbon-addons-iot-react/pull/1028

Long strings in ValueCards were not very accessible with only one line of text before the ellipsis. This PR allows long strings to wrap to a max of 2 lines.

Change List (commits, features, bugs, etc)

Added styling to ValueRenderer
Created new ValueCard story with a long string

Acceptance Test (how to verify the PR)

Navigate to ValueCard 'small / long string' and see the text wrap to two lines before the ellipsis.
