### PR TITLE
[TimeSeriesCard] enable hiding zero

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -64,7 +64,7 @@ module.exports = {
       statements: 70,
       branches: 50,
       lines: 69,
-      functions: 77,
+      functions: 76.47,
     },
     './src/components/Page/EditPage.jsx': {
       statements: 63,

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     ]
   },
   "dependencies": {
-    "@carbon/charts": "^0.29.0",
-    "@carbon/charts-react": "^0.29.0",
+    "@carbon/charts": "^0.30.5",
+    "@carbon/charts-react": "^0.30.5",
     "@carbon/colors": "10.7.0",
     "@carbon/icons": "10.6.1",
     "@carbon/icons-react": "10.6.1",

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useRef, useMemo, useCallback } from 'react';
+import React, { useRef, useMemo, useCallback } from 'react';
 import moment from 'moment/min/moment-with-locales.min';
 import LineChart from '@carbon/charts-react/line-chart';
 import StackedBarChart from '@carbon/charts-react/bar-chart-stacked';
@@ -182,12 +182,21 @@ export const handleTooltip = (dataOrHoveredElement, defaultTooltip, alertRanges,
 
 const TimeSeriesCard = ({
   title,
-  content: { series, timeDataSourceId = 'timestamp', alertRanges, xLabel, yLabel, unit, chartType },
+  content: {
+    series,
+    timeDataSourceId = 'timestamp',
+    alertRanges,
+    xLabel,
+    yLabel,
+    includeZeroOnXaxis,
+    includeZeroOnYaxis,
+    unit,
+    chartType,
+  },
   size,
   interval,
   isEditable,
   values: valuesProp,
-
   locale,
   i18n: { alertDetected, noDataLabel },
   i18n,
@@ -368,7 +377,7 @@ const TimeSeriesCard = ({
       isLazyLoading={isLazyLoading || (valueSort && valueSort.length > 200)}
     >
       {!others.isLoading && !isAllValuesEmpty ? (
-        <Fragment>
+        <>
           <LineChartWrapper
             size={newSize}
             isEditable={isEditable}
@@ -394,6 +403,7 @@ const TimeSeriesCard = ({
                       max: maxTicksPerSize,
                       formatter: formatTick,
                     },
+                    includeZero: includeZeroOnXaxis,
                   },
                   left: {
                     title: yLabel,
@@ -405,6 +415,7 @@ const TimeSeriesCard = ({
                       ? { primary: true }
                       : { secondary: true }),
                     stacked: chartType === TIME_SERIES_TYPES.BAR && lines.length > 1,
+                    includeZero: includeZeroOnYaxis,
                   },
                 },
                 legend: { position: 'top', clickable: !isEditable, enabled: lines.length > 1 },
@@ -462,7 +473,7 @@ const TimeSeriesCard = ({
               i18n={i18n}
             />
           ) : null}
-        </Fragment>
+        </>
       ) : null}
     </Card>
   );
@@ -478,6 +489,10 @@ TimeSeriesCard.defaultProps = {
   },
   chartType: TIME_SERIES_TYPES.LINE,
   locale: 'en',
+  content: {
+    includeZeroOnXaxis: true,
+    includeZeroOnYaxis: true,
+  },
 };
 
 export default TimeSeriesCard;

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -34,6 +34,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             ],
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('hour', 1, { min: 10, max: 100 }, 100)}
@@ -64,6 +66,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             ],
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 10, { min: 10, max: 100 }, 100)}
@@ -95,6 +99,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
 
             xLabel: text('xLabel', 'Time t'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           locale={select('locale', ['en', 'fr', 'zh_TW'], 'en')}
@@ -126,6 +132,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
 
             xLabel: text('xLabel', 'Time t'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 10, { min: 10, max: 100 }, 100)}
@@ -158,6 +166,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
 
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('minute', 10, { min: 10, max: 100 }, 100)}
@@ -185,9 +195,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('hour', 24, { min: 10, max: 100 }, 100)}
@@ -215,9 +226,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100)}
@@ -248,6 +260,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
 
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 30, { min: 10, max: 100 }, 100)}
@@ -275,9 +289,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 19, { min: 10, max: 100 }, 100)}
@@ -305,9 +320,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('month', 6, { min: 10, max: 100 }, 100)}
@@ -335,9 +351,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
@@ -380,9 +397,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('month', 6, { min: 10, max: 100 }, 100)}
@@ -409,14 +427,15 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
               {
-                label: 'Presurre',
+                label: 'Pressure',
                 dataSourceId: 'pressure',
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('year', 2, { min: 10, max: 100 }, 100)}
@@ -458,9 +477,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.TEAL),
               },
             ],
-
             xLabel: text('xLabel', ''),
             yLabel: text('yLabel', ''),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('minute', 12, { min: 10, max: 100 }, 100)}
@@ -487,9 +507,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('minute', 15, { min: 10, max: 100 }, 100)}
@@ -517,9 +538,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('hour', 32, { min: 10, max: 100 }, 100)}
@@ -547,9 +569,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 24, { min: 10, max: 100 }, 100)}
@@ -577,9 +600,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 30, { min: 10, max: 100 }, 100)}
@@ -607,9 +631,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('month', 6, { min: 10, max: 100 }, 100)}
@@ -637,9 +662,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('month', 24, { min: 10, max: 100 }, 100)}
@@ -667,9 +693,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('year', 10, { min: 10, max: 100 }, 100)}
@@ -696,9 +723,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 12, { min: 2000, max: 7000 }, 100)}
@@ -726,9 +754,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Pressure'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 10, { min: 10, max: 100 }, 1000)}
@@ -761,9 +790,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 // color: text('color', COLORS.PURPLE),
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100)}
@@ -795,9 +825,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 color: COLORS.TEAL,
               },
             ],
-
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('minute', 12, { min: 10, max: 100 }, 100)}
@@ -830,9 +861,10 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 color: text('color', COLORS.TEAL),
               },
             ],
-
             xLabel: text('xLabel', ''),
             yLabel: text('yLabel', ''),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('minute', 12, { min: 10, max: 100 }, 100)}
@@ -863,6 +895,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             unit: '˚F',
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 10, { min: 10, max: 100 }, 100)}
@@ -893,6 +927,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             unit: '˚F',
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('year', 5, { min: 10, max: 100 }, 100)}
@@ -925,9 +961,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
                 color: text('color', COLORS.TEAL),
               },
             ],
-
-            // xLabel: text('xLabel', ),
-            // yLabel: text('yLabel',),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('minute', 12, { min: 10, max: 100 }, 100)}
@@ -984,6 +1019,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             ],
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
             alertRanges: [
               {
@@ -1026,6 +1063,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               },
             ],
             timeDataSourceId: 'timestamp',
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
           })}
           range="day"
           interval="hour"
@@ -1055,6 +1094,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             ],
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature (˚F)'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 100, { min: 10, max: 100 }, 100, 1572824320000)}
@@ -1094,6 +1135,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               },
             ],
             xLabel: text('xLabel', 'Time'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           interval={select('interval', ['hour', 'day', 'week', 'month', 'year'], 'hour')}
@@ -1125,6 +1168,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             unit: '˚F',
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
             chartType: TIME_SERIES_TYPES.BAR,
           })}
@@ -1169,6 +1214,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             unit: '˚F',
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('day', 12, { min: 10, max: 100 }, 100).reduce(
@@ -1211,6 +1258,8 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             unit: '˚F',
             xLabel: text('xLabel', 'Time'),
             yLabel: text('yLabel', 'Temperature'),
+            includeZeroOnXaxis: boolean('Include Zero On X-Axis', true),
+            includeZeroOnYaxis: boolean('Include Zero On Y-Axis', true),
             timeDataSourceId: 'timestamp',
           })}
           locale="sq"

--- a/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -8,7 +8,6 @@ import { CARD_SIZES } from '../../constants/LayoutConstants';
 /* eslint-disable */
 import TimeSeriesCard, {
   determinePrecision,
-  formatChartData,
   valueFormatter,
   handleTooltip,
 } from './TimeSeriesCard';
@@ -29,7 +28,7 @@ const timeSeriesCardProps = {
     yLabel: 'Temperature (˚F)',
     timeDataSourceId: 'timestamp',
   },
-  values: getIntervalChartData('hour', 1, { min: 10, max: 100 }, 100),
+  values: getIntervalChartData('hour', 1, { min: 50, max: 100 }, 100),
   interval: 'hour',
   breakpoint: 'lg',
   size: 'LARGE',

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -90,8 +90,14 @@ export const TimeSeriesCardPropTypes = {
       TimeSeriesDatasetPropTypes,
       PropTypes.arrayOf(TimeSeriesDatasetPropTypes),
     ]).isRequired,
+    /** Custom X-axis label */
     xLabel: PropTypes.string,
+    /** Custom Y-axis label */
     yLabel: PropTypes.string,
+    /** Optionally hide zero. Useful when chart values are not close to zero, giving a better view of the meaningful data */
+    includeZeroOnXaxis: PropTypes.bool,
+    /** Optionally hide zero. Useful when chart values are not close to zero, giving a better view of the meaningful data */
+    includeZeroOnYaxis: PropTypes.bool,
     /** Which attribute is the time attribute */
     timeDataSourceId: PropTypes.string,
     /** should it be a line chart or bar chart, default is line chart */

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7484,6 +7484,10 @@ Map {
   "TimeSeriesCard" => Object {
     "defaultProps": Object {
       "chartType": "LINE",
+      "content": Object {
+        "includeZeroOnXaxis": true,
+        "includeZeroOnYaxis": true,
+      },
       "i18n": Object {
         "alertDetected": "Alert detected:",
       },
@@ -7958,6 +7962,12 @@ Map {
                 ],
               ],
               "type": "oneOf",
+            },
+            "includeZeroOnXaxis": Object {
+              "type": "bool",
+            },
+            "includeZeroOnYaxis": Object {
+              "type": "bool",
             },
             "series": Object {
               "args": Array [

--- a/src/utils/sample.jsx
+++ b/src/utils/sample.jsx
@@ -2439,7 +2439,7 @@ export const generateData = (quantity, intInterval, decimals) => {
 
 /**
  *
- * @param {*} interval
+ * @param {string} interval time-based
  * @param {*} quantity
  * @param {*} intInterval
  * @param {*} decimals

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,24 +1972,28 @@
   resolved "https://registry.yarnpkg.com/@base2/pretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha512-4Th98KlMHr5+JkxfcoDT//6vY8vM+iSPrLNpHhRyLx2CFYi8e2RfqPLdpbnpo0Q5lQC5hNB79yes07zb02fvCw==
 
-"@carbon/charts-react@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@carbon/charts-react/-/charts-react-0.29.0.tgz#89223751fc51e037c0c1fb10711fffa5bc6d1eca"
-  integrity sha512-uwFv7sGtA8wSZYQmSB297yLtW9lILbNrD9/grbZQnYHKkOUFZStoJs/wU+46yGoPGvbRfXnPGoPsIVfi8F8Vhg==
+"@carbon/charts-react@^0.30.5":
+  version "0.30.5"
+  resolved "https://registry.yarnpkg.com/@carbon/charts-react/-/charts-react-0.30.5.tgz#74bfe1bc15cdd37b41f180f31a9dfe3a1c127887"
+  integrity sha512-p35StjL/XNBvLWiVSfhB+Kpg9MNA4pGSKyQxNhMW7+mGUWsRATqYBRwPZ1XjxzN/Vx9dhg5FsKSq+JpUPwHvwg==
   dependencies:
-    "@carbon/charts" "^0.29.0"
+    "@carbon/charts" "^0.30.5"
 
-"@carbon/charts@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@carbon/charts/-/charts-0.29.0.tgz#8ea1c6449de741465ea574b51bf94ba11d35b6ef"
-  integrity sha512-QWD73L5dHI1JU5S87VIJWuvKzdpOXZ7g9pnWQ4BiFtzjFfplZnEnRQT6d/b4n4kmZ4Oze4i0ekI5kMlNs5MWGQ==
+"@carbon/charts@^0.30.5":
+  version "0.30.5"
+  resolved "https://registry.yarnpkg.com/@carbon/charts/-/charts-0.30.5.tgz#e503c93ca93ea0a31c417fad7a399e88343877e8"
+  integrity sha512-IrPwKIpU61RnKVKgD3zfrLKoag8To2M4WtZ/3gszQdE816TbLhURI28RaYQlUvqcu3nPIWo+jnhAHjb7Xh5XPw==
   dependencies:
+    "@carbon/colors" "10.4.0"
     "@carbon/utils-position" "1.1.1"
-    babel-polyfill "6.26.0"
-    carbon-components "10.5.0"
     date-fns "2.8.1"
     lodash-es "4.17.15"
     resize-observer-polyfill "1.5.0"
+
+"@carbon/colors@10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-10.4.0.tgz#8c21127926bc389dcb4d415b55d4eae278f3d525"
+  integrity sha512-UERU07hWXAjsaWu6JPJDyJnwVLkJr+8wTvFrbCkubCfl/MZjKoyLgz0CNypu8hSg8ZaDUzl/NfXMgRpprzuSjQ==
 
 "@carbon/colors@10.7.0", "@carbon/colors@^10.7.0":
   version "10.7.0"
@@ -5577,16 +5581,6 @@ carbon-components-react@7.9.1:
     react-is "^16.8.6"
     warning "^3.0.0"
     window-or-global "^1.0.1"
-
-carbon-components@10.5.0:
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.5.0.tgz#f9d0d4da57b41ba958a30745cb4ada902e491345"
-  integrity sha512-ptsULtugjrrnj7rb2BYK3KAvNjbTdphh62OmOMNaLLswB7jA7S3rnXJrOOWt8o7PeEad3U0ewW49G9OlbpX+mg==
-  dependencies:
-    carbon-icons "^7.0.7"
-    flatpickr "4.6.1"
-    lodash.debounce "^4.0.8"
-    warning "^3.0.0"
 
 carbon-components@10.9.1:
   version "10.9.1"


### PR DESCRIPTION
Closes #1048 

**Summary**

- Allows user to hide zero, meaning the data can be focused and be easier to read

**Before**
![Screen Shot 2020-03-30 at 12 37 06 PM](https://user-images.githubusercontent.com/25177649/77943691-414bf280-7283-11ea-8575-b77f7117086e.png)


**After**
![Screen Shot 2020-03-30 at 12 37 12 PM](https://user-images.githubusercontent.com/25177649/77943699-4610a680-7283-11ea-8301-ba7874604f47.png)


**Change List (commits, features, bugs, etc)**

- Upgraded carbon version to pick up the `showZero` prop
- Added `includeZeroOnXaxis` and `includeZeroOnYaxis` props which default to true
- Added knobs to each TimeSeriesCard story

**Acceptance Test (how to verify the PR)**

- Go to any TimeSeriesCard story that has data high above 0 and change the `content` JSON object's `includeZeroOnYaxis` prop to false to see the change. The stories' data is randomized so this may take a few clicks between stories or refreshes.
