### PR TITLE
[TableCard] - columns render in correct order regardless or quantity

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -212,6 +212,7 @@ export const findMatchingThresholds = (thresholds, item, columnId) => {
       const currentThresholdIndex = highestSeverityThreshold.findIndex(
         currentThreshold => currentThreshold.dataSourceId === threshold.dataSourceId
       );
+
       if (
         // If I don't have a threshold currently for this column
         currentThresholdIndex < 0
@@ -374,15 +375,15 @@ const TableCard = ({
    */
   const generateThresholdColumn = columnId => {
     // Need to find the index of the dataSource regardless of uniqueThresholds ordering
-    const thresholdIndex = uniqueThresholds.findIndex(
+    const uniqueThresholdIndex = uniqueThresholds.findIndex(
       threshold => threshold.dataSourceId === columnId
     );
     return {
       id: `iconColumn-${columnId}`,
-      label: uniqueThresholds[thresholdIndex].label
-        ? uniqueThresholds[thresholdIndex].label
+      label: uniqueThresholds[uniqueThresholdIndex].label
+        ? uniqueThresholds[uniqueThresholdIndex].label
         : `${capitalize(columnId)} ${strings.severityLabel}`,
-      width: uniqueThresholds[thresholdIndex].width,
+      width: uniqueThresholds[uniqueThresholdIndex].width,
       isSortable: true,
       renderDataFunction: renderThresholdIcon,
       priority: 1,
@@ -408,25 +409,32 @@ const TableCard = ({
 
   // Don't add the icon column in sample mode
   if (!isEditable) {
-    const indexes = columns
-      .map((column, index) =>
-        uniqueThresholds.filter(item => item.dataSourceId === column.dataSourceId)[0]
-          ? { i: index, columnId: column.dataSourceId } // Find the column and put the threshold next to it
-          : null
-      )
-      .filter(i => !isNil(i));
-    indexes.forEach(({ i, columnId }, index) => {
-      columnsUpdated.splice(index !== 0 ? i + 1 : i, 0, generateThresholdColumn(columnId));
+    // Add the new threshold columns to the existing columns
+    uniqueThresholds.forEach(threshold => {
+      const columnIndex = columnsUpdated.findIndex(
+        column => column.dataSourceId === threshold.dataSourceId
+      );
+      // If columnIndex is not -1, there was a match so add the column. Otherwise, skip the column as it will be added
+      // in the next call
+      if (columnIndex !== -1) {
+        columnsUpdated.splice(columnIndex, 0, generateThresholdColumn(threshold.dataSourceId));
+      }
     });
+
     // Check for any threshold columns that weren't matched (if the column was hidden) and add to the end of the array
-    const missingThresholdColumns = uniqueThresholds.filter(
-      threshold => !find(columnsUpdated, column => threshold.dataSourceId === column.dataSourceId)
-    );
-    columnsUpdated.splice(
-      columnsUpdated.length,
-      0,
-      ...missingThresholdColumns.map(({ dataSourceId }) => generateThresholdColumn(dataSourceId))
-    );
+    const missingThresholdColumns = uniqueThresholds.filter(threshold => {
+      return !find(columnsUpdated, column => {
+        return threshold.dataSourceId === column.dataSourceId;
+      });
+    });
+
+    if (missingThresholdColumns.length > 0) {
+      columnsUpdated.splice(
+        columnsUpdated.length,
+        0,
+        ...missingThresholdColumns.map(({ dataSourceId }) => generateThresholdColumn(dataSourceId))
+      );
+    }
   }
 
   const newColumns = thresholds ? columnsUpdated : columns;


### PR DESCRIPTION
Closes #1052 

**Summary**

- Column indices were being referenced from the incorrect column array in a loop causing the indices to be off on each iteration

Apologies for 2 different photos, but you can see the threshold column differences

**Before**

![image](https://media.github.ibm.com/user/103145/files/f3001900-72ad-11ea-97f1-58337fad4927)

**After**

![Screen Shot 2020-03-31 at 1 17 18 PM](https://user-images.githubusercontent.com/25177649/78060899-f8af3a80-7351-11ea-95e7-da6c7eeafe83.png)

**Change List (commits, features, bugs, etc)**

- Updated variable names to be more specific
- Updated `generateThresholdColumn` to iterate on the `uniqueThresholds` vs the `columns` as its less complex and will require fewer iterations
- Updated column update splicing and indexing to use `columnsUpdated` vs `columns` as `columnsUpdated` is whats actually being manipulated

**Acceptance Test (how to verify the PR)**

1. Go to TableCard with thresholds story and add a third threshold for hours with the following additional threshold: 
```
{
          dataSourceId: 'hour',
          comparison: '<',
          value: 10,
          severity: 1,
 },
```
2. You should see the Hour Severity column display to the left of Hour, and all other severity columns should be to the left of their respective source columns

