### PR TITLE
Allow tooltip content to contain button and links

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -110,6 +110,5 @@ module.exports = {
     // rewrite carbon-components(-react) es imports to lib/cjs imports because jest doesn't support es modules
     '@carbon/icons-react/es/(.*)': '@carbon/icons-react/lib/$1',
     'carbon-components-react/es/(.*)': 'carbon-components-react/lib/$1',
-    'react-syntax-highlighter/dist/esm/(.*)': 'react-syntax-highlighter/dist/cjs/$1',
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -110,5 +110,6 @@ module.exports = {
     // rewrite carbon-components(-react) es imports to lib/cjs imports because jest doesn't support es modules
     '@carbon/icons-react/es/(.*)': '@carbon/icons-react/lib/$1',
     'carbon-components-react/es/(.*)': 'carbon-components-react/lib/$1',
+    'react-syntax-highlighter/dist/esm/(.*)': 'react-syntax-highlighter/dist/cjs/$1',
   },
 };

--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -60,6 +60,12 @@ const defaultProps = {
   content: undefined,
 };
 
+// do typecheck to support old markup with surrounding 'p' tag
+// eslint-disable-next-line
+export const TooltipDescription = ({ description }) => {
+  return typeof description === 'string' ? <p>{description}</p> : description;
+};
+
 const PageTitleBar = ({
   title,
   description,
@@ -77,10 +83,6 @@ const PageTitleBar = ({
 }) => {
   //
   const titleBarContent = content || tabs;
-  // do typecheck to support old markup with surrounding 'p' tag
-  const TooltipDescription = () => {
-    return typeof description === 'string' ? <p>{description}</p> : description;
-  };
 
   return (
     <div className={classNames(className, 'page-title-bar')}>
@@ -110,7 +112,7 @@ const PageTitleBar = ({
                       tooltipId="tooltip"
                       renderIcon={Information20}
                     >
-                      {<TooltipDescription />}
+                      {<TooltipDescription description={description} />}
                     </Tooltip>
                   ) : null}
                   {editable ? (

--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -77,6 +77,9 @@ const PageTitleBar = ({
 }) => {
   //
   const titleBarContent = content || tabs;
+  // do typecheck to support old markup with surrounding 'p' tag
+  const tooltipDescription = typeof description === 'string' ? <p>{description}</p> : description;
+
   return (
     <div className={classNames(className, 'page-title-bar')}>
       {isLoading ? (
@@ -105,7 +108,7 @@ const PageTitleBar = ({
                       tooltipId="tooltip"
                       renderIcon={Information20}
                     >
-                      <p>{description}</p>
+                      {tooltipDescription}
                     </Tooltip>
                   ) : null}
                   {editable ? (

--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -78,7 +78,9 @@ const PageTitleBar = ({
   //
   const titleBarContent = content || tabs;
   // do typecheck to support old markup with surrounding 'p' tag
-  const tooltipDescription = typeof description === 'string' ? <p>{description}</p> : description;
+  const TooltipDescription = () => {
+    return typeof description === 'string' ? <p>{description}</p> : description;
+  };
 
   return (
     <div className={classNames(className, 'page-title-bar')}>
@@ -108,7 +110,7 @@ const PageTitleBar = ({
                       tooltipId="tooltip"
                       renderIcon={Information20}
                     >
-                      {tooltipDescription}
+                      {<TooltipDescription />}
                     </Tooltip>
                   ) : null}
                   {editable ? (

--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -11,7 +11,7 @@ const PageTitleBarPropTypes = {
   /** Title of the page  */
   title: PropTypes.node.isRequired,
   /** Details about what the page shows */
-  description: PropTypes.node,
+  description: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   /** Optional node to render in the right side of the PageTitleBar
    *  NOTE: Deprecated in favor of extraContent
    */
@@ -61,7 +61,7 @@ const defaultProps = {
 };
 
 // do typecheck to support old markup with surrounding 'p' tag
-// eslint-disable-next-line
+// eslint-disable-next-line react/prop-types
 export const TooltipDescription = ({ description }) => {
   return typeof description === 'string' ? <p>{description}</p> : description;
 };

--- a/src/components/PageTitleBar/PageTitleBar.story.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.story.jsx
@@ -24,6 +24,13 @@ export const commonPageTitleBarProps = {
   ),
 };
 
+const NodeTooltip = () => (
+  <div>
+    Descriptive text about this page and what the user can or should do on it{' '}
+    <button type="button">Even Buttons</button>
+  </div>
+);
+
 export const pageTitleBarBreadcrumb = [
   <a href="/">Home</a>,
   <a href="/">Type</a>,
@@ -42,10 +49,10 @@ storiesOf('Watson IoT/PageTitleBar', module)
       description={commonPageTitleBarProps.description}
     />
   ))
-  .add('with tooltip description', () => (
+  .add('with tooltip description as node', () => (
     <PageTitleBar
       title={commonPageTitleBarProps.title}
-      description={commonPageTitleBarProps.description}
+      description={<NodeTooltip />}
       breadcrumb={pageTitleBarBreadcrumb}
       collapsed
     />

--- a/src/components/PageTitleBar/PageTitleBar.test.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.test.jsx
@@ -4,7 +4,7 @@ import { SkeletonText, Tabs, Tab } from 'carbon-components-react';
 
 import Button from '../Button';
 
-import PageTitleBar from './PageTitleBar';
+import PageTitleBar, { TooltipDescription } from './PageTitleBar';
 import { commonPageTitleBarProps, pageTitleBarBreadcrumb } from './PageTitleBar.story';
 
 describe('PageTitleBar', () => {
@@ -115,5 +115,21 @@ describe('PageTitleBar', () => {
   test('Renders loading state as expected', () => {
     const wrapper = mount(<PageTitleBar title={commonPageTitleBarProps.title} isLoading />);
     expect(wrapper.find(SkeletonText)).toHaveLength(1);
+  });
+
+  test('Should render p tag for legacy support', () => {
+    const wrapper = mount(<TooltipDescription description={commonPageTitleBarProps.description} />);
+    expect(wrapper.find('p')).toHaveLength(1);
+  });
+
+  test('Should not render p tag', () => {
+    const NodeTooltip = () => (
+      <div>
+        Descriptive text about this page and what the user can or should do on it{' '}
+        <button type="button">Even Buttons</button>
+      </div>
+    );
+    const wrapper = mount(<TooltipDescription description={<NodeTooltip />} />);
+    expect(wrapper.find('p')).toHaveLength(0);
   });
 });

--- a/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -397,8 +397,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                 width={10}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <path
-                  d="M5 6L0 1 0.7 0.3 5 4.6 9.3 0.3 10 1z"
+                <polygon
+                  points="5,6 0,1 0.7,0.3 5,4.6 9.3,0.3 10,1"
                 />
                 <title>
                   show menu options
@@ -958,8 +958,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                 width={10}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <path
-                  d="M5 6L0 1 0.7 0.3 5 4.6 9.3 0.3 10 1z"
+                <polygon
+                  points="5,6 0,1 0.7,0.3 5,4.6 9.3,0.3 10,1"
                 />
                 <title>
                   show menu options
@@ -1255,7 +1255,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
 </div>
 `;
 
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageTitleBar with tooltip description 1`] = `
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageTitleBar with tooltip description as node 1`] = `
 <div
   className="storybook-container"
 >

--- a/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
+++ b/src/components/PageTitleBar/__snapshots__/PageTitleBar.story.storyshot
@@ -397,8 +397,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                 width={10}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <polygon
-                  points="5,6 0,1 0.7,0.3 5,4.6 9.3,0.3 10,1"
+                <path
+                  d="M5 6L0 1 0.7 0.3 5 4.6 9.3 0.3 10 1z"
                 />
                 <title>
                   show menu options
@@ -958,8 +958,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/PageT
                 width={10}
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <polygon
-                  points="5,6 0,1 0.7,0.3 5,4.6 9.3,0.3 10,1"
+                <path
+                  d="M5 6L0 1 0.7 0.3 5 4.6 9.3 0.3 10 1z"
                 />
                 <title>
                   show menu options


### PR DESCRIPTION
Closes #1010 

**Summary**

Tooltip should have the ability to render links and buttons inside. Most of our implementation allows for this. The only exceptions in PageTitleBar. This PR changes the markup to allow for any type of content and not just text. 

**Change List (commits, features, bugs, etc)**

- Added check for description type in PageTitleBar.jsx to support old markup and the new custom node. 
- Changed the story to show off the rendering node as tooltip. 

**Acceptance Test (how to verify the PR)**

- go to PageTitleBar story at ...
- Should see tooltip render with Button inside. 
