### PR TITLE
chore(catalog-content): migrate to scss

### DIFF
--- a/src/components/TileCatalog/CatalogContent.jsx
+++ b/src/components/TileCatalog/CatalogContent.jsx
@@ -1,54 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
-import { COLORS, TYPOGRAPHY, MEDIA_QUERIES } from '../../styles/styles';
+import { settings } from '../../constants/Settings';
 
-const SampleTile = styled.div`
-  display: flex;
-  flex-flow: row nowrap;
-  align-items: center;
-  min-height: 6rem;
-  height: 100%;
-  overflow: hidden;
-`;
-
-const SampleTileIcon = styled.div`
-  background-color: ${COLORS.lightGrey};
-  height: 100px;
-  width: 100px;
-  min-height: 100px;
-  min-width: 100px;
-  display: flex;
-  flex-flow: column;
-  align-items: center;
-  justify-content: center;
-`;
-const SampleTileTitle = styled.div`
-  color: ${COLORS.blue};
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow-x: hidden;
-  padding-bottom: 0.5rem;
-  max-width: calc(100vw - 20rem);
-  @media screen and (min-width: ${MEDIA_QUERIES.twoPane}) {
-    max-width: calc(100vw / 2 - 15rem);
-  }
-  @media screen and (min-width: ${MEDIA_QUERIES.threePane}) {
-    max-width: calc(100vw / 3 - 15rem);
-  }
-`;
-
-const SampleTileContents = styled.div`
-  display: flex;
-  flex-flow: column nowrap;
-  padding: 0 1rem;
-  align-self: flex-start;
-`;
-
-const SampleTileDescription = styled.div`
-  font-size: ${TYPOGRAPHY.details};
-`;
+const { iotPrefix } = settings;
 
 const propTypes = {
   /** optional icon to visually describe catalog item */
@@ -63,15 +18,15 @@ const defaultProps = {
 };
 /** Reusable widget to show Catalog contents in a tile catalog */
 const CatalogContent = ({ icon, title, description }) => (
-  <SampleTile>
-    {icon ? <SampleTileIcon>{icon}</SampleTileIcon> : null}
-    <SampleTileContents>
-      <SampleTileTitle>
+  <div className={`${iotPrefix}--sample-tile`}>
+    {icon ? <div className={`${iotPrefix}--sample-tile-icon`}>{icon}</div> : null}
+    <div className={`${iotPrefix}--sample-tile-contents`}>
+      <div className={`${iotPrefix}--sample-tile-title`}>
         <span title={title}>{title}</span>
-      </SampleTileTitle>
-      <SampleTileDescription>{description}</SampleTileDescription>
-    </SampleTileContents>
-  </SampleTile>
+      </div>
+      <div className={`${iotPrefix}--sample-tile-description`}>{description}</div>
+    </div>
+  </div>
 );
 
 CatalogContent.propTypes = propTypes;

--- a/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
+++ b/src/components/TileCatalog/__snapshots__/TileCatalog.story.storyshot
@@ -245,10 +245,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -270,10 +270,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile with really long title that should wrap"
@@ -282,7 +282,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -341,10 +341,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -366,10 +366,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile2"
@@ -378,7 +378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -437,10 +437,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -462,10 +462,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile3"
@@ -474,7 +474,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Tile contents
                 </div>
@@ -533,10 +533,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -558,10 +558,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile4"
@@ -570,7 +570,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -629,10 +629,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -654,10 +654,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile5"
@@ -666,7 +666,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -725,10 +725,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -750,10 +750,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile6"
@@ -762,7 +762,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -821,10 +821,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -846,10 +846,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile7"
@@ -858,7 +858,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -1039,10 +1039,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1064,10 +1064,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile with really long title that should wrap"
@@ -1076,7 +1076,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -1135,10 +1135,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1160,10 +1160,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile2"
@@ -1172,7 +1172,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -1231,10 +1231,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1256,10 +1256,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile3"
@@ -1268,7 +1268,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Tile contents
                 </div>
@@ -1327,10 +1327,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1352,10 +1352,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile4"
@@ -1364,7 +1364,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -1423,10 +1423,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1448,10 +1448,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile5"
@@ -1460,7 +1460,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -1519,10 +1519,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1544,10 +1544,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile6"
@@ -1556,7 +1556,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -1615,10 +1615,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1640,10 +1640,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile7"
@@ -1652,7 +1652,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -1947,10 +1947,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -1972,10 +1972,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile with really long title that should wrap"
@@ -1984,7 +1984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -2043,10 +2043,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2068,10 +2068,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile2"
@@ -2080,7 +2080,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -2139,10 +2139,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2164,10 +2164,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile3"
@@ -2176,7 +2176,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Tile contents
                 </div>
@@ -2235,10 +2235,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2260,10 +2260,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile4"
@@ -2272,7 +2272,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -2331,10 +2331,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2356,10 +2356,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile5"
@@ -2368,7 +2368,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -2427,10 +2427,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2452,10 +2452,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile6"
@@ -2464,7 +2464,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -2715,10 +2715,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2740,10 +2740,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile with really long title that should wrap"
@@ -2752,7 +2752,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -2811,10 +2811,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2836,10 +2836,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile2"
@@ -2848,7 +2848,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -2907,10 +2907,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -2932,10 +2932,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile3"
@@ -2944,7 +2944,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Tile contents
                 </div>
@@ -3003,10 +3003,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -3028,10 +3028,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile4"
@@ -3040,7 +3040,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -3099,10 +3099,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -3124,10 +3124,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile5"
@@ -3136,7 +3136,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>
@@ -3195,10 +3195,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
             className="bx--tile-content"
           >
             <div
-              className="CatalogContent__SampleTile-ewhoqc-0 fGbFFm"
+              className="iot--sample-tile"
             >
               <div
-                className="CatalogContent__SampleTileIcon-ewhoqc-1 bUtNbv"
+                className="iot--sample-tile-icon"
               >
                 <svg
                   aria-hidden={true}
@@ -3220,10 +3220,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                 </svg>
               </div>
               <div
-                className="CatalogContent__SampleTileContents-ewhoqc-3 jiLgiJ"
+                className="iot--sample-tile-contents"
               >
                 <div
-                  className="CatalogContent__SampleTileTitle-ewhoqc-2 hHDEru"
+                  className="iot--sample-tile-title"
                 >
                   <span
                     title="Test Tile6"
@@ -3232,7 +3232,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TileC
                   </span>
                 </div>
                 <div
-                  className="CatalogContent__SampleTileDescription-ewhoqc-4 kFPOSR"
+                  className="iot--sample-tile-description"
                 >
                   Really long string with lots of lots of text too much to show on one line and when it wraps it might cause some interesting issues especially if it starts vertically wrapping outside of tile bounds at the bottom of the tile
                 </div>

--- a/src/components/TileCatalog/_catalog-content.scss
+++ b/src/components/TileCatalog/_catalog-content.scss
@@ -1,0 +1,48 @@
+@import '~carbon-components/scss/globals/scss/vars';
+@import '../../globals/vars';
+
+.#{$iot-prefix}--sample-tile {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  min-height: 6rem;
+  height: 100%;
+  overflow: hidden;
+}
+.#{$iot-prefix}--sample-tile-icon {
+  background-color: #dfe3e6;
+  height: 100px;
+  width: 100px;
+  min-height: 100px;
+  min-width: 100px;
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.#{$iot-prefix}--sample-tile-title {
+  color: #3d70b2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-x: hidden;
+  padding-bottom: 0.5rem;
+  max-width: calc(100vw - 20rem);
+  @media screen and (min-width: $two-pane) {
+    max-width: calc(100vw / 2 - 15rem);
+  }
+  @media screen and (min-width: $three-pane) {
+    max-width: calc(100vw / 3 - 15rem);
+  }
+}
+
+.#{$iot-prefix}--sample-tile-contents {
+  display: flex;
+  flex-flow: column nowrap;
+  padding: 0 1rem;
+  align-self: flex-start;
+}
+
+.#{$iot-prefix}--sample-tile-description {
+  font-size: $typography-01;
+}

--- a/src/globals/_vars.scss
+++ b/src/globals/_vars.scss
@@ -16,3 +16,8 @@ $iot-prefix: 'iot';
 /// @example 700px
 $two-pane: 700px;
 $three-pane: 1000px;
+
+/// @access public
+/// @type Number
+/// @example 0.5rem
+$typography-01: 0.875rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -243,5 +243,6 @@ $deprecations--message: 'Deprecated code was found, this code will be removed be
 @import 'components/TileCatalogNew/tile-catalog';
 @import 'components/TileCatalog/tile-catalog';
 @import 'components/TileCatalog/tile-group';
+@import 'components/TileCatalog/catalog-content';
 @import 'components/ValueCard/value-card';
 @import 'components/TimePickerSpinner/time-picker-spinner';


### PR DESCRIPTION
**Summary**

Migrate `CatalogContent` from styled-components to scss

**Acceptance Test (how to verify the PR)**

Navigate to TileCatalog and see that the content is still styled correctly.
