### PR TITLE
feat(timeseriescard): hide zero on axis by default

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -491,8 +491,8 @@ TimeSeriesCard.defaultProps = {
   chartType: TIME_SERIES_TYPES.LINE,
   locale: 'en',
   content: {
-    includeZeroOnXaxis: true,
-    includeZeroOnYaxis: true,
+    includeZeroOnXaxis: false,
+    includeZeroOnYaxis: false,
   },
 };
 

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7484,8 +7484,8 @@ Map {
     "defaultProps": Object {
       "chartType": "LINE",
       "content": Object {
-        "includeZeroOnXaxis": true,
-        "includeZeroOnYaxis": true,
+        "includeZeroOnXaxis": false,
+        "includeZeroOnYaxis": false,
       },
       "i18n": Object {
         "alertDetected": "Alert detected:",


### PR DESCRIPTION
#1048

**Summary**

- It was more beneficial to the user to hide zero on the axes and keep the data visualization more focused by default

**Change List (commits, features, bugs, etc)**

- Changed default setting to hide zero on x and y axes

**Acceptance Test (how to verify the PR)**

- Check the TimeSeriesCards to see that the 0 is hidden by default on stories that have no data near 0
