### PR TITLE
fix(valuecard): at certain card sizes font sizes were too big

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -16656,7 +16656,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="48.7 ˚F"
                               value={48.7}
@@ -16745,7 +16745,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="88.1 ˚F"
                               value={88.1}
@@ -16831,7 +16831,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="103.2 ˚F"
                               value={103.2}
@@ -18553,7 +18553,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="48.7 ˚F"
                               value={48.7}
@@ -18642,7 +18642,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="88.1 ˚F"
                               value={88.1}
@@ -18728,7 +18728,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="103.2 ˚F"
                               value={103.2}
@@ -19760,7 +19760,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -19801,7 +19801,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -19890,7 +19890,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -19931,7 +19931,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -20018,7 +20018,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -20059,7 +20059,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -20213,7 +20213,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -20254,7 +20254,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -20343,7 +20343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -20384,7 +20384,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -20471,7 +20471,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -20512,7 +20512,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -20666,7 +20666,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -20707,7 +20707,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -20796,7 +20796,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -20837,7 +20837,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -20924,7 +20924,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -20965,7 +20965,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -21119,7 +21119,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="89.2 %"
                               value={89.2}
@@ -21160,7 +21160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="21.3 mb"
                               value={21.3}
@@ -21249,7 +21249,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="88.3 ˚F"
                               value={88.3}
@@ -21290,7 +21290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                               size="SMALLWIDE"
                               title="Elevated "
                               value="Elevated"
@@ -21377,7 +21377,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="103.7 ˚F"
                               value={103.7}
@@ -21418,7 +21418,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="1709384.1 people"
                               value={1709384.1}
@@ -21572,7 +21572,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="38.2 %"
                               value={38.2}
@@ -21639,7 +21639,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="65.3 %"
                               value={65.3}
@@ -21754,7 +21754,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="77.2 ˚F"
                               value={77.2}
@@ -21821,7 +21821,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="91.3 ˚F"
                               value={91.3}
@@ -22001,7 +22001,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="38.2 %"
                               value={38.2}
@@ -22068,7 +22068,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="65.3 %"
                               value={65.3}
@@ -22183,7 +22183,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="77.2 ˚F"
                               value={77.2}
@@ -22250,7 +22250,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             color={null}
                           >
                             <span
-                              className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                              className="ValueRenderer__AttributeValue-f4stpz-1 ciICRO"
                               size="SMALLWIDE"
                               title="91.3 ˚F"
                               value={91.3}

--- a/src/components/ValueCard/ValueCard.jsx
+++ b/src/components/ValueCard/ValueCard.jsx
@@ -90,6 +90,7 @@ const determineLabelFontSize = ({ size, layout, attributeCount, isVertical }) =>
     case CARD_SIZES.SMALLWIDE:
       fontSize = 0.875;
       break;
+    case CARD_SIZES.MEDIUMTHIN:
     case CARD_SIZES.MEDIUM:
       fontSize = isVertical && attributeCount > 2 ? 0.875 : 1;
       break;
@@ -156,11 +157,11 @@ const determineLayout = (size, attributes, measuredWidth) => {
           ? CARD_LAYOUTS.VERTICAL
           : CARD_LAYOUTS.HORIZONTAL;
       break;
+    case CARD_SIZES.MEDIUM:
     case CARD_SIZES.MEDIUMTHIN:
       layout = CARD_LAYOUTS.VERTICAL;
       break;
     case CARD_SIZES.LARGETHIN:
-    case CARD_SIZES.MEDIUM:
     case CARD_SIZES.MEDIUMWIDE:
       if (attributes.length > 2) {
         layout = CARD_LAYOUTS.VERTICAL;
@@ -284,7 +285,9 @@ const ValueCard = ({
                         isVertical={isVertical}
                         layout={layout}
                         isSmall={
-                          newSize === CARD_SIZES.SMALL &&
+                          (newSize === CARD_SIZES.SMALL ||
+                            newSize === CARD_SIZES.SMALLWIDE ||
+                            newSize === CARD_SIZES.MEDIUMTHIN) &&
                           (attribute.secondaryValue !== undefined || attribute.label !== undefined)
                         }
                         isMini={isMini}

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -485,8 +485,8 @@ storiesOf('Watson IoT/ValueCard', module)
       </div>
     );
   })
-  .add('medium / vertical /  3', () => {
-    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUM);
+  .add('mediumthin / vertical /  3', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.MEDIUMTHIN);
     return (
       <div style={{ width: text('cardWidth', `120px`), margin: 20 }}>
         <ValueCard
@@ -677,7 +677,7 @@ storiesOf('Watson IoT/ValueCard', module)
               { label: 'Utilization', dataSourceId: 'utilization', unit: '%' },
               { label: 'CPU', dataSourceId: 'cpu', unit: '%' },
               { label: 'Humidity', dataSourceId: 'humidity', unit: '%' },
-              { label: 'Air flow', dataSourceId: 'air_flow', unit: '%' },
+              { label: 'Location', dataSourceId: 'location' },
               { label: 'Air quality', dataSourceId: 'air_quality', unit: '%' },
             ]),
           }}
@@ -689,7 +689,7 @@ storiesOf('Watson IoT/ValueCard', module)
             utilization: number('utilization', 76),
             humidity: number('humidity', 76),
             cpu: number('cpu', 76),
-            air_flow: number('air_flow', 76),
+            location: text('location', 'Australia'),
             air_quality: number('air_quality', 76),
           }}
         />

--- a/src/components/ValueCard/ValueCard.test.jsx
+++ b/src/components/ValueCard/ValueCard.test.jsx
@@ -15,6 +15,7 @@ describe('ValueCard', () => {
       <ValueCard
         content={{ attributes: [{ label: 'title', dataSourceId: 'v' }] }}
         values={{ v: 'value' }}
+        size={CARD_SIZES.LARGE}
       />
     );
     expect(wrapper.find(Attribute).prop('layout')).toEqual(CARD_LAYOUTS.HORIZONTAL);
@@ -30,6 +31,7 @@ describe('ValueCard', () => {
             { label: 'title4', dataSourceId: 'v4' },
           ],
         }}
+        size={CARD_SIZES.LARGE}
         values={{ v: 'value' }}
       />
     );

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -54,7 +54,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
               className="iot--data-state-container"
@@ -567,7 +567,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
               className="iot--data-state-container"
@@ -762,10 +762,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -778,7 +778,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="100 %"
                     value="100"
@@ -790,7 +790,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -806,7 +806,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               </div>
             </div>
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUM"
+            >
+              <hr
+                className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+              />
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -819,7 +827,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="50 %"
                     value="50"
@@ -831,7 +839,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -931,10 +939,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -947,7 +955,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="-- Wh"
                     value="--"
@@ -959,7 +967,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -975,7 +983,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               </div>
             </div>
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUM"
+            >
+              <hr
+                className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+              />
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -988,7 +1004,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="-- Wh"
                     value="--"
@@ -1000,7 +1016,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -1770,20 +1786,20 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
             >
               <div
                 className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                label="Air flow"
+                label="Location"
                 size="LARGETHIN"
               >
                 <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  className="ValueRenderer__Attribute-f4stpz-0 loxLrG"
                   color={null}
                 >
                   <span
                     className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="LARGETHIN"
-                    title="76 %"
-                    value={76}
+                    title="Australia "
+                    value="Australia"
                   >
-                    76
+                    Australia
                   </span>
                 </div>
                 <span
@@ -1794,15 +1810,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                     }
                   }
                 >
-                  %
+                  
                 </span>
               </div>
               <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
+                className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
                 size="LARGETHIN"
-                title="Air flow"
+                title="Location"
               >
-                Air flow
+                Location
               </div>
             </div>
             <div
@@ -2067,10 +2083,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -2083,7 +2099,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="100000000 Wh"
                     value={100000000}
@@ -2095,7 +2111,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -2111,7 +2127,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               </div>
             </div>
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUM"
+            >
+              <hr
+                className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+              />
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -2124,7 +2148,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="40000000000000 Wh"
                     value={40000000000000}
@@ -2136,7 +2160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -2236,10 +2260,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -2252,7 +2276,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="89 %"
                     value={89}
@@ -2264,7 +2288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -2280,7 +2304,15 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
               </div>
             </div>
             <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUM"
+            >
+              <hr
+                className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+              />
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
               size="MEDIUM"
             >
               <div
@@ -2293,7 +2325,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="76.7 ˚F"
                     value={76.7}
@@ -2305,7 +2337,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -2631,175 +2663,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
-          >
-            <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
-              size="MEDIUM"
-            >
-              <div
-                className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                label="Comfort Level"
-                size="MEDIUM"
-              >
-                <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                  color={null}
-                >
-                  <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
-                    size="MEDIUM"
-                    title="89 %"
-                    value={89}
-                  >
-                    89
-                  </span>
-                </div>
-                <span
-                  className="iot--value-card__attribute-unit"
-                  style={
-                    Object {
-                      "--default-font-size": "1.25rem",
-                    }
-                  }
-                >
-                  %
-                </span>
-              </div>
-              <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                size="MEDIUM"
-                title="Comfort Level"
-              >
-                Comfort Level
-              </div>
-            </div>
-            <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 fwYwXi"
-              size="MEDIUM"
-            >
-              <div
-                className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                label="Average Temperature"
-                size="MEDIUM"
-              >
-                <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                  color={null}
-                >
-                  <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
-                    size="MEDIUM"
-                    title="76.7 ˚F"
-                    value={76.7}
-                  >
-                    76.7
-                  </span>
-                </div>
-                <span
-                  className="iot--value-card__attribute-unit"
-                  style={
-                    Object {
-                      "--default-font-size": "1.25rem",
-                    }
-                  }
-                >
-                  ˚F
-                </span>
-              </div>
-              <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
-                size="MEDIUM"
-                title="Average Temperature"
-              >
-                Average Temperature
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <button
-    className="info__show-button"
-    onClick={[Function]}
-    style={
-      Object {
-        "background": "#027ac5",
-        "border": "none",
-        "borderRadius": "0 0 0 5px",
-        "color": "#fff",
-        "cursor": "pointer",
-        "display": "block",
-        "fontFamily": "sans-serif",
-        "fontSize": 12,
-        "padding": "5px 15px",
-        "position": "fixed",
-        "right": 0,
-        "top": 0,
-      }
-    }
-    type="button"
-  >
-    Show Info
-  </button>
-</div>
-`;
-
-exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard medium / vertical /  3 1`] = `
-<div
-  className="storybook-container"
->
-  <div
-    style={
-      Object {
-        "position": "relative",
-        "zIndex": 0,
-      }
-    }
-  >
-    <div
-      style={
-        Object {
-          "margin": 20,
-          "width": "120px",
-        }
-      }
-    >
-      <div
-        className="iot--card iot--card--wrapper"
-        data-testid="Card"
-        id="facilitycard"
-        role="presentation"
-        style={
-          Object {
-            "--card-default-height": "304px",
-          }
-        }
-      >
-        <div
-          className="iot--card--header"
-        >
-          <span
-            className="iot--card--title"
-            title="Facility Conditions"
-          >
-            <div
-              className="iot--card--title--text"
-            >
-              Facility Conditions
-            </div>
-          </span>
-        </div>
-        <div
-          className="iot--card--content"
-          style={
-            Object {
-              "--card-content-height": "256px",
-            }
-          }
-        >
-          <div
             className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
@@ -2818,10 +2681,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   <span
                     className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
-                    title="345678234234234240 %"
-                    value={345678234234234240}
+                    title="89 %"
+                    value={89}
                   >
-                    345678T
+                    89
                   </span>
                 </div>
                 <span
@@ -2834,32 +2697,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 >
                   %
                 </span>
-                <div
-                  className="iot--value-card__attribute-icon-container"
-                >
-                  <div
-                    className="iot--value-card__attribute-threshold-icon-container"
-                  >
-                    <svg
-                      aria-label="> 80"
-                      className="Attribute__ThresholdIcon-dhraql-2 goOrNp"
-                      fill="#F00"
-                      fillRule="evenodd"
-                      height="16"
-                      role="img"
-                      title="> 80"
-                      viewBox="0 0 16 16"
-                      width="16"
-                    >
-                      <title>
-                        &gt; 80
-                      </title>
-                      <path
-                        d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"
-                      />
-                    </svg>
-                  </div>
-                </div>
               </div>
               <div
                 className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
@@ -2893,10 +2730,10 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   <span
                     className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
-                    title="456778234234234240 ˚F"
-                    value={456778234234234240}
+                    title="76.7 ˚F"
+                    value={76.7}
                   >
-                    456778T
+                    76.7
                   </span>
                 </div>
                 <span
@@ -2909,32 +2746,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 >
                   ˚F
                 </span>
-                <div
-                  className="iot--value-card__attribute-icon-container"
-                >
-                  <div
-                    className="iot--value-card__attribute-threshold-icon-container"
-                  >
-                    <svg
-                      aria-label="> 80"
-                      className="Attribute__ThresholdIcon-dhraql-2 goOrNp"
-                      fill="#F00"
-                      fillRule="evenodd"
-                      height="16"
-                      role="img"
-                      title="> 80"
-                      viewBox="0 0 16 16"
-                      width="16"
-                    >
-                      <title>
-                        &gt; 80
-                      </title>
-                      <path
-                        d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"
-                      />
-                    </svg>
-                  </div>
-                </div>
               </div>
               <div
                 className="ValueCard__AttributeLabel-hyxf2q-4 hFUKTu"
@@ -2942,81 +2753,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 title="Average Temperature"
               >
                 Average Temperature
-              </div>
-            </div>
-            <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-              size="MEDIUM"
-            >
-              <hr
-                className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
-              />
-            </div>
-            <div
-              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
-              size="MEDIUM"
-            >
-              <div
-                className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
-                label="Humidity"
-                size="MEDIUM"
-              >
-                <div
-                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
-                  color={null}
-                >
-                  <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
-                    size="MEDIUM"
-                    title="88888678234234240000 ˚F"
-                    value={88888678234234240000}
-                  >
-                    88888678T
-                  </span>
-                </div>
-                <span
-                  className="iot--value-card__attribute-unit"
-                  style={
-                    Object {
-                      "--default-font-size": "1.5rem",
-                    }
-                  }
-                >
-                  ˚F
-                </span>
-                <div
-                  className="iot--value-card__attribute-icon-container"
-                >
-                  <div
-                    className="iot--value-card__attribute-threshold-icon-container"
-                  >
-                    <svg
-                      aria-label="> 80"
-                      className="Attribute__ThresholdIcon-dhraql-2 goOrNp"
-                      fill="#F00"
-                      fillRule="evenodd"
-                      height="16"
-                      role="img"
-                      title="> 80"
-                      viewBox="0 0 16 16"
-                      width="16"
-                    >
-                      <title>
-                        &gt; 80
-                      </title>
-                      <path
-                        d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ValueCard__AttributeLabel-hyxf2q-4 ceuwLr"
-                size="MEDIUM"
-                title="Humidity"
-              >
-                Humidity
               </div>
             </div>
           </div>
@@ -3330,7 +3066,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
           }
         >
           <div
-            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
           >
             <div
               className="ValueCard__AttributeWrapper-hyxf2q-1 eGXBSf"
@@ -3346,7 +3082,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 eXiWbd"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 ecuAUH"
                     size="MEDIUM"
                     title="89 %"
                     value={89}
@@ -3358,7 +3094,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   className="iot--value-card__attribute-unit"
                   style={
                     Object {
-                      "--default-font-size": "1.25rem",
+                      "--default-font-size": "1.5rem",
                     }
                   }
                 >
@@ -3597,6 +3333,310 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                 title="Utilization"
               >
                 Utilization
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard mediumthin / vertical /  3 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "120px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="facilitycard"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "304px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Facility Conditions"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Facility Conditions
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "256px",
+            }
+          }
+        >
+          <div
+            className="ValueCard__ContentWrapper-hyxf2q-0 jWmKBV"
+          >
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUMTHIN"
+            >
+              <div
+                className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                label="Comfort Level"
+                size="MEDIUMTHIN"
+              >
+                <div
+                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  color={null}
+                >
+                  <span
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kolfZc"
+                    size="MEDIUMTHIN"
+                    title="345678234234234240 %"
+                    value={345678234234234240}
+                  >
+                    345678T
+                  </span>
+                </div>
+                <span
+                  className="iot--value-card__attribute-unit"
+                  style={
+                    Object {
+                      "--default-font-size": "1.5rem",
+                    }
+                  }
+                >
+                  %
+                </span>
+                <div
+                  className="iot--value-card__attribute-icon-container"
+                >
+                  <div
+                    className="iot--value-card__attribute-threshold-icon-container"
+                  >
+                    <svg
+                      aria-label="> 80"
+                      className="Attribute__ThresholdIcon-dhraql-2 goOrNp"
+                      fill="#F00"
+                      fillRule="evenodd"
+                      height="16"
+                      role="img"
+                      title="> 80"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <title>
+                        &gt; 80
+                      </title>
+                      <path
+                        d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
+                size="MEDIUMTHIN"
+                title="Comfort Level"
+              >
+                Comfort Level
+              </div>
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUMTHIN"
+            >
+              <hr
+                className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+              />
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUMTHIN"
+            >
+              <div
+                className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                label="Average Temperature"
+                size="MEDIUMTHIN"
+              >
+                <div
+                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  color={null}
+                >
+                  <span
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kolfZc"
+                    size="MEDIUMTHIN"
+                    title="456778234234234240 ˚F"
+                    value={456778234234234240}
+                  >
+                    456778T
+                  </span>
+                </div>
+                <span
+                  className="iot--value-card__attribute-unit"
+                  style={
+                    Object {
+                      "--default-font-size": "1.5rem",
+                    }
+                  }
+                >
+                  ˚F
+                </span>
+                <div
+                  className="iot--value-card__attribute-icon-container"
+                >
+                  <div
+                    className="iot--value-card__attribute-threshold-icon-container"
+                  >
+                    <svg
+                      aria-label="> 80"
+                      className="Attribute__ThresholdIcon-dhraql-2 goOrNp"
+                      fill="#F00"
+                      fillRule="evenodd"
+                      height="16"
+                      role="img"
+                      title="> 80"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <title>
+                        &gt; 80
+                      </title>
+                      <path
+                        d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ValueCard__AttributeLabel-hyxf2q-4 IgeiL"
+                size="MEDIUMTHIN"
+                title="Average Temperature"
+              >
+                Average Temperature
+              </div>
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUMTHIN"
+            >
+              <hr
+                className="ValueCard__AttributeSeparator-hyxf2q-2 hazVaq"
+              />
+            </div>
+            <div
+              className="ValueCard__AttributeWrapper-hyxf2q-1 emVGjx"
+              size="MEDIUMTHIN"
+            >
+              <div
+                className="Attribute__StyledAttribute-dhraql-0 gYrKUA"
+                label="Humidity"
+                size="MEDIUMTHIN"
+              >
+                <div
+                  className="ValueRenderer__Attribute-f4stpz-0 hqoUNX"
+                  color={null}
+                >
+                  <span
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kolfZc"
+                    size="MEDIUMTHIN"
+                    title="88888678234234240000 ˚F"
+                    value={88888678234234240000}
+                  >
+                    88888678T
+                  </span>
+                </div>
+                <span
+                  className="iot--value-card__attribute-unit"
+                  style={
+                    Object {
+                      "--default-font-size": "1.5rem",
+                    }
+                  }
+                >
+                  ˚F
+                </span>
+                <div
+                  className="iot--value-card__attribute-icon-container"
+                >
+                  <div
+                    className="iot--value-card__attribute-threshold-icon-container"
+                  >
+                    <svg
+                      aria-label="> 80"
+                      className="Attribute__ThresholdIcon-dhraql-2 goOrNp"
+                      fill="#F00"
+                      fillRule="evenodd"
+                      height="16"
+                      role="img"
+                      title="> 80"
+                      viewBox="0 0 16 16"
+                      width="16"
+                    >
+                      <title>
+                        &gt; 80
+                      </title>
+                      <path
+                        d="M.75 16a.75.75 0 0 1-.67-1.085L7.33.415a.75.75 0 0 1 1.34 0l7.25 14.5A.75.75 0 0 1 15.25 16H.75zm6.5-10v5h1.5V6h-1.5zM8 13.5A.75.75 0 1 0 8 12a.75.75 0 0 0 0 1.5z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ValueCard__AttributeLabel-hyxf2q-4 fVxPsv"
+                size="MEDIUMTHIN"
+                title="Humidity"
+              >
+                Humidity
               </div>
             </div>
           </div>
@@ -5015,7 +5055,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                     size="SMALLWIDE"
                     title="Problem "
                     value="Problem"
@@ -5056,7 +5096,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                     size="SMALLWIDE"
                     title="Healthy feels"
                     value="Healthy"
@@ -5335,7 +5375,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                     size="SMALLWIDE"
                     title="Good "
                     value="Good"
@@ -5376,7 +5416,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
                   color={null}
                 >
                   <span
-                    className="ValueRenderer__AttributeValue-f4stpz-1 jRoLEg"
+                    className="ValueRenderer__AttributeValue-f4stpz-1 kmAyHP"
                     size="SMALLWIDE"
                     title="Healthy "
                     value="Healthy"


### PR DESCRIPTION
Closes #

**Summary**

- Small fix to make font sizes smaller at Medium and Medium Thin sizes and to always align vertically

**Change List (commits, features, bugs, etc)**

- test(story): added a few new card sizes to the stories

**Acceptance Test (how to verify the PR)**

- Check the Value Card layout in all the stories and make sure they look ok.
