### PR TITLE
1031 xxl input

### DIFF
--- a/src/components/TextInput/TextInput.story.jsx
+++ b/src/components/TextInput/TextInput.story.jsx
@@ -1,3 +1,164 @@
-export {
-  default as TextInputStory,
-} from 'carbon-components-react/lib/components/TextInput/TextInput-story';
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+
+import { TextInputSkeleton, TextInput } from '.';
+
+const types = {
+  None: '',
+  'Text (text)': 'text',
+  'For email (email)': 'email',
+  'For password (password)': 'password',
+};
+
+const sizes = {
+  'Extra large size (xxl)': 'xxl',
+  'Extra large size (xl)': 'xl',
+  'Default size': undefined,
+  'Small size (sm)': 'sm',
+};
+
+function ControlledPasswordInputApp(props) {
+  const [type, setType] = useState('password');
+  const togglePasswordVisibility = () => {
+    setType(type === 'password' ? 'text' : 'password');
+  };
+  return (
+    <>
+      <TextInput.ControlledPasswordInput
+        type={type}
+        togglePasswordVisibility={togglePasswordVisibility}
+        {...props}
+      />
+      <button type="button" onClick={() => setType('text')}>
+        Show password
+      </button>
+      <button type="button" onClick={() => setType('password')}>
+        Hide password
+      </button>
+    </>
+  );
+}
+
+const props = {
+  TextInputProps: () => ({
+    className: 'some-class',
+    id: 'test2',
+    defaultValue: text('Default value (defaultValue)', 'This is not a default value'),
+    size: select('Field size (size)', sizes, undefined) || undefined,
+    labelText: text('Label text (labelText)', 'Text Input label'),
+    placeholder: text('Placeholder text (placeholder)', 'Placeholder text'),
+    light: boolean('Light variant (light)', false),
+    disabled: boolean('Disabled (disabled)', false),
+    hideLabel: boolean('No label (hideLabel)', false),
+    invalid: boolean('Show form validation UI (invalid)', false),
+    invalidText: text('Form validation UI content (invalidText)', 'A valid value is required'),
+    helperText: text('Helper text (helperText)', 'Optional helper text.'),
+    onClick: action('onClick'),
+    onChange: action('onChange'),
+  }),
+  PasswordInputProps: () => ({
+    tooltipPosition: select(
+      'Tooltip position (tooltipPosition)',
+      ['top', 'right', 'bottom', 'left'],
+      'bottom'
+    ),
+    tooltipAlignment: select(
+      'Tooltip alignment (tooltipAlignment)',
+      ['start', 'center', 'end'],
+      'center'
+    ),
+    hidePasswordLabel: text(
+      '"Hide password" tooltip label for password visibility toggle (hidePasswordLabel)',
+      'Hide password'
+    ),
+    showPasswordLabel: text(
+      '"Show password" tooltip label for password visibility toggle (showPasswordLabel)',
+      'Show password'
+    ),
+  }),
+};
+
+TextInput.displayName = 'TextInput';
+
+storiesOf('TextInput', module)
+  .addDecorator(withKnobs)
+  .add(
+    'Default',
+    () => (
+      <TextInput
+        type={select('Form control type (type)', types, 'text')}
+        {...props.TextInputProps()}
+      />
+    ),
+    {
+      info: {
+        text: `
+            Text fields enable the user to interact with and input data. A single line
+            field is used when the input anticipated by the user is a single line of
+            text as opposed to a paragraph.
+            The default type is 'text' and its value can be either 'string' or 'number'.
+          `,
+      },
+    }
+  )
+  .add(
+    'Toggle password visibility',
+    () => {
+      return (
+        <TextInput.PasswordInput {...props.TextInputProps()} {...props.PasswordInputProps()} />
+      );
+    },
+    {
+      info: {
+        text: `
+          Text field with password visibility toggle.
+        `,
+      },
+    }
+  )
+  .add(
+    'Fully controlled toggle password visibility',
+    () => {
+      ControlledPasswordInputApp.__docgenInfo = {
+        ...TextInput.PasswordInput.__docgenInfo,
+        props: {
+          ...TextInput.PasswordInput.__docgenInfo.props,
+        },
+      };
+
+      return (
+        <ControlledPasswordInputApp {...props.TextInputProps()} {...props.PasswordInputProps()} />
+      );
+    },
+    {
+      info: {
+        text: `
+        Fully controlled text field with password visibility toggle.
+      `,
+      },
+    }
+  )
+  .add(
+    'skeleton',
+    () => (
+      <div
+        aria-label="loading text input"
+        aria-live="assertive"
+        role="status"
+        tabIndex="0" // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+      >
+        <TextInputSkeleton />
+        <br />
+        <TextInputSkeleton hideLabel />
+      </div>
+    ),
+    {
+      info: {
+        text: `
+            Placeholder skeleton state to use when content is loading.
+            `,
+      },
+    }
+  );

--- a/src/components/TextInput/_text-input.scss
+++ b/src/components/TextInput/_text-input.scss
@@ -1,1 +1,5 @@
 @import '~carbon-components/scss/components/text-input/text-input';
+
+.#{$prefix}--text-input--xxl {
+  height: 3.5rem;
+}


### PR DESCRIPTION
Closes #1031 

**Summary**

Add xxl height to text inputs

**Change List (commits, features, bugs, etc)**

- Component already adds size prop to a classname. Just added styles for xxl variant 

**Acceptance Test (how to verify the PR)**

- Go to Text input story
- Go to knob and choose xxl for size
- Profit
