### PR TITLE
chore: updated invalid prop types

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -135,7 +135,6 @@ export const defaultProps = {
   title: undefined,
   toolbar: undefined,
   hideHeader: false,
-  showOverflow: false,
   timeRange: undefined,
   isLoading: false,
   isEmpty: false,

--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -11,7 +11,7 @@ const PageTitleBarPropTypes = {
   /** Title of the page  */
   title: PropTypes.node.isRequired,
   /** Details about what the page shows */
-  description: PropTypes.oneOf(PropTypes.element, PropTypes.string),
+  description: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   /** Optional node to render in the right side of the PageTitleBar
    *  NOTE: Deprecated in favor of extraContent
    */

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -3321,14 +3321,16 @@ Map {
       },
       "description": Object {
         "args": Array [
-          Object {
-            "type": "element",
-          },
-          Object {
-            "type": "string",
-          },
+          Array [
+            Object {
+              "type": "element",
+            },
+            Object {
+              "type": "string",
+            },
+          ],
         ],
-        "type": "oneOf",
+        "type": "oneOfType",
       },
       "editable": Object {
         "type": "bool",
@@ -6247,7 +6249,6 @@ Map {
         "xl": 144,
         "xs": 144,
       },
-      "showOverflow": false,
       "size": "MEDIUM",
       "testID": "Card",
       "timeRange": undefined,


### PR DESCRIPTION
Closes #1120 

**Summary**

Small fix to the prop types that are incorrectly defined.
Removed the default prop type for deprecated prop type to avoid a constant set of warning about it being deprecated even when it wasn't being used.
