### PR TITLE
fix(table): locale format any number values

### DIFF
--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -746,7 +746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Card 
                         className=""
                         title={12341231231}
                       >
-                        12,341,231,231
+                        12341231231
                       </span>
                     </span>
                   </td>

--- a/src/components/Card/__snapshots__/Card.story.storyshot
+++ b/src/components/Card/__snapshots__/Card.story.storyshot
@@ -746,7 +746,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Card 
                         className=""
                         title={12341231231}
                       >
-                        12341231231
+                        12,341,231,231
                       </span>
                     </span>
                   </td>

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -7913,7 +7913,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8011,7 +8011,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8109,7 +8109,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8207,7 +8207,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8305,7 +8305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8403,7 +8403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8501,7 +8501,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8599,7 +8599,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8697,7 +8697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>
@@ -8795,7 +8795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1,569,819,600,000
+                                  1569819600000
                                 </span>
                               </span>
                             </td>

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -7913,7 +7913,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8011,7 +8011,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8109,7 +8109,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8207,7 +8207,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8305,7 +8305,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8403,7 +8403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8501,7 +8501,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8599,7 +8599,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8697,7 +8697,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>
@@ -8795,7 +8795,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                   className=""
                                   title={1569819600000}
                                 >
-                                  1569819600000
+                                  1,569,819,600,000
                                 </span>
                               </span>
                             </td>

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -160,7 +160,7 @@ const propTypes = {
       onColumnResize: PropTypes.func,
     }).isRequired,
   }),
-  /** what locale should we use to format values, defaults to 'en' */
+  /** what locale should we use to format table values if left empty no locale formatting happens */
   locale: PropTypes.string,
   i18n: I18NPropTypes,
 };
@@ -232,7 +232,7 @@ export const defaultProps = baseProps => ({
       onColumnResize: defaultFunction('actions.table.onColumnResize'),
     },
   },
-  locale: 'en',
+  locale: null,
   i18n: {
     /** pagination */
     pageBackwardAria: 'Previous page',

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -160,6 +160,8 @@ const propTypes = {
       onColumnResize: PropTypes.func,
     }).isRequired,
   }),
+  /** what locale should we use to format values, defaults to 'en' */
+  locale: PropTypes.string,
   i18n: I18NPropTypes,
 };
 
@@ -230,6 +232,7 @@ export const defaultProps = baseProps => ({
       onColumnResize: defaultFunction('actions.table.onColumnResize'),
     },
   },
+  locale: 'en',
   i18n: {
     /** pagination */
     pageBackwardAria: 'Previous page',
@@ -280,6 +283,7 @@ const Table = props => {
     columns,
     data,
     expandedData,
+    locale,
     view,
     actions,
     options,
@@ -480,6 +484,7 @@ const Table = props => {
             <TableBody
               tableId={id}
               rows={visibleData}
+              locale={locale}
               rowActionsState={view.table.rowActions}
               expandedRows={expandedData}
               columns={visibleColumns}

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -1613,6 +1613,10 @@ storiesOf('Watson IoT/Table', module)
         view={{
           filters: [],
           table: {
+            sort: {
+              columnId: 'number',
+              direction: 'DESC',
+            },
             rowActions: [
               {
                 rowId: 'row-1',
@@ -1625,6 +1629,7 @@ storiesOf('Watson IoT/Table', module)
             ],
           },
         }}
+        locale={select('locale', ['fr', 'en'], 'fr')}
         i18n={{
           /** pagination */
           pageBackwardAria: text('i18n.pageBackwardAria', '__Previous page__'),

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -76,7 +76,7 @@ const defaultProps = {
   overflowMenuAria: 'More actions',
   clickToExpandAria: 'Click to expand.',
   clickToCollapseAria: 'Click to collapse.',
-  locale: 'en',
+  locale: null,
   rows: [],
   expandedRows: [],
   rowActionsState: [],

--- a/src/components/Table/TableBody/TableBody.jsx
+++ b/src/components/Table/TableBody/TableBody.jsx
@@ -51,6 +51,7 @@ const propTypes = {
   rowActionsState: RowActionsStatePropTypes,
   shouldExpandOnRowClick: PropTypes.bool,
   shouldLazyRender: PropTypes.bool,
+  locale: PropTypes.string,
 
   actions: PropTypes.shape({
     onRowSelected: PropTypes.func,
@@ -75,6 +76,7 @@ const defaultProps = {
   overflowMenuAria: 'More actions',
   clickToExpandAria: 'Click to expand.',
   clickToCollapseAria: 'Click to collapse.',
+  locale: 'en',
   rows: [],
   expandedRows: [],
   rowActionsState: [],
@@ -115,6 +117,7 @@ const TableBody = ({
   ordering,
   wrapCellText,
   truncateCellText,
+  locale,
 }) => {
   // Need to merge the ordering and the columns since the columns have the renderer function
   const orderingMap = useMemo(
@@ -156,6 +159,7 @@ const TableBody = ({
         columns={columns}
         tableId={tableId}
         id={row.id}
+        locale={locale}
         totalColumns={totalColumns}
         options={{
           hasRowSelection,

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -326,6 +326,7 @@ const TableBodyRow = ({
   totalColumns,
   ordering,
   columns,
+  locale,
   options: {
     hasRowSelection,
     hasRowExpansion,
@@ -419,7 +420,11 @@ const TableBodyRow = ({
                   row: values,
                 })
               ) : (
-                <TableCellRenderer wrapText={wrapCellText} truncateCellText={truncateCellText}>
+                <TableCellRenderer
+                  wrapText={wrapCellText}
+                  truncateCellText={truncateCellText}
+                  locale={locale}
+                >
                   {values[col.columnId]}
                 </TableCellRenderer>
               )}

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -19,7 +19,7 @@ const propTypes = {
 const defaultProps = {
   children: null,
   allowTooltip: true,
-  locale: 'en',
+  locale: null,
 };
 
 const isElementTruncated = element => element.offsetWidth < element.scrollWidth;
@@ -63,7 +63,7 @@ const TableCellRenderer = ({ children, wrapText, allowTooltip, truncateCellText,
   const cellContent =
     typeof children === 'string' || typeof children === 'number' ? (
       <span className={myClasses} title={children} ref={mySpanRef}>
-        {typeof children === 'number'
+        {typeof children === 'number' && locale
           ? children.toLocaleString(locale, { maximumFractionDigits: 20 })
           : children}
       </span>

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.jsx
@@ -12,17 +12,20 @@ const propTypes = {
   wrapText: PropTypes.oneOf(['always', 'never', 'auto']).isRequired,
   truncateCellText: PropTypes.bool.isRequired,
   allowTooltip: PropTypes.bool,
+  /** What locale should the number be rendered in */
+  locale: PropTypes.string,
 };
 
 const defaultProps = {
   children: null,
   allowTooltip: true,
+  locale: 'en',
 };
 
 const isElementTruncated = element => element.offsetWidth < element.scrollWidth;
 
 /** Supports our default render decisions for primitive values */
-const TableCellRenderer = ({ children, wrapText, allowTooltip, truncateCellText }) => {
+const TableCellRenderer = ({ children, wrapText, allowTooltip, truncateCellText, locale }) => {
   const mySpanRef = React.createRef();
   const myClasses = classnames({
     [`${iotPrefix}--table__cell-text--truncate`]: wrapText !== 'always' && truncateCellText,
@@ -60,7 +63,9 @@ const TableCellRenderer = ({ children, wrapText, allowTooltip, truncateCellText 
   const cellContent =
     typeof children === 'string' || typeof children === 'number' ? (
       <span className={myClasses} title={children} ref={mySpanRef}>
-        {children}
+        {typeof children === 'number'
+          ? children.toLocaleString(locale, { maximumFractionDigits: 20 })
+          : children}
       </span>
     ) : typeof children === 'boolean' ? ( // handle booleans
       <span className={myClasses} title={children.toString()}>

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
@@ -146,4 +146,12 @@ describe('TableCellRenderer', () => {
     setOffsetWidth(0);
     setScrollWidth(0);
   });
+
+  test('locale formats numbers', () => {
+    const wrapper = mount(<TableCellRenderer locale="fr">{35.6}</TableCellRenderer>);
+    expect(wrapper.text()).toContain('35,6'); // french locale should have commas for decimals
+
+    const wrapper2 = mount(<TableCellRenderer locale="en">{35.1234567}</TableCellRenderer>);
+    expect(wrapper2.text()).toContain('35.1234567'); // no limit on the count of decimals
+  });
 });

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -344,6 +344,7 @@ Map {
       },
       "id": "Table",
       "lightweight": false,
+      "locale": "en",
       "options": Object {
         "hasColumnSelection": false,
         "hasColumnSelectionConfig": false,
@@ -821,6 +822,9 @@ Map {
       },
       "lightweight": Object {
         "type": "bool",
+      },
+      "locale": Object {
+        "type": "string",
       },
       "options": Object {
         "args": Array [
@@ -1631,6 +1635,7 @@ Map {
       "hasRowExpansion": false,
       "hasRowNesting": false,
       "hasRowSelection": false,
+      "locale": "en",
       "overflowMenuAria": "More actions",
       "rowActionsState": Array [],
       "rows": Array [],
@@ -1810,6 +1815,9 @@ Map {
         "type": "string",
       },
       "learnMoreText": Object {
+        "type": "string",
+      },
+      "locale": Object {
         "type": "string",
       },
       "ordering": Object {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -344,7 +344,7 @@ Map {
       },
       "id": "Table",
       "lightweight": false,
-      "locale": "en",
+      "locale": null,
       "options": Object {
         "hasColumnSelection": false,
         "hasColumnSelectionConfig": false,
@@ -1635,7 +1635,7 @@ Map {
       "hasRowExpansion": false,
       "hasRowNesting": false,
       "hasRowSelection": false,
-      "locale": "en",
+      "locale": null,
       "overflowMenuAria": "More actions",
       "rowActionsState": Array [],
       "rows": Array [],


### PR DESCRIPTION
Prereqs: https://github.com/IBM/carbon-addons-iot-react/pull/1134

**Summary**

- Fixes issues with numeric formatting in locales.  I made this feature opt-in so it wouldn't break previous Table users.  If you don't pass a locale prop to the Table, it doesn't locale format your numbers.

**Change List (commits, features, bugs, etc)**

- fix(Table): add locale option to table, pass through to TableCellRenderer
- fix(TableCellRenderer): render the numeric value in the current locale with the maximum available amount of decimal points

**Acceptance Test (how to verify the PR)**

- Check that the Table i18n story is locale formatting in the thousands correctly.
