### PR TITLE
fix(timeseriescard): render no data instead of error

### DIFF
--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -24,12 +24,7 @@ import {
   handleCardVariables,
 } from '../../utils/cardUtilityFunctions';
 
-import {
-  generateSampleValues,
-  isValuesEmpty,
-  formatGraphTick,
-  findMatchingAlertRange,
-} from './timeSeriesUtils';
+import { generateSampleValues, formatGraphTick, findMatchingAlertRange } from './timeSeriesUtils';
 
 const { iotPrefix } = settings;
 
@@ -101,6 +96,7 @@ export const determinePrecision = (size, value, defaultPrecision) => {
 export const formatChartData = (timeDataSourceId = 'timestamp', series, values) => {
   const timestamps = [...new Set(values.map(val => val[timeDataSourceId]))];
   const data = [];
+
   // Series is the different groups of datasets
   series.forEach(({ dataSourceId, dataFilter = {}, label }) => {
     timestamps.forEach(timestamp => {
@@ -243,8 +239,6 @@ const TimeSeriesCard = ({
     ? memoizedGenerateSampleValues(series, timeDataSourceId, interval)
     : valuesProp;
 
-  const isAllValuesEmpty = isValuesEmpty(values, timeDataSourceId);
-
   // Unfortunately the API returns the data out of order sometimes
   const valueSort = useMemo(
     () =>
@@ -351,6 +345,8 @@ const TimeSeriesCard = ({
     valueSort,
   ]);
 
+  const isChartDataEmpty = isEmpty(chartData);
+
   const { tableData, columnNames } = useMemo(
     () => {
       let maxColumnNames = [];
@@ -407,10 +403,10 @@ const TimeSeriesCard = ({
       {...others}
       isExpanded={isExpanded}
       isEditable={isEditable}
-      isEmpty={isAllValuesEmpty}
+      isEmpty={isChartDataEmpty}
       isLazyLoading={isLazyLoading || (valueSort && valueSort.length > 200)}
     >
-      {!isLoading && !isAllValuesEmpty ? (
+      {!isLoading && !isChartDataEmpty ? (
         <>
           <LineChartWrapper
             size={newSize}

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -405,8 +405,9 @@ const TimeSeriesCard = ({
       isEditable={isEditable}
       isEmpty={isChartDataEmpty}
       isLazyLoading={isLazyLoading || (valueSort && valueSort.length > 200)}
+      isLoading={isLoading}
     >
-      {!isLoading && !isChartDataEmpty ? (
+      {!isChartDataEmpty ? (
         <>
           <LineChartWrapper
             size={newSize}

--- a/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -45,9 +45,11 @@ describe('TimeSeriesCard tests', () => {
       <TimeSeriesCard {...timeSeriesCardProps} isLoading size={CARD_SIZES.MEDIUM} />
     );
     expect(wrapper.find('LineChart')).toHaveLength(0);
+    expect(wrapper.find('SkeletonText')).toHaveLength(1);
 
     wrapper = mount(<TimeSeriesCard {...timeSeriesCardProps} size={CARD_SIZES.MEDIUM} />);
     expect(wrapper.find('LineChart')).toHaveLength(1);
+    expect(wrapper.find('SkeletonText')).toHaveLength(0);
   });
   test('does not fail to render if no data is given', () => {
     // For whatever reason, these devices do not give back real data so the No data message

--- a/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import Table from '../Table/Table';
 import { getIntervalChartData } from '../../utils/sample';
@@ -46,6 +48,16 @@ describe('TimeSeriesCard tests', () => {
 
     wrapper = mount(<TimeSeriesCard {...timeSeriesCardProps} size={CARD_SIZES.MEDIUM} />);
     expect(wrapper.find('LineChart')).toHaveLength(1);
+  });
+  test('does not fail to render if no data is given', () => {
+    // For whatever reason, these devices do not give back real data so the No data message
+    // should render instead of the line graph
+    const emptyValues = [{ deviceid: 'robot1' }, { deviceid: 'robot2' }];
+    const { getByText } = render(
+      <TimeSeriesCard {...timeSeriesCardProps} values={emptyValues} size={CARD_SIZES.MEDIUM} />
+    );
+
+    expect(getByText('No data is available for this time range.')).toBeInTheDocument();
   });
   test('shows table with data when expanded', () => {
     const wrapper = mount(

--- a/src/components/TimeSeriesCard/timeSeriesUtils.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.js
@@ -1,8 +1,5 @@
 import moment from 'moment';
-import isNil from 'lodash/isNil';
-import every from 'lodash/every';
 import isEmpty from 'lodash/isEmpty';
-import omit from 'lodash/omit';
 import find from 'lodash/find';
 
 /** Generate fake values for my line chart */
@@ -59,16 +56,6 @@ export const generateSampleValues = (series, timeDataSourceId, timeGrain = 'day'
     return sampleData;
   }, []);
 };
-
-/**
- * Is every value empty except timestamp in the data
- * @param {} values
- * @param {*} timeDataSourceId
- */
-export const isValuesEmpty = (values, timeDataSourceId) =>
-  every(values, dataPoint =>
-    every(Object.values(omit(dataPoint, [timeDataSourceId])), value => isNil(value))
-  );
 
 /**
  * Generate fake data to fill table columns for the preview mode of the table in the dashboard

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -3,45 +3,11 @@ import every from 'lodash/every';
 import {
   generateSampleValues,
   generateTableSampleValues,
-  isValuesEmpty,
   formatGraphTick,
   findMatchingAlertRange,
 } from './timeSeriesUtils';
 
 describe('timeSeriesUtils', () => {
-  test('isValuesEmpty', () => {
-    const sampleValues = [
-      { timestamp: 1571162400000, sound_db: null },
-      { timestamp: 1571166000000, sound_db: null },
-      { timestamp: 1571169600000, sound_db: null },
-      { timestamp: 1571173200000, sound_db: null },
-      { timestamp: 1571176800000, sound_db: null },
-      { timestamp: 1571180400000, sound_db: null },
-      { timestamp: 1571184000000, sound_db: null },
-      { timestamp: 1571187600000, sound_db: null },
-      { timestamp: 1571191200000, sound_db: null },
-      { timestamp: 1571194800000, sound_db: null },
-      { timestamp: 1571198400000, sound_db: null },
-      { timestamp: 1571202000000, sound_db: null },
-      { timestamp: 1571205600000, sound_db: null },
-      { timestamp: 1571209200000, sound_db: null },
-      { timestamp: 1571212800000, sound_db: null },
-      { timestamp: 1571216400000, sound_db: null },
-      { timestamp: 1571220000000, sound_db: null },
-      { timestamp: 1571223600000, sound_db: null },
-      { timestamp: 1571227200000, sound_db: null },
-      { timestamp: 1571230800000, sound_db: null },
-      { timestamp: 1571234400000, sound_db: null },
-      { timestamp: 1571238000000, sound_db: null },
-      { timestamp: 1571241600000, sound_db: null },
-      { timestamp: 1571245200000, sound_db: null },
-      { timestamp: 1571248800000, sound_db: null },
-    ];
-    expect(isValuesEmpty(sampleValues, 'timestamp')).toEqual(true);
-    expect(
-      isValuesEmpty([...sampleValues, { timestamp: 1571162400000, sound_db: 10 }], 'timestamp')
-    ).toEqual(false);
-  });
   test('generateSampleValues', () => {
     const sampleValues = generateSampleValues(
       [{ dataSourceId: 'temperature' }, { dataSourceId: 'pressure' }],


### PR DESCRIPTION
Closes #1159 
Closes #1161 

**Summary**

- TimeSeriesCard's logic to detect if the values was empty didn't cover all cases so the function was adjusted to handle the new `formatChartData` returned data
- TimeSeriesCard was not passing props correctly for `isLoading` and was rendering an empty div instead of the SkeletonText

**Change List (commits, features, bugs, etc)**

- Removed `isValuesEmpty` function in favor of checking if the returned formatted data is empty or not, as `formatChartData` will filter out the empty values instead
- Added test for this use-case
- Added check for SkeletonText in isLoading test for pesky render bug

**Acceptance Test (how to verify the PR)**

1.
- Go to TimeSeriesCard and adjust the values array prop to give incomplete data such as `[{deviceId: "robot1"}, {deviceId: "robot2"}]`
- See the correct No data / empty data render in the card

2. 
- Go to any TimeSeriesCard story and set the `isLoading` knob to true to see the SkeletonText again