### PR TITLE
refactor(tests): standardize on describe/it, bulk reformat

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -75,8 +75,8 @@
     "lodash/import-scope": [2, "method"],
     "react/destructuring-assignment": [2, "always", { "ignoreClassFields": true }],
     "jest/expect-expect": "error",
-    "jest/prefer-hooks-on-top": "error"
-    // "jest/consistent-test-it": ["error", { "fn": "test", "withinDescribe": "it" }]
+    "jest/prefer-hooks-on-top": "error",
+    "jest/consistent-test-it": ["error", { "fn": "test", "withinDescribe": "it" }]
   },
   // Testcases have less eslint rules applied to them
   "overrides": [

--- a/src/components/Accordion/AccordionItemDefer.test.jsx
+++ b/src/components/Accordion/AccordionItemDefer.test.jsx
@@ -6,7 +6,7 @@ import AccordionItemDefer from './AccordionItemDefer';
 import { Accordion } from '.';
 
 describe('AccordionItemDefer', () => {
-  test('renders content when expanded', () => {
+  it('renders content when expanded', () => {
     const { container, getByTestId } = render(
       <Accordion>
         <AccordionItemDefer id="a" title="Title one">
@@ -22,7 +22,7 @@ describe('AccordionItemDefer', () => {
     expect(getByTestId('accordion-item-deferred').lastElementChild.childElementCount).toEqual(1);
   });
 
-  test('does not remove content when closed', () => {
+  it('does not remove content when closed', () => {
     const { container, getByTestId } = render(
       <Accordion>
         <AccordionItemDefer id="a" title="Title one" open>

--- a/src/components/AddCard/AddCard.test.jsx
+++ b/src/components/AddCard/AddCard.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import AddCard from './AddCard';
 
 describe('Add Card testcases', () => {
-  test('onClick', () => {
+  it('onClick', () => {
     const onClick = jest.fn();
     const wrapper = mount(<AddCard title="My Title" onClick={onClick} />);
     wrapper.childAt(0).simulate('click');

--- a/src/components/AddCard/AddCard.test.jsx
+++ b/src/components/AddCard/AddCard.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import AddCard from './AddCard';
 
-describe('Add Card testcases', () => {
+describe('AddCard', () => {
   it('onClick', () => {
     const onClick = jest.fn();
     const wrapper = mount(<AddCard title="My Title" onClick={onClick} />);

--- a/src/components/BarChartCard/BarChartCard.test.jsx
+++ b/src/components/BarChartCard/BarChartCard.test.jsx
@@ -25,7 +25,7 @@ const barChartCardProps = {
   onCardAction: () => {},
 };
 
-describe('BarChartCard tests', () => {
+describe('BarChartCard', () => {
   it('does not show bar chart when loading', () => {
     let wrapper = mount(<BarChartCard {...barChartCardProps} isLoading />);
     expect(wrapper.find('SimpleBarChart')).toHaveLength(0);

--- a/src/components/BarChartCard/BarChartCard.test.jsx
+++ b/src/components/BarChartCard/BarChartCard.test.jsx
@@ -26,7 +26,7 @@ const barChartCardProps = {
 };
 
 describe('BarChartCard tests', () => {
-  test('does not show bar chart when loading', () => {
+  it('does not show bar chart when loading', () => {
     let wrapper = mount(<BarChartCard {...barChartCardProps} isLoading />);
     expect(wrapper.find('SimpleBarChart')).toHaveLength(0);
 
@@ -34,7 +34,7 @@ describe('BarChartCard tests', () => {
     expect(wrapper.find('SimpleBarChart')).toHaveLength(1);
   });
 
-  test('does not show bar chart when empty data', () => {
+  it('does not show bar chart when empty data', () => {
     let wrapper = mount(
       <BarChartCard
         {...barChartCardProps}
@@ -47,7 +47,7 @@ describe('BarChartCard tests', () => {
     expect(wrapper.find('SimpleBarChart')).toHaveLength(0);
   });
 
-  test('shows groupedBarChart on grouped data', () => {
+  it('shows groupedBarChart on grouped data', () => {
     const wrapper = mount(
       <BarChartCard
         {...barChartCardProps}
@@ -65,7 +65,7 @@ describe('BarChartCard tests', () => {
     expect(wrapper.find('GroupedBarChart')).toHaveLength(1);
   });
 
-  test('shows stackedBarChart on stacked data', () => {
+  it('shows stackedBarChart on stacked data', () => {
     const wrapper = mount(
       <BarChartCard
         {...barChartCardProps}
@@ -83,7 +83,7 @@ describe('BarChartCard tests', () => {
     expect(wrapper.find('StackedBarChart')).toHaveLength(1);
   });
 
-  test('shows a timeSeries chart', () => {
+  it('shows a timeSeries chart', () => {
     const wrapper = mount(
       <BarChartCard
         {...barChartCardProps}
@@ -101,7 +101,7 @@ describe('BarChartCard tests', () => {
     expect(wrapper.find('SimpleBarChart')).toHaveLength(1);
   });
 
-  test('shows a horizontal chart', () => {
+  it('shows a horizontal chart', () => {
     const wrapper = mount(
       <BarChartCard
         {...barChartCardProps}
@@ -119,7 +119,7 @@ describe('BarChartCard tests', () => {
     );
     expect(wrapper.find('SimpleBarChart')).toHaveLength(1);
   });
-  test('mapValuesToAxes returns axes for non-timebased group charts ', () => {
+  it('mapValuesToAxes returns axes for non-timebased group charts ', () => {
     const series = {
       groupDataSourceId: 'quarter',
       labelDataSourceId: 'city',
@@ -136,7 +136,7 @@ describe('BarChartCard tests', () => {
       leftAxesMapsTo: 'value',
     });
   });
-  test('mapValuesToAxes returns axes for timebased group charts ', () => {
+  it('mapValuesToAxes returns axes for timebased group charts ', () => {
     const series = {
       groupDataSourceId: 'quarter',
       labelDataSourceId: 'city',
@@ -154,7 +154,7 @@ describe('BarChartCard tests', () => {
       leftAxesMapsTo: 'value',
     });
   });
-  test('mapValuesToAxes returns axes for non-timebased and non-group charts AKA simple', () => {
+  it('mapValuesToAxes returns axes for non-timebased and non-group charts AKA simple', () => {
     const series = {
       labelDataSourceId: 'city',
       dataSourceId: 'particles',
@@ -170,7 +170,7 @@ describe('BarChartCard tests', () => {
       leftAxesMapsTo: 'value',
     });
   });
-  test('formatChartData returns formatted data for group-based chart', () => {
+  it('formatChartData returns formatted data for group-based chart', () => {
     const series = {
       groupDataSourceId: 'quarter',
       labelDataSourceId: 'city',
@@ -260,7 +260,7 @@ describe('BarChartCard tests', () => {
       },
     ]);
   });
-  test('formatChartData returns formatted data for time-based and group-based chart', () => {
+  it('formatChartData returns formatted data for time-based and group-based chart', () => {
     const series = {
       groupDataSourceId: 'timestamp',
       labelDataSourceId: 'city',
@@ -367,7 +367,7 @@ describe('BarChartCard tests', () => {
       },
     ]);
   });
-  test('formatChartData returns formatted data for simple, non-time and non-group chart', () => {
+  it('formatChartData returns formatted data for simple, non-time and non-group chart', () => {
     const series = {
       labelDataSourceId: 'city',
       dataSourceId: 'particles',
@@ -440,7 +440,7 @@ describe('BarChartCard tests', () => {
       },
     ]);
   });
-  test('formatChartData returns formatted data for time-based, non-group chart', () => {
+  it('formatChartData returns formatted data for time-based, non-group chart', () => {
     const series = {
       dataSourceId: 'particles',
       timeDataSourceId: 'timestamp',
@@ -529,7 +529,7 @@ describe('BarChartCard tests', () => {
       },
     ]);
   });
-  test('formatColors returns correct format if series is array', () => {
+  it('formatColors returns correct format if series is array', () => {
     const series = {
       dataSourceId: 'particles',
       timeDataSourceId: 'timestamp',

--- a/src/components/Breadcrumb/Breadcrumb.test.jsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.jsx
@@ -9,7 +9,7 @@ const commonProps = {
 };
 
 describe('Breadcrumb', () => {
-  test('overflows when container is smaller than breadcrumbs', () => {
+  it('overflows when container is smaller than breadcrumbs', () => {
     const { container } = render(
       <Breadcrumb {...commonProps} hasOverflow>
         <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
@@ -40,7 +40,7 @@ describe('Breadcrumb with overflow', () => {
     delete HTMLElement.prototype.scrollWidth;
   });
 
-  test('overflows when container is smaller than breadcrumbs', () => {
+  it('overflows when container is smaller than breadcrumbs', () => {
     const { container } = render(
       <Breadcrumb {...commonProps} hasOverflow>
         <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>
@@ -74,7 +74,7 @@ describe('Breadcrumb with overflow', () => {
       console.error.mockRestore();
     });
 
-    test('when ResizeObserver is not supported in the current environment', () => {
+    it('when ResizeObserver is not supported in the current environment', () => {
       render(
         <Breadcrumb {...commonProps} hasOverflow>
           <BreadcrumbItem href="#">Breadcrumb 1</BreadcrumbItem>

--- a/src/components/Button/Button.test.jsx
+++ b/src/components/Button/Button.test.jsx
@@ -9,7 +9,7 @@ const commonProps = {
 };
 
 describe('Button', () => {
-  test('loading', () => {
+  it('loading', () => {
     const wrapper = mount(
       <Button loading {...commonProps}>
         Click Me

--- a/src/components/Card/Card.test.jsx
+++ b/src/components/Card/Card.test.jsx
@@ -19,7 +19,7 @@ const cardProps = {
   id: 'my card',
 };
 
-describe('Card testcases', () => {
+describe('Card', () => {
   it('small', () => {
     const wrapper = mount(<Card {...cardProps} size={CARD_SIZES.SMALL} />);
 

--- a/src/components/Card/CardRangePicker.test.jsx
+++ b/src/components/Card/CardRangePicker.test.jsx
@@ -16,7 +16,7 @@ describe('CardRangePicker', () => {
   const last24HoursLabel = 'Last 24 Hours';
   const thisWeekLabel = 'This week';
 
-  test('card editable actions', async () => {
+  it('card editable actions', async () => {
     const { getByTitle, getByText } = render(
       <CardRangePicker
         i18n={{
@@ -55,7 +55,7 @@ describe('CardRangePicker', () => {
     });
   });
 
-  test('show time range label when enough space', () => {
+  it('show time range label when enough space', () => {
     const wrapper = mount(
       <CardRangePicker
         i18n={{

--- a/src/components/Card/DataStateRenderer.test.jsx
+++ b/src/components/Card/DataStateRenderer.test.jsx
@@ -24,7 +24,7 @@ function getDataStateProp() {
 }
 
 describe('ValueCard', () => {
-  test('should render custom icon', () => {
+  it('should render custom icon', () => {
     const size = CARD_SIZES.SMALL;
     const myDataState = getDataStateProp();
     myDataState.icon = (
@@ -38,7 +38,7 @@ describe('ValueCard', () => {
     expect(wrapper.find(`svg.${iotPrefix}--data-state-default-error-icon`)).toHaveLength(0);
   });
 
-  test('should use default icons if no app icon is passed down', () => {
+  it('should use default icons if no app icon is passed down', () => {
     const size = CARD_SIZES.SMALL;
     const myDataState = getDataStateProp();
     const wrapperNoData = mount(
@@ -57,7 +57,7 @@ describe('ValueCard', () => {
     expect(wrapperError.find(`svg.${iotPrefix}--data-state-default-warning-icon`)).toHaveLength(0);
   });
 
-  test('should render icon, label, description for sizes not equal SMALL, SMALLWIDE or MEDIUMTHIN', () => {
+  it('should render icon, label, description for sizes not equal SMALL, SMALLWIDE or MEDIUMTHIN', () => {
     const myDataState = getDataStateProp();
     function hasLabelDescription(jsx) {
       const wrapper = mount(jsx);
@@ -77,7 +77,7 @@ describe('ValueCard', () => {
     hasLabelDescription(<DataStateRenderer dataState={myDataState} size={CARD_SIZES.LARGEWIDE} />);
   });
 
-  test('should render only icon for size SMALL', () => {
+  it('should render only icon for size SMALL', () => {
     const myDataState = getDataStateProp();
     const wrapper = mount(<DataStateRenderer dataState={myDataState} size={CARD_SIZES.SMALL} />);
 
@@ -86,7 +86,7 @@ describe('ValueCard', () => {
     expect(wrapper.find(`.${iotPrefix}--data-state-grid__description`)).toHaveLength(0);
   });
 
-  test('should render only icon for size SMALLWIDE', () => {
+  it('should render only icon for size SMALLWIDE', () => {
     const myDataState = getDataStateProp();
     const wrapper = mount(
       <DataStateRenderer dataState={myDataState} size={CARD_SIZES.SMALLWIDE} />
@@ -97,7 +97,7 @@ describe('ValueCard', () => {
     expect(wrapper.find(`.${iotPrefix}--data-state-grid__description`)).toHaveLength(0);
   });
 
-  test('should render only icon for size MEDIUMTHIN', () => {
+  it('should render only icon for size MEDIUMTHIN', () => {
     const myDataState = getDataStateProp();
     const wrapper = mount(
       <DataStateRenderer dataState={myDataState} size={CARD_SIZES.MEDIUMTHIN} />
@@ -108,7 +108,7 @@ describe('ValueCard', () => {
     expect(wrapper.find(`.${iotPrefix}--data-state-grid__description`)).toHaveLength(0);
   });
 
-  test('should contain tooltip for icon, label and description', () => {
+  it('should contain tooltip for icon, label and description', () => {
     const myDataState = getDataStateProp();
 
     const wrapper = mount(<DataStateRenderer dataState={myDataState} size={CARD_SIZES.MEDIUM} />);
@@ -128,7 +128,7 @@ describe('ValueCard', () => {
     expect(descriptionTooltipTrigger).toHaveLength(1);
   });
 
-  test('should render label, description and extra text in the tooltip when present', () => {
+  it('should render label, description and extra text in the tooltip when present', () => {
     const myDataState = getDataStateProp();
     const wrapper = mount(<TooltipContent tooltipContent={myDataState} />);
 
@@ -140,14 +140,14 @@ describe('ValueCard', () => {
     expect(wrapper.text()).toMatch(RegExp(`.${myDataState.extraTooltipText}.`));
   });
 
-  test('should render learn-more link as anchor link', () => {
+  it('should render learn-more link as anchor link', () => {
     const myDataState = getDataStateProp();
     const wrapper = mount(<TooltipContent tooltipContent={myDataState} />);
 
     expect(wrapper.find(`a.learn-more-link`).text()).toEqual('Learn more');
   });
 
-  test('should render learn-more link as button with onClick', () => {
+  it('should render learn-more link as button with onClick', () => {
     const onLearnMoreClick = jest.fn();
     const myDataState = getDataStateProp();
     myDataState.learnMoreElement = (
@@ -163,7 +163,7 @@ describe('ValueCard', () => {
     expect(onLearnMoreClick).toHaveBeenCalled();
   });
 
-  test('should not render extraTooltipText nor learnMoreElement when missing', () => {
+  it('should not render extraTooltipText nor learnMoreElement when missing', () => {
     const myDataState = getDataStateProp();
     delete myDataState.learnMoreElement;
     delete myDataState.extraTooltipText;

--- a/src/components/ComposedModal/ComposedModal.test.jsx
+++ b/src/components/ComposedModal/ComposedModal.test.jsx
@@ -12,12 +12,12 @@ const modalProps = {
 };
 
 describe('ComposedModal', () => {
-  test('invalid field should be scrolled into view', () => {
+  it('invalid field should be scrolled into view', () => {
     const wrapper = mount(<ComposedModal {...modalProps} />);
     wrapper.setProps({ invalid: true, submitFailed: true });
     expect(utilityFunctions.scrollErrorIntoView).toHaveBeenCalledTimes(1);
   });
-  test('errors should be cleared', () => {
+  it('errors should be cleared', () => {
     const onClearError = jest.fn();
     const wrapper = mount(
       <ComposedModal {...modalProps} error="error" onClearError={onClearError} />
@@ -28,7 +28,7 @@ describe('ComposedModal', () => {
       .simulate('click');
     expect(onClearError).toHaveBeenCalledTimes(1);
   });
-  test('errors should not cause error', () => {
+  it('errors should not cause error', () => {
     const wrapper = mount(<ComposedModal {...modalProps} error="error" />);
     wrapper
       .find('.bx--inline-notification__close-button')
@@ -37,7 +37,7 @@ describe('ComposedModal', () => {
     // the close button shouldn't cause exception
     expect(wrapper).toBeDefined();
   });
-  test('clicking outside Composedmodal does not close it', () => {
+  it('clicking outside Composedmodal does not close it', () => {
     const wrapper = mount(<ComposedModal {...modalProps} />);
     // Have to return false
     expect(wrapper.instance().doNotClose()).toEqual(false);

--- a/src/components/ComposedStructuredList/ComposedStructuredList.test.jsx
+++ b/src/components/ComposedStructuredList/ComposedStructuredList.test.jsx
@@ -47,7 +47,7 @@ const data = [
 
 describe('Structured List', () => {
   // handle click function test
-  test('onRowClick', () => {
+  it('onRowClick', () => {
     const onRowClick = jest.fn();
     const wrapper = mount(
       <ComposedStructuredList

--- a/src/components/Dashboard/CardRenderer.test.jsx
+++ b/src/components/Dashboard/CardRenderer.test.jsx
@@ -123,7 +123,7 @@ const cardValues = [
 const onClick = jest.fn();
 
 describe('CardRenderer testcases', () => {
-  test('load card data', async () => {
+  it('load card data', async () => {
     let state = {
       dataSource: {},
       hasLoaded: false,
@@ -140,7 +140,7 @@ describe('CardRenderer testcases', () => {
     expect(state.hasLoaded).toEqual(true);
   });
 
-  test('expanded card rendered', async () => {
+  it('expanded card rendered', async () => {
     const { getByTitle } = render(
       <Dashboard
         title="My Dashboard"

--- a/src/components/Dashboard/CardRenderer.test.jsx
+++ b/src/components/Dashboard/CardRenderer.test.jsx
@@ -122,7 +122,7 @@ const cardValues = [
 
 const onClick = jest.fn();
 
-describe('CardRenderer testcases', () => {
+describe('CardRenderer', () => {
   it('load card data', async () => {
     let state = {
       dataSource: {},

--- a/src/components/Dashboard/Dashboard.test.jsx
+++ b/src/components/Dashboard/Dashboard.test.jsx
@@ -142,7 +142,7 @@ let wrapper = mount(
     onDashboardAction={onClick}
   />
 );
-describe('Dashboard testcases', () => {
+describe('Dashboard', () => {
   it('verify dashboard still renders with bad layout', () => {
     // should still render even with incorrect layout
     expect(wrapper).toBeDefined();

--- a/src/components/Dashboard/Dashboard.test.jsx
+++ b/src/components/Dashboard/Dashboard.test.jsx
@@ -143,17 +143,17 @@ let wrapper = mount(
   />
 );
 describe('Dashboard testcases', () => {
-  test('verify dashboard still renders with bad layout', () => {
+  it('verify dashboard still renders with bad layout', () => {
     // should still render even with incorrect layout
     expect(wrapper).toBeDefined();
   });
 
-  test('verify onDashboardAction is called on click', () => {
+  it('verify onDashboardAction is called on click', () => {
     wrapper.find('#action-icon--edit').simulate('click');
     expect(wrapper.prop('onDashboardAction')).toHaveBeenCalled();
   });
 
-  test('verify onDashboardAction is called on enter keydown', () => {
+  it('verify onDashboardAction is called on enter keydown', () => {
     wrapper = mount(
       <Dashboard
         title="My Dashboard"
@@ -173,7 +173,7 @@ describe('Dashboard testcases', () => {
     expect(wrapper.prop('onDashboardAction')).toHaveBeenCalled();
   });
 
-  test('verify onFetchData is called by each card if loading changes to true', () => {
+  it('verify onFetchData is called by each card if loading changes to true', () => {
     return new Promise(async (done, reject) => {
       try {
         const mockOnFetchData = jest.fn().mockImplementation(card => Promise.resolve(card));
@@ -226,7 +226,7 @@ describe('Dashboard testcases', () => {
       }
     });
   });
-  test('verify onLayoutChange is called when the dashboard renders', () => {
+  it('verify onLayoutChange is called when the dashboard renders', () => {
     const mockOnLayoutChange = jest.fn();
 
     wrapper = mount(

--- a/src/components/Dashboard/DashboardGrid.test.jsx
+++ b/src/components/Dashboard/DashboardGrid.test.jsx
@@ -6,7 +6,7 @@ jest.mock('../../utils/componentUtilityFunctions.js'); // this happens automatic
 const componentUtilityFunctions = require('../../utils/componentUtilityFunctions.js');
 
 describe('DashboardGrid', () => {
-  test('findLayoutOrGenerate', () => {
+  it('findLayoutOrGenerate', () => {
     // if no layouts exist they should be generated
     findLayoutOrGenerate({}, [{ id: 'mycard', size: CARD_SIZES.MEDIUM }]);
     expect(componentUtilityFunctions.getLayout).toHaveBeenCalled();

--- a/src/components/DateTimePicker/DateTimePicker.test.jsx
+++ b/src/components/DateTimePicker/DateTimePicker.test.jsx
@@ -67,7 +67,7 @@ describe('DateTimePicker', () => {
     expect(dateTimePickerProps.onCancel).toHaveBeenCalled();
   });
 
-  it('it should render with a predefined preset', () => {
+  it('should render with a predefined preset', () => {
     const wrapper = mount(
       <DateTimePicker {...dateTimePickerProps} defaultValue={PRESET_VALUES[1]} />
     );
@@ -76,7 +76,7 @@ describe('DateTimePicker', () => {
     expect(wrapper.find('.bx--tooltip__trigger').text()).toEqual(PRESET_VALUES[1].label);
   });
 
-  it('it should render with a predefined relative range', () => {
+  it('should render with a predefined relative range', () => {
     const wrapper = mount(
       <DateTimePicker {...dateTimePickerProps} defaultValue={defaultRelativeValue} />
     );
@@ -134,7 +134,7 @@ describe('DateTimePicker', () => {
     expect(dateTimePickerProps.onApply).toHaveBeenCalled();
   });
 
-  it('it should render with a predefined absolute range', () => {
+  it('should render with a predefined absolute range', () => {
     const wrapper = mount(
       <DateTimePicker {...dateTimePickerProps} defaultValue={defaultAbsoluteValue} />
     );
@@ -179,7 +179,7 @@ describe('DateTimePicker', () => {
     expect(dateTimePickerProps.onApply).toHaveBeenCalled();
   });
 
-  it('it should switch from relative to absolute', () => {
+  it('should switch from relative to absolute', () => {
     const wrapper = mount(
       <DateTimePicker {...dateTimePickerProps} defaultValue={defaultRelativeValue} />
     );
@@ -194,7 +194,7 @@ describe('DateTimePicker', () => {
     expect(wrapper.find('.iot--time-picker__controls--btn')).toHaveLength(4);
   });
 
-  it('it should not show the relative option', () => {
+  it('should not show the relative option', () => {
     const wrapper = mount(
       <DateTimePicker
         {...dateTimePickerProps}
@@ -207,7 +207,7 @@ describe('DateTimePicker', () => {
     expect(wrapper.find('.bx--radio-button')).toHaveLength(0);
   });
 
-  it('it should switch from relative to presets', () => {
+  it('should switch from relative to presets', () => {
     const wrapper = mount(
       <DateTimePicker {...dateTimePickerProps} defaultValue={defaultRelativeValue} />
     );
@@ -226,7 +226,7 @@ describe('DateTimePicker', () => {
     expect(wrapper.find('.iot--time-picker__controls--btn')).toHaveLength(0);
   });
 
-  test('it should keep preset value when switching from presets to relative and back', () => {
+  it('should keep preset value when switching from presets to relative and back', () => {
     const wrapper = mount(<DateTimePicker {...dateTimePickerProps} />);
     wrapper
       .find('.iot--date-time-picker__field')

--- a/src/components/FileDrop/FileDrop.test.jsx
+++ b/src/components/FileDrop/FileDrop.test.jsx
@@ -50,7 +50,7 @@ describe('File Drop', () => {
   afterEach(() => {
     window.FileReader = originalFileReader;
   });
-  test('handleChange and addNewFiles', () => {
+  it('handleChange and addNewFiles', () => {
     // If I call handleChange it should update my state with files
     expect(wrapper.state('files')).toEqual([]);
     const instance = wrapper.instance();
@@ -64,7 +64,7 @@ describe('File Drop', () => {
     expect(instance.readFileContent).toHaveBeenCalled();
   });
   // handle click function test
-  test('handleClick', () => {
+  it('handleClick', () => {
     const mockFileNamesNodes = [{ innerText: 'fileToClear' }];
 
     wrapper.instance().clearFile = jest.fn().mockImplementationOnce();
@@ -73,7 +73,7 @@ describe('File Drop', () => {
     wrapper.instance().handleClick(null, 0);
     expect(wrapper.instance().clearFile).toHaveBeenCalledWith('fileToClear');
   });
-  test('fileType', () => {
+  it('fileType', () => {
     const textWrapper = mount(<FileDrop {...commonProps} fileType="TEXT" />);
     const textInstance = textWrapper.instance();
     const binaryWrapper = mount(<FileDrop {...commonProps} fileType="BINARY" />);
@@ -84,12 +84,12 @@ describe('File Drop', () => {
     expect(mockFileReader.readAsBinaryString).toHaveBeenCalled();
   });
   // Example of how to trigger from direct instance call
-  test('fileDragHover', () => {
+  it('fileDragHover', () => {
     wrapper.instance().fileDragHover(mockHoverEvent);
     expect(wrapper.state('hover')).toBe(true);
   });
   // Example of how to click on an element
-  test('fileDrop', () => {
+  it('fileDrop', () => {
     const dragAndDropWrapper = mount(<FileDrop {...dragAndDropProps} />);
     // console.log(`drag and drop version: ${dragAndDropWrapper.debug()}`)
     const instance = dragAndDropWrapper.instance();
@@ -103,13 +103,13 @@ describe('File Drop', () => {
     expect(instance.addNewFiles).toHaveBeenCalled();
   });
   // Example of how to clear an element
-  test('fileDrop clearFile', () => {
+  it('fileDrop clearFile', () => {
     wrapper.setState({ files: mockFiles });
     expect(wrapper.state('files')).toHaveLength(1);
     wrapper.instance().clearFile(mockFiles[0].name);
     expect(wrapper.state('files')).toHaveLength(0);
   });
-  test('readFileContent', () => {
+  it('readFileContent', () => {
     const instance = wrapper.instance();
     expect(instance.readers).toEqual({});
     instance.handleFileError = jest.fn().mockImplementationOnce();
@@ -118,7 +118,7 @@ describe('File Drop', () => {
     expect(Object.keys(instance.readers)).toHaveLength(1);
     expect(instance.readers.fakeFileName).toBeDefined();
   });
-  test('handleFileErro', () => {
+  it('handleFileErro', () => {
     const instance = wrapper.instance();
     instance.readers = { fakeFileError: 'fake File Reader' };
     expect(commonProps.onError).not.toHaveBeenCalled();
@@ -126,7 +126,7 @@ describe('File Drop', () => {
     expect(Object.keys(instance.readers)).toHaveLength(0);
     expect(commonProps.onError).toHaveBeenCalled();
   });
-  test('handleFileLoad', () => {
+  it('handleFileLoad', () => {
     const instance = wrapper.instance();
     wrapper.setState({ files: mockFiles });
     expect(wrapper.state('files')[0].contents).toEqual(null);
@@ -136,7 +136,7 @@ describe('File Drop', () => {
     expect(wrapper.state('files')[0].contents).toEqual('resultFromFileReader');
   });
   // We should not include duplicated files in the state
-  test('addNewFiles - not include duplicate files', () => {
+  it('addNewFiles - not include duplicate files', () => {
     const instance = wrapper.instance();
     wrapper.setState({ files: mockFiles });
     expect(wrapper.state('files')).toHaveLength(1);

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -283,7 +283,7 @@ describe('Header testcases', () => {
     expect(menuTrigger.getAttribute('aria-expanded')).toBe('false');
   });
 
-  test('onClick event on empty onClick prop', () => {
+  it('onClick event on empty onClick prop', () => {
     const { getByLabelText } = render(<Header {...HeaderPropsWithoutOnClick} />);
     const menuItem = getByLabelText('user');
     fireEvent.click(menuItem);

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -10,7 +10,7 @@ import Header, { APP_SWITCHER } from './Header';
 
 React.Fragment = ({ children }) => children;
 
-describe('Header testcases', () => {
+describe('Header', () => {
   const onClick = jest.fn();
   const HeaderProps = {
     user: 'JohnDoe@ibm.com',

--- a/src/components/Header/__snapshots__/Header.test.jsx.snap
+++ b/src/components/Header/__snapshots__/Header.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Header testcases should render 1`] = `
+exports[`Header should render 1`] = `
 <div>
   <header
     aria-label="main header"

--- a/src/components/ImageCard/CardIcon.test.jsx
+++ b/src/components/ImageCard/CardIcon.test.jsx
@@ -15,7 +15,7 @@ describe('CardIcon', () => {
     // globally this is false, but we need it true so the warning pops
     global.__DEV__ = false;
   });
-  test('validate default', () => {
+  it('validate default', () => {
     render(<CardIcon icon="bogus" title="title" color="#FFFFFF" />);
     expect(spy.console).toHaveBeenCalled();
   });

--- a/src/components/ImageCard/HotspotContent.test.jsx
+++ b/src/components/ImageCard/HotspotContent.test.jsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import HotspotContent from './HotspotContent';
 
 describe('HotspotContent', () => {
-  test('basic attributes', () => {
+  it('basic attributes', () => {
     const { getAllByText } = render(
       <HotspotContent
         title="My hotspot"
@@ -25,7 +25,7 @@ describe('HotspotContent', () => {
     // should be english formatted
     expect(getAllByText(/35.05/)).toHaveLength(1);
   });
-  test('can support react element for title', () => {
+  it('can support react element for title', () => {
     const { getAllByText } = render(
       <HotspotContent
         title={<span>My hotspot</span>}
@@ -39,7 +39,7 @@ describe('HotspotContent', () => {
     // check the titles first
     expect(getAllByText(/My hotspot/)).toHaveLength(1);
   });
-  test('empty values show --', () => {
+  it('empty values show --', () => {
     const { getAllByText, queryAllByText } = render(
       <HotspotContent
         title={<span>My hotspot</span>}
@@ -54,7 +54,7 @@ describe('HotspotContent', () => {
     expect(getAllByText(/--/)).toHaveLength(1);
     expect(queryAllByText(/Celsius/)).toHaveLength(0);
   });
-  test('precision tests', () => {
+  it('precision tests', () => {
     const { getAllByText } = render(
       <HotspotContent
         title={<span>My hotspot</span>}
@@ -71,7 +71,7 @@ describe('HotspotContent', () => {
     expect(getAllByText(/^0$/)).toHaveLength(1);
     expect(getAllByText(/0.125/)).toHaveLength(1);
   });
-  test('units', () => {
+  it('units', () => {
     const { getAllByText } = render(
       <HotspotContent
         title={<span>My hotspot</span>}
@@ -85,7 +85,7 @@ describe('HotspotContent', () => {
     // values should render units
     expect(getAllByText(/Celsius/)).toHaveLength(1);
   });
-  test('locale formatting', () => {
+  it('locale formatting', () => {
     const { getAllByText } = render(
       <HotspotContent
         title="My hotspot"
@@ -103,7 +103,7 @@ describe('HotspotContent', () => {
     // should be french formatted
     expect(getAllByText(/35,05/)).toHaveLength(1);
   });
-  test('attribute thresholds', () => {
+  it('attribute thresholds', () => {
     const { getAllByTitle } = render(
       <HotspotContent
         title="My hotspot"
@@ -124,7 +124,7 @@ describe('HotspotContent', () => {
     // threshold should be found and french formatted
     expect(getAllByTitle(/temperature > 0,05/)).toHaveLength(2);
   });
-  test('hotspot threshold', () => {
+  it('hotspot threshold', () => {
     const { getAllByTitle } = render(
       <HotspotContent
         title="My hotspot"
@@ -150,7 +150,7 @@ describe('HotspotContent', () => {
     // threshold should be found
     expect(getAllByTitle(/temperature > 0.05/)).toHaveLength(2);
   });
-  test('custom render Icon By Name', () => {
+  it('custom render Icon By Name', () => {
     const mockRenderIconByName = jest.fn().mockReturnValue(<span />);
     render(
       <HotspotContent

--- a/src/components/ImageCard/ImageHotspots.test.jsx
+++ b/src/components/ImageCard/ImageHotspots.test.jsx
@@ -114,7 +114,7 @@ describe('ImageHotspots', () => {
     const image = container.querySelector('img');
     expect(isDOMComponent(image)).toBe(false);
   });
-  test('calculateImageHeight', () => {
+  it('calculateImageHeight', () => {
     // landscape test where image is bigger picks container height
     expect(
       calculateImageHeight(
@@ -132,7 +132,7 @@ describe('ImageHotspots', () => {
       )
     ).toEqual(200);
   });
-  test('calculateImageWidth', () => {
+  it('calculateImageWidth', () => {
     // landscape test where image is bigger picks container height
     expect(
       calculateImageWidth(
@@ -150,7 +150,7 @@ describe('ImageHotspots', () => {
       )
     ).toEqual(200);
   });
-  test('zoom', () => {
+  it('zoom', () => {
     const image = {
       initialWidth: 5000,
       width: 200,

--- a/src/components/ImageCard/ImageHotspotsRender.test.jsx
+++ b/src/components/ImageCard/ImageHotspotsRender.test.jsx
@@ -28,7 +28,7 @@ afterAll(() => {
 });
 
 describe('render tests for the image hotspots component', () => {
-  test('minimap rendering', () => {
+  it('minimap rendering', () => {
     const { getByAltText, queryByAltText, getByTitle } = render(
       <div style={{ maxWidth: '50px', maxHeight: '50px', width: '50px', height: '50px' }}>
         <ImageHotspots

--- a/src/components/List/HierarchyList/HierarchyList.test.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.test.jsx
@@ -60,7 +60,7 @@ describe('HierarchyList', () => {
     })),
   ];
 
-  test('searchForNestedItemValues should return results for single nested list', () => {
+  it('searchForNestedItemValues should return results for single nested list', () => {
     const foundValue = searchForNestedItemValues(items, 'jd');
     expect(foundValue).toEqual([
       {
@@ -83,12 +83,12 @@ describe('HierarchyList', () => {
     ]);
   });
 
-  test('searchForNestedItemValues should not return results for single nested list', () => {
+  it('searchForNestedItemValues should not return results for single nested list', () => {
     const foundValue = searchForNestedItemValues(items, 'abcdefg');
     expect(foundValue).toEqual([]);
   });
 
-  test('searchForNestedItemIds should return results for single nested list', () => {
+  it('searchForNestedItemIds should return results for single nested list', () => {
     const foundValue = searchForNestedItemIds(items, 'New York Mets_JD Davis');
     expect(foundValue).toEqual([
       {
@@ -111,12 +111,12 @@ describe('HierarchyList', () => {
     ]);
   });
 
-  test('searchNestedItems should not return results for single nested list', () => {
+  it('searchNestedItems should not return results for single nested list', () => {
     const foundValue = searchForNestedItemIds(items, 'abcdefg');
     expect(foundValue).toEqual([]);
   });
 
-  test('clicking expansion caret should expand item', () => {
+  it('clicking expansion caret should expand item', () => {
     const { getByTitle, getAllByRole } = render(
       <HierarchyList items={items} title="Hierarchy List" pageSize="xl" />
     );
@@ -134,7 +134,7 @@ describe('HierarchyList', () => {
     expect(getByTitle('Washington Nationals')).toBeInTheDocument();
   });
 
-  test('clicking expansion caret should collapse expanded item', () => {
+  it('clicking expansion caret should collapse expanded item', () => {
     const { getByTitle, getAllByRole, queryByTitle } = render(
       <HierarchyList items={items} title="Hierarchy List" pageSize="xl" />
     );
@@ -166,7 +166,7 @@ describe('HierarchyList', () => {
     expect(getByTitle('Washington Nationals')).toBeInTheDocument();
   });
 
-  test('clicking nextpage should display the second page', () => {
+  it('clicking nextpage should display the second page', () => {
     const { getByTitle, queryByTitle, getAllByRole } = render(
       <HierarchyList items={items} title="Hierarchy List" pageSize="sm" />
     );
@@ -194,7 +194,7 @@ describe('HierarchyList', () => {
     expect(queryByTitle('Houston Astros')).not.toBeInTheDocument();
   });
 
-  test('found search result categories should be expanded', () => {
+  it('found search result categories should be expanded', () => {
     const { getAllByLabelText, getByTitle, queryByTitle } = render(
       <HierarchyList items={items} hasSearch title="Hierarchy List" pageSize="lg" />
     );
@@ -212,7 +212,7 @@ describe('HierarchyList', () => {
     expect(getByTitle('JD Davis')).toBeInTheDocument();
   });
 
-  test('all items should return if search value is empty string', () => {
+  it('all items should return if search value is empty string', () => {
     const { getAllByLabelText, getByTitle, queryByTitle } = render(
       <HierarchyList items={items} hasSearch title="Hierarchy List" />
     );
@@ -242,7 +242,7 @@ describe('HierarchyList', () => {
     expect(getByTitle('New York Yankees')).toBeInTheDocument();
   });
 
-  test('parent items of defaultSelectedId should be expanded', () => {
+  it('parent items of defaultSelectedId should be expanded', () => {
     const { getByTitle, queryByTitle } = render(
       <HierarchyList
         items={items}
@@ -266,7 +266,7 @@ describe('HierarchyList', () => {
     expect(queryByTitle('Gary Sanchez')).not.toBeInTheDocument();
   });
 
-  test('clicking item should fire onSelect', () => {
+  it('clicking item should fire onSelect', () => {
     const onSelect = jest.fn();
     const { getByTitle, getAllByRole } = render(
       <HierarchyList items={items} title="Hierarchy List" pageSize="xl" onSelect={onSelect} />

--- a/src/components/List/List.test.jsx
+++ b/src/components/List/List.test.jsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import List from './List';
 import { sampleHierarchy } from './List.story';
 
-describe('List component tests', () => {
+describe('List', () => {
   const getListItems = num =>
     Array(num)
       .fill(0)

--- a/src/components/List/List.test.jsx
+++ b/src/components/List/List.test.jsx
@@ -14,29 +14,29 @@ describe('List component tests', () => {
         isSelectable: true,
       }));
 
-  test('List when pagination is null', () => {
+  it('List when pagination is null', () => {
     const renderedElement = render(<List title="list" items={getListItems(5)} />);
     expect(renderedElement.container.innerHTML).toBeTruthy();
   });
 
-  test('List to have default handleSelect', () => {
+  it('List to have default handleSelect', () => {
     expect(List.defaultProps.handleSelect).toBeDefined();
     List.defaultProps.handleSelect();
   });
 
-  test('List to have default toggleExpansion', () => {
+  it('List to have default toggleExpansion', () => {
     expect(List.defaultProps.toggleExpansion).toBeDefined();
     List.defaultProps.toggleExpansion();
   });
 
-  test('List when selectedIds is set', () => {
+  it('List when selectedIds is set', () => {
     const renderedElement = render(
       <List title="list" items={getListItems(5)} selectedIds={['1', '2']} />
     );
     expect(renderedElement.container.innerHTML).toBeTruthy();
   });
 
-  test('List hasChildren and expanded', () => {
+  it('List hasChildren and expanded', () => {
     const { getByTitle } = render(
       <List
         title="list"

--- a/src/components/List/ListHeader/ListHeader.test.jsx
+++ b/src/components/List/ListHeader/ListHeader.test.jsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 
 import ListHeader from './ListHeader';
 
-describe('ListHeader tests', () => {
+describe('ListHeader', () => {
   it('ListHeader gets rendered', () => {
     const { getByText } = render(<ListHeader title="List Header" i18n={{}} />);
     expect(getByText('List Header')).toBeTruthy();

--- a/src/components/List/ListHeader/ListHeader.test.jsx
+++ b/src/components/List/ListHeader/ListHeader.test.jsx
@@ -4,17 +4,17 @@ import { render } from '@testing-library/react';
 import ListHeader from './ListHeader';
 
 describe('ListHeader tests', () => {
-  test('ListHeader gets rendered', () => {
+  it('ListHeader gets rendered', () => {
     const { getByText } = render(<ListHeader title="List Header" i18n={{}} />);
     expect(getByText('List Header')).toBeTruthy();
   });
 
-  test('ListHeader with defaultProps onChange function', () => {
+  it('ListHeader with defaultProps onChange function', () => {
     expect(ListHeader.defaultProps.search.onChange).toBeDefined();
     ListHeader.defaultProps.search.onChange();
   });
 
-  test('ListHeader with no title', () => {
+  it('ListHeader with no title', () => {
     const { queryByText } = render(<ListHeader i18n={{}} />);
     expect(queryByText('List Header')).toBeNull();
   });

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -4,7 +4,7 @@ import { Add16, Edit16 } from '@carbon/icons-react';
 
 import ListItem from './ListItem';
 
-describe('ListItem component tests', () => {
+describe('ListItem', () => {
   it('test ListItem gets rendered', () => {
     const { getByText } = render(<ListItem id="1" value="test" />);
     expect(getByText('test')).toBeTruthy();

--- a/src/components/List/ListItem/ListItem.test.jsx
+++ b/src/components/List/ListItem/ListItem.test.jsx
@@ -5,12 +5,12 @@ import { Add16, Edit16 } from '@carbon/icons-react';
 import ListItem from './ListItem';
 
 describe('ListItem component tests', () => {
-  test('test ListItem gets rendered', () => {
+  it('test ListItem gets rendered', () => {
     const { getByText } = render(<ListItem id="1" value="test" />);
     expect(getByText('test')).toBeTruthy();
   });
 
-  test('ListItem with large row and secondary value', () => {
+  it('ListItem with large row and secondary value', () => {
     const { getByText } = render(
       <ListItem id="1" value="test" secondaryValue="second" isLargeRow />
     );
@@ -18,7 +18,7 @@ describe('ListItem component tests', () => {
     expect(getByText('second')).toBeTruthy();
   });
 
-  test('ListItem when isSelectable set to true', () => {
+  it('ListItem when isSelectable set to true', () => {
     const onSelect = jest.fn();
     const { getAllByRole } = render(
       <ListItem id="1" value="test" isSelectable onSelect={onSelect} />
@@ -27,28 +27,28 @@ describe('ListItem component tests', () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
-  test('ListItem when isSelectable is set to true and onClick will trigger onSelect', () => {
+  it('ListItem when isSelectable is set to true and onClick will trigger onSelect', () => {
     const onSelect = jest.fn();
     const { getAllByRole } = render(<ListItem id="1" value="" isSelectable onSelect={onSelect} />);
     fireEvent.click(getAllByRole('button')[0]);
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
-  test('ListItem when is Expandable set to true', () => {
+  it('ListItem when is Expandable set to true', () => {
     const onExpand = jest.fn();
     const { getAllByRole } = render(<ListItem id="1" value="" isExpandable onExpand={onExpand} />);
     fireEvent.keyPress(getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
     expect(onExpand).toHaveBeenCalledTimes(1);
   });
 
-  test('ListItem when is Expandable set to true and onClick will trigger onExpand', () => {
+  it('ListItem when is Expandable set to true and onClick will trigger onExpand', () => {
     const onExpand = jest.fn();
     const { getAllByRole } = render(<ListItem id="1" value="" isExpandable onExpand={onExpand} />);
     fireEvent.click(getAllByRole('button')[0]);
     expect(onExpand).toHaveBeenCalledTimes(1);
   });
 
-  test('ListItem with Icon', () => {
+  it('ListItem with Icon', () => {
     const onClick = jest.fn();
     const { getByTitle } = render(
       <ListItem
@@ -62,7 +62,7 @@ describe('ListItem component tests', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  test('ListItem with rowActions', () => {
+  it('ListItem with rowActions', () => {
     const rowActionOnClick = jest.fn();
     const rowActions = [<Edit16 title="iconTitle" onClick={rowActionOnClick} />];
     const { getByTitle } = render(<ListItem id="1" value="test" rowActions={rowActions} />);

--- a/src/components/List/SimpleList/SimpleList.test.jsx
+++ b/src/components/List/SimpleList/SimpleList.test.jsx
@@ -38,7 +38,7 @@ const getEmptyListItems = num =>
       isSelectable: true,
     }));
 
-describe('SimpleList component tests', () => {
+describe('SimpleList', () => {
   it('Simple List when pageSize is set to sm', () => {
     const { getByTitle } = render(
       <SimpleList title="Simple list" items={getListItems(5)} pageSize="sm" />

--- a/src/components/List/SimpleList/SimpleList.test.jsx
+++ b/src/components/List/SimpleList/SimpleList.test.jsx
@@ -39,7 +39,7 @@ const getEmptyListItems = num =>
     }));
 
 describe('SimpleList component tests', () => {
-  test('Simple List when pageSize is set to sm', () => {
+  it('Simple List when pageSize is set to sm', () => {
     const { getByTitle } = render(
       <SimpleList title="Simple list" items={getListItems(5)} pageSize="sm" />
     );
@@ -50,7 +50,7 @@ describe('SimpleList component tests', () => {
     expect(getByTitle('Item 5')).toBeTruthy();
   });
 
-  test('Simple List when pageSize is set to lg', () => {
+  it('Simple List when pageSize is set to lg', () => {
     const { getByTitle } = render(
       <SimpleList title="Simple list" items={getListItems(5)} pageSize="lg" />
     );
@@ -61,7 +61,7 @@ describe('SimpleList component tests', () => {
     expect(getByTitle('Item 5')).toBeTruthy();
   });
 
-  test('Simple List when pageSize is set to xl', () => {
+  it('Simple List when pageSize is set to xl', () => {
     const { getByTitle } = render(
       <SimpleList title="Simple list" items={getListItems(5)} pageSize="xl" />
     );
@@ -72,7 +72,7 @@ describe('SimpleList component tests', () => {
     expect(getByTitle('Item 5')).toBeTruthy();
   });
 
-  test('the first item is selectable via keyboard', () => {
+  it('the first item is selectable via keyboard', () => {
     const { getAllByRole } = render(<SimpleList title="Simple list" items={getListItems(1)} />);
     fireEvent.keyPress(getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
     expect(getAllByRole('button')[0]).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('SimpleList component tests', () => {
 
   // this is a failing test, opened defect at https://github.com/IBM/carbon-addons-iot-react/issues/1149
   // eslint-disable-next-line jest/no-commented-out-tests
-  // test('the first item is properly unselected via keyboard', () => {
+  // it('the first item is properly unselected via keyboard', () => {
   //   const { getAllByRole } = render(<SimpleList title="Simple list" items={getListItems(1)} />);
   //   fireEvent.keyPress(getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
   //   fireEvent.keyPress(getAllByRole('button')[0], { key: 'Enter', charCode: 13 });
@@ -95,7 +95,7 @@ describe('SimpleList component tests', () => {
   //   ).toEqual(false);
   // });
 
-  test('SimpleList when click on next page', () => {
+  it('SimpleList when click on next page', () => {
     const { getAllByRole, getByTitle } = render(
       <SimpleList items={getListItems(10)} title="Simple List" pageSize="sm" />
     );
@@ -109,7 +109,7 @@ describe('SimpleList component tests', () => {
     expect(getByTitle('Item 10')).toBeTruthy();
   });
 
-  test('SimpleList when hasSearch', () => {
+  it('SimpleList when hasSearch', () => {
     const { getAllByLabelText, getByTitle, queryByTitle } = render(
       <SimpleList title="Simple list" hasSearch items={getListItems(5)} />
     );
@@ -118,7 +118,7 @@ describe('SimpleList component tests', () => {
     expect(queryByTitle('Item 1')).toBeFalsy();
   });
 
-  test('SimpleList when hasSearch and item values are empty', () => {
+  it('SimpleList when hasSearch and item values are empty', () => {
     const { getAllByLabelText, queryByTitle } = render(
       <SimpleList title="Simple list" hasSearch items={getEmptyListItems(5)} />
     );
@@ -126,7 +126,7 @@ describe('SimpleList component tests', () => {
     expect(queryByTitle('Item 1')).toBeFalsy();
   });
 
-  test('SimpleList when hasSearch and pagination', () => {
+  it('SimpleList when hasSearch and pagination', () => {
     const { getAllByLabelText, getByTitle, queryByTitle } = render(
       <SimpleList title="Simple list" hasSearch items={getListItems(5)} pageSize="sm" />
     );
@@ -135,7 +135,7 @@ describe('SimpleList component tests', () => {
     expect(queryByTitle('Item 1')).toBeFalsy();
   });
 
-  test('SimpleList when search large row', () => {
+  it('SimpleList when search large row', () => {
     const { getAllByLabelText, getByTitle } = render(
       <SimpleList title="Simple list" hasSearch items={getFatRowListItems(5)} />
     );
@@ -143,7 +143,7 @@ describe('SimpleList component tests', () => {
     expect(getByTitle('Item 5')).toBeTruthy();
   });
 
-  test('SimpleList when search term is empty should return all items', () => {
+  it('SimpleList when search term is empty should return all items', () => {
     const { getAllByLabelText, getByTitle } = render(
       <SimpleList title="Simple list" hasSearch items={getListItems(5)} />
     );
@@ -155,7 +155,7 @@ describe('SimpleList component tests', () => {
     expect(getByTitle('Item 5')).toBeTruthy();
   });
 
-  test('SimpleList when search input is undefined should return all items', () => {
+  it('SimpleList when search input is undefined should return all items', () => {
     const { getAllByLabelText, getByTitle } = render(
       <SimpleList title="Simple list" hasSearch items={getListItems(5)} />
     );

--- a/src/components/ListCard/ListCard.test.jsx
+++ b/src/components/ListCard/ListCard.test.jsx
@@ -36,7 +36,7 @@ const mockScrollEvent = {
 };
 
 describe('ListCard', () => {
-  test('calls loadData callback on scroll', () => {
+  it('calls loadData callback on scroll', () => {
     const onLoadData = jest.fn();
 
     const wrapper = mount(
@@ -47,7 +47,7 @@ describe('ListCard', () => {
     expect(onLoadData).toHaveBeenCalled();
   });
 
-  test('LoadData when data is null', () => {
+  it('LoadData when data is null', () => {
     const onLoadData = jest.fn();
 
     const wrapper = mount(
@@ -57,7 +57,7 @@ describe('ListCard', () => {
     expect(wrapper.find('InlineLoading')).toHaveLength(0);
   });
 
-  test('Inline Loading', () => {
+  it('Inline Loading', () => {
     const onLoadData = jest.fn();
 
     const wrapper = mount(

--- a/src/components/NavigationBar/NavigationBar.test.jsx
+++ b/src/components/NavigationBar/NavigationBar.test.jsx
@@ -11,7 +11,7 @@ const commonNavigationBarProps = {
 };
 
 describe('NavigationBar', () => {
-  test('onSelectionChange', () => {
+  it('onSelectionChange', () => {
     const wrapper = mount(<NavigationBar {...commonNavigationBarProps} />);
     const tab1 = wrapper.find('[data-id="tab1"]');
     tab1.at(0).simulate('click');

--- a/src/components/Page/PageHero.test.jsx
+++ b/src/components/Page/PageHero.test.jsx
@@ -11,7 +11,7 @@ const commonPageHeroProps = {
   rightContent: <div>Right Content</div>,
 };
 
-describe('Page Hero', () => {
+describe('PageHero', () => {
   // handle click function test
   it('onClick switcher', () => {
     const commonSwitchProps = {

--- a/src/components/Page/PageHero.test.jsx
+++ b/src/components/Page/PageHero.test.jsx
@@ -13,7 +13,7 @@ const commonPageHeroProps = {
 
 describe('Page Hero', () => {
   // handle click function test
-  test('onClick switcher', () => {
+  it('onClick switcher', () => {
     const commonSwitchProps = {
       onChange: jest.fn(),
       options: [

--- a/src/components/Page/PageWorkArea.test.jsx
+++ b/src/components/Page/PageWorkArea.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import PageWorkArea from './PageWorkArea';
 
 describe('PageWorkArea', () => {
-  test('isOpen', () => {
+  it('isOpen', () => {
     const wrapper = mount(<PageWorkArea isOpen={false}>Hi</PageWorkArea>);
     expect(wrapper.find('div')).toHaveLength(0);
     const wrapper2 = mount(<PageWorkArea isOpen>Hi</PageWorkArea>);

--- a/src/components/PageTitleBar/PageTitleBar.test.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.test.jsx
@@ -8,21 +8,21 @@ import PageTitleBar from './PageTitleBar';
 import { commonPageTitleBarProps, pageTitleBarBreadcrumb } from './PageTitleBar.story';
 
 describe('PageTitleBar', () => {
-  test('Renders common props as expected', () => {
+  it('Renders common props as expected', () => {
     const wrapper = mount(<PageTitleBar {...commonPageTitleBarProps} />);
     expect(wrapper.find('.page-title-bar-title--text h2')).toHaveLength(1);
     expect(wrapper.find('.page-title-bar-description')).toHaveLength(1);
     expect(wrapper.find(Button)).toHaveLength(1);
   });
 
-  test('Renders breadrumbs as expected', () => {
+  it('Renders breadrumbs as expected', () => {
     const wrapper = mount(
       <PageTitleBar {...commonPageTitleBarProps} breadcrumb={pageTitleBarBreadcrumb} />
     );
     expect(wrapper.find('.page-title-bar-breadcrumb')).toHaveLength(1);
   });
 
-  test('Renders tooltip as expected', () => {
+  it('Renders tooltip as expected', () => {
     const wrapper = mount(
       <PageTitleBar
         title={commonPageTitleBarProps.title}
@@ -35,7 +35,7 @@ describe('PageTitleBar', () => {
     expect(wrapper.find('.page-title-bar-description')).toHaveLength(0);
   });
 
-  test('Renders content and tooltip as expected', () => {
+  it('Renders content and tooltip as expected', () => {
     const wrapper = mount(
       <PageTitleBar
         title={commonPageTitleBarProps.title}
@@ -54,7 +54,7 @@ describe('PageTitleBar', () => {
     expect(wrapper.find('.page-title-bar-content')).toHaveLength(1);
   });
 
-  test('Does not render tooltip when no description', () => {
+  it('Does not render tooltip when no description', () => {
     const wrapper = mount(
       <PageTitleBar
         title={commonPageTitleBarProps.title}
@@ -66,7 +66,7 @@ describe('PageTitleBar', () => {
     expect(wrapper.find('.page-title-bar-description')).toHaveLength(0);
   });
 
-  test('Does not render tooltip when no description with content', () => {
+  it('Does not render tooltip when no description with content', () => {
     const wrapper = mount(
       <PageTitleBar
         title={commonPageTitleBarProps.title}
@@ -112,7 +112,7 @@ describe('PageTitleBar', () => {
     });
   });
 
-  test('Renders loading state as expected', () => {
+  it('Renders loading state as expected', () => {
     const wrapper = mount(<PageTitleBar title={commonPageTitleBarProps.title} isLoading />);
     expect(wrapper.find(SkeletonText)).toHaveLength(1);
   });

--- a/src/components/PageWizard/PageWizard.test.jsx
+++ b/src/components/PageWizard/PageWizard.test.jsx
@@ -6,7 +6,7 @@ import { ProgressIndicator } from 'carbon-components-react';
 import PageWizard from './PageWizard';
 import { content, StepValidation } from './PageWizard.story';
 
-describe('PageWizard tests', () => {
+describe('PageWizard', () => {
   it('error states', () => {
     const i18n = {
       close: 'Close',

--- a/src/components/PageWizard/PageWizard.test.jsx
+++ b/src/components/PageWizard/PageWizard.test.jsx
@@ -7,7 +7,7 @@ import PageWizard from './PageWizard';
 import { content, StepValidation } from './PageWizard.story';
 
 describe('PageWizard tests', () => {
-  test('error states', () => {
+  it('error states', () => {
     const i18n = {
       close: 'Close',
     };
@@ -28,12 +28,12 @@ describe('PageWizard tests', () => {
     expect(queryByText('My Custom Error')).toBeNull();
   });
 
-  test('currentStepId prop', () => {
+  it('currentStepId prop', () => {
     const wrapper = shallow(<PageWizard currentStepId="step1">{content}</PageWizard>);
     expect(wrapper.find('PageWizardStep').prop('id')).toEqual('step1');
   });
 
-  test('button events during first step (no validation)', () => {
+  it('button events during first step (no validation)', () => {
     const mocks = {
       onNext: jest.fn(),
       onClose: jest.fn(),
@@ -53,7 +53,7 @@ describe('PageWizard tests', () => {
     expect(mocks.onNext).toHaveBeenCalledTimes(1);
   });
 
-  test('button events during middle step (no validation)', () => {
+  it('button events during middle step (no validation)', () => {
     const mocks = {
       onBack: jest.fn(),
       onNext: jest.fn(),
@@ -73,7 +73,7 @@ describe('PageWizard tests', () => {
     expect(mocks.onNext).toHaveBeenCalledTimes(1);
   });
 
-  test('button events during final step (no validation)', () => {
+  it('button events during final step (no validation)', () => {
     const mocks = {
       onBack: jest.fn(),
       onSubmit: jest.fn(),
@@ -93,7 +93,7 @@ describe('PageWizard tests', () => {
     expect(mocks.onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  test('validation in first step', () => {
+  it('validation in first step', () => {
     const mocks = {
       onNext: jest.fn(),
     };
@@ -121,7 +121,7 @@ describe('PageWizard tests', () => {
     expect(mocks.onNext).toHaveBeenCalledTimes(1);
   });
 
-  test('progress indicator should not render if there is only 1 step', () => {
+  it('progress indicator should not render if there is only 1 step', () => {
     const wrapper = shallow(<PageWizard currentStepId="step1">{content[0]}</PageWizard>);
     expect(wrapper.find(ProgressIndicator)).toHaveLength(0);
   });

--- a/src/components/PageWizard/StatefulPageWizard.test.jsx
+++ b/src/components/PageWizard/StatefulPageWizard.test.jsx
@@ -5,7 +5,7 @@ import StatefulPageWizard from './StatefulPageWizard';
 import { content } from './PageWizard.story';
 
 describe('StatefulPageWizard tests', () => {
-  test('button events during first step (no validation)', () => {
+  it('button events during first step (no validation)', () => {
     const mocks = {
       onNext: jest.fn(),
       onClose: jest.fn(),
@@ -30,7 +30,7 @@ describe('StatefulPageWizard tests', () => {
     expect(mocks.onNext).toHaveBeenCalledTimes(1);
   });
 
-  test('button events during second step (no validation)', () => {
+  it('button events during second step (no validation)', () => {
     const mocks = {
       onNext: jest.fn(),
       onBack: jest.fn(),
@@ -59,7 +59,7 @@ describe('StatefulPageWizard tests', () => {
     expect(mocks.onNext).toHaveBeenCalledTimes(2);
   });
 
-  test('button events during final step (no validation)', () => {
+  it('button events during final step (no validation)', () => {
     const mocks = {
       onBack: jest.fn(),
       onNext: jest.fn(),
@@ -90,7 +90,7 @@ describe('StatefulPageWizard tests', () => {
     expect(mocks.onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  test('step indicator to go to a specific step', () => {
+  it('step indicator to go to a specific step', () => {
     const mocks = {
       setStep: jest.fn(),
     };
@@ -106,7 +106,7 @@ describe('StatefulPageWizard tests', () => {
     expect(mocks.setStep).toHaveBeenCalledTimes(1);
   });
 
-  test('without setting currentStepId', () => {
+  it('without setting currentStepId', () => {
     const mocks = {
       setStep: jest.fn(),
     };
@@ -118,7 +118,7 @@ describe('StatefulPageWizard tests', () => {
     expect(mocks.setStep).toHaveBeenCalledTimes(1);
   });
 
-  test("not passing onBack function doesn't blow things up", () => {
+  it('not passing onBack function does not blow things up', () => {
     const i18n = {
       back: 'Back',
       next: 'Next',

--- a/src/components/PageWizard/StatefulPageWizard.test.jsx
+++ b/src/components/PageWizard/StatefulPageWizard.test.jsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from '@testing-library/react';
 import StatefulPageWizard from './StatefulPageWizard';
 import { content } from './PageWizard.story';
 
-describe('StatefulPageWizard tests', () => {
+describe('StatefulPageWizard', () => {
   it('button events during first step (no validation)', () => {
     const mocks = {
       onNext: jest.fn(),

--- a/src/components/ProgressIndicator/ProgressIndicator.test.jsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.test.jsx
@@ -6,14 +6,14 @@ import ProgressIndicator from './ProgressIndicator';
 const mockItems = [{ id: 'myid', label: 'my label' }, { id: 'myid2', label: 'my label2' }];
 
 describe('ProgressIndicator', () => {
-  test('handleChange', () => {
+  it('handleChange', () => {
     const mockOnClickItem = jest.fn();
     const wrapper = mount(<ProgressIndicator items={mockItems} onClickItem={mockOnClickItem} />);
     // click the next step
     wrapper.find('[tabIndex=0]').simulate('click');
     expect(mockOnClickItem).toHaveBeenCalledWith('myid2');
   });
-  test('if click item is not set it still works', () => {
+  it('if click item is not set it still works', () => {
     const wrapper = mount(<ProgressIndicator items={mockItems} />);
     // click the next step
     wrapper.find('[tabIndex=0]').simulate('click');

--- a/src/components/ResourceList/ResourceList.test.jsx
+++ b/src/components/ResourceList/ResourceList.test.jsx
@@ -27,7 +27,7 @@ const resourceData = [
 
 describe('Resource List', () => {
   // handle click function test
-  test('onRowClick', () => {
+  it('onRowClick', () => {
     const onRowClick = jest.fn();
     const wrapper = mount(
       <ResourceList
@@ -44,7 +44,7 @@ describe('Resource List', () => {
       .simulate('click');
     expect(onRowClick.mock.calls).toHaveLength(1);
   });
-  test('customAction', () => {
+  it('customAction', () => {
     const actionClick = jest.fn();
     const wrapper = mount(
       <ResourceList
@@ -63,7 +63,7 @@ describe('Resource List', () => {
       .simulate('click');
     expect(actionClick.mock.calls).toHaveLength(1);
   });
-  test('extraContent', () => {
+  it('extraContent', () => {
     const wrapper = mount(
       <ResourceList
         design="normal"

--- a/src/components/ResourceList/ResourceList.test.jsx
+++ b/src/components/ResourceList/ResourceList.test.jsx
@@ -25,7 +25,7 @@ const resourceData = [
   },
 ];
 
-describe('Resource List', () => {
+describe('ResourceList', () => {
   // handle click function test
   it('onRowClick', () => {
     const onRowClick = jest.fn();

--- a/src/components/SideNav/SideNav.test.jsx
+++ b/src/components/SideNav/SideNav.test.jsx
@@ -8,7 +8,7 @@ import SideNav from './SideNav';
 
 React.Fragment = ({ children }) => children;
 
-describe('SideNav testcases', () => {
+describe('SideNav', () => {
   const links = [
     {
       icon: () => (

--- a/src/components/SimplePagination/SimplePagination.test.jsx
+++ b/src/components/SimplePagination/SimplePagination.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import SimplePagination from './SimplePagination';
 
 describe('SimplePagination', () => {
-  test('only one page', () => {
+  it('only one page', () => {
     const mockPage = jest.fn();
     const wrapper = mount(<SimplePagination page={1} maxPage={1} onPage={mockPage} />);
     const clickableButtons = wrapper.find('div[onClick]');
@@ -14,7 +14,7 @@ describe('SimplePagination', () => {
     // Because the page number is the same as maxPage we shouldn't have any clickable or tabbable buttons
     expect(tabbableButtons).toHaveLength(0);
   });
-  test('both buttons should be clickable', () => {
+  it('both buttons should be clickable', () => {
     const mockPage = jest.fn();
     const wrapper = mount(<SimplePagination page={2} maxPage={4} onPage={mockPage} />);
     const clickableButtons = wrapper.find('div[onClick]');
@@ -24,7 +24,7 @@ describe('SimplePagination', () => {
     // Because the page number is the same as maxPage we shouldn't have any clickable or tabbable buttons
     expect(tabbableButtons).toHaveLength(2);
   });
-  test('next and prev', () => {
+  it('next and prev', () => {
     const mockPage = jest.fn();
     const wrapper = mount(<SimplePagination page={2} maxPage={4} onPage={mockPage} />);
     const nextAndPrevButtons = wrapper.find('div[onClick]');
@@ -37,7 +37,7 @@ describe('SimplePagination', () => {
     nextAndPrevButtons.at(0).simulate('click');
     expect(mockPage).toHaveBeenCalledWith(1);
   });
-  test('next and prev key down', () => {
+  it('next and prev key down', () => {
     const mockPage = jest.fn();
     const wrapper = mount(<SimplePagination page={2} maxPage={4} onPage={mockPage} />);
     const nextAndPrevButtons = wrapper.find('div[tabIndex=0]');

--- a/src/components/Table/Pagination.test.jsx
+++ b/src/components/Table/Pagination.test.jsx
@@ -17,7 +17,7 @@ describe('Pagination', () => {
   afterAll(() => {
     Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
-  test('Pagination display hides', () => {
+  it('Pagination display hides', () => {
     // Need to mock getBoundingClientRect for react-sizeme
     mockGetBoundingClientRect.mockImplementation(() => {
       return {
@@ -35,7 +35,7 @@ describe('Pagination', () => {
     rerender(<Pagination pageSizes={[10, 20, 30]} />);
     expect(queryByText('Items per page')).toBeNull();
   });
-  test('Pagination page display shows', () => {
+  it('Pagination page display shows', () => {
     // at wider widths it should show
     mockGetBoundingClientRect.mockImplementation(() => {
       return {

--- a/src/components/Table/StatefulTable.test.jsx
+++ b/src/components/Table/StatefulTable.test.jsx
@@ -9,7 +9,7 @@ import { mockActions } from './Table.test.helpers';
 import { initialState } from './Table.story';
 
 describe('stateful table with real reducer', () => {
-  test('verify stateful table can support loading state', () => {
+  it('verify stateful table can support loading state', () => {
     const statefulTable = mount(
       <StatefulTable
         {...merge({}, initialState, { view: { table: { loadingState: { isLoading: true } } } })}
@@ -18,7 +18,7 @@ describe('stateful table with real reducer', () => {
     );
     expect(statefulTable.find(TableSkeletonWithHeaders)).toHaveLength(1);
   });
-  test('stateful table verify page change', () => {
+  it('stateful table verify page change', () => {
     const statefulTable = mount(
       <StatefulTable
         {...merge(

--- a/src/components/Table/StatefulTableMockReducers.test.jsx
+++ b/src/components/Table/StatefulTableMockReducers.test.jsx
@@ -22,17 +22,17 @@ describe('StatefulTable tests with Mock reducer', () => {
     jest.unmock('react');
     jest.resetModules();
   });
-  test('check renders nested table', () => {
+  it('check renders nested table', () => {
     const statefulTable = mount(<StatefulTable {...initialState} actions={mockActions} />);
     expect(statefulTable.find(Table)).toHaveLength(1);
   });
-  test('check renders nested table passthrough props', () => {
+  it('check renders nested table passthrough props', () => {
     const statefulTable = mount(
       <StatefulTable {...initialState} actions={mockActions} className="custom-class" />
     );
     expect(statefulTable.find(Table).prop('className')).toEqual('custom-class');
   });
-  test('async data load', () => {
+  it('async data load', () => {
     // Need the real reducer to fire
     const statefulTable = mount(
       <StatefulTable {...initialState} data={[]} actions={mockActions} />
@@ -58,7 +58,7 @@ describe('StatefulTable tests with Mock reducer', () => {
       type: 'TABLE_REGISTER',
     });
   });
-  test('check callbacks are propagated up!', () => {
+  it('check callbacks are propagated up!', () => {
     const statefulTable = mount(<StatefulTable {...initialState} actions={mockActions} />);
     const tableProps = statefulTable.find(Table).props();
     Object.keys(tableProps.actions).forEach(actionType =>

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -142,7 +142,7 @@ describe('Table', () => {
     },
   ];
 
-  test('handles row collapse', () => {
+  it('handles row collapse', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -160,7 +160,7 @@ describe('Table', () => {
     expect(mockActions.table.onRowExpanded).toHaveBeenCalled();
   });
 
-  test('handles row expansion', () => {
+  it('handles row expansion', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -177,7 +177,7 @@ describe('Table', () => {
     expect(mockActions.table.onRowExpanded).toHaveBeenCalled();
   });
 
-  test('handles column sort', () => {
+  it('handles column sort', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -191,7 +191,7 @@ describe('Table', () => {
     expect(mockActions.table.onChangeSort).toHaveBeenCalled();
   });
 
-  test('custom emptystate only renders with no filters', () => {
+  it('custom emptystate only renders with no filters', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -228,7 +228,7 @@ describe('Table', () => {
     expect(mockActions.toolbar.onClearAllFilters).toHaveBeenCalled();
   });
 
-  test('validate row count function ', () => {
+  it('validate row count function ', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -257,7 +257,7 @@ describe('Table', () => {
     expect(renderItemRangeField).toContain('items');
   });
 
-  test('validate show/hide hasRowCountInHeader property ', () => {
+  it('validate show/hide hasRowCountInHeader property ', () => {
     const tableHeaderWrapper = mount(
       <TableToolbar actions={mockActions} options={options} tableState={tableState} />
     );
@@ -277,7 +277,7 @@ describe('Table', () => {
     expect(renderRowCountLabel2).toHaveLength(0);
   });
 
-  test('enter key should trigger onDownload', () => {
+  it('enter key should trigger onDownload', () => {
     const { getByTestId } = render(
       <TableToolbar actions={mockActions.toolbar} options={options2} tableState={tableState} />
     );
@@ -288,7 +288,7 @@ describe('Table', () => {
     expect(mockActions.toolbar.onDownloadCSV).toHaveBeenCalledTimes(1);
   });
 
-  test('enter key should trigger onColumnSelection', () => {
+  it('enter key should trigger onColumnSelection', () => {
     const { getByTestId } = render(
       <TableToolbar
         actions={mockActions.toolbar}
@@ -303,7 +303,7 @@ describe('Table', () => {
     expect(mockActions.toolbar.onToggleColumnSelection).toHaveBeenCalledTimes(1);
   });
 
-  test('enter key should trigger onFilter', () => {
+  it('enter key should trigger onFilter', () => {
     const { getByTestId } = render(
       <TableToolbar
         actions={mockActions.toolbar}
@@ -318,7 +318,7 @@ describe('Table', () => {
     expect(mockActions.toolbar.onToggleFilter).toHaveBeenCalledTimes(1);
   });
 
-  test('toolbar search should render with default value', () => {
+  it('toolbar search should render with default value', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -354,7 +354,7 @@ describe('Table', () => {
     expect(wrapper.find('.bx--search-input').html()).toContain(`aria-hidden="true"`);
   });
 
-  test('cells should always wrap by default', () => {
+  it('cells should always wrap by default', () => {
     const wrapper = mount(
       <Table columns={tableColumns} data={[tableData[0]]} options={{ hasResize: true }} />
     );
@@ -376,7 +376,7 @@ describe('Table', () => {
     expect(wrapper3.find(TableHead).prop('options').wrapCellText).toEqual('always');
   });
 
-  test('cells should truncate with wrapCellText:auto if resize or fixed col widths', () => {
+  it('cells should truncate with wrapCellText:auto if resize or fixed col widths', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -398,7 +398,7 @@ describe('Table', () => {
     expect(wrapper2.find(TableHead).prop('options').truncateCellText).toBeTruthy();
   });
 
-  test('cells should wrap (not truncate) with wrapCellText:auto if no resize nor fixed col widths', () => {
+  it('cells should wrap (not truncate) with wrapCellText:auto if no resize nor fixed col widths', () => {
     const wrapper3 = mount(
       <Table
         columns={tableColumns}
@@ -412,7 +412,7 @@ describe('Table', () => {
     expect(wrapper3.find(TableHead).prop('options').wrapCellText).toEqual('auto');
   });
 
-  test('cells should wrap (not truncate) for wrapCellText:auto + resize + table-layout:auto', () => {
+  it('cells should wrap (not truncate) for wrapCellText:auto + resize + table-layout:auto', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}
@@ -426,7 +426,7 @@ describe('Table', () => {
     expect(wrapper.find(TableHead).prop('options').truncateCellText).toBeFalsy();
   });
 
-  test('cells should always wrap when wrapCellText is always', () => {
+  it('cells should always wrap when wrapCellText is always', () => {
     const wrapper = mount(
       <Table
         columns={tableColumns}

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
@@ -18,7 +18,7 @@ describe('RowActionsCell', () => {
   beforeEach(() => {
     mockApplyRowAction.mockClear();
   });
-  test('click handler', () => {
+  it('click handler', () => {
     const actions = [{ id: 'addAction', renderIcon: Add32, iconDescription: 'See more' }];
     const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
     const button = wrapper.find('.bx--btn');
@@ -27,7 +27,7 @@ describe('RowActionsCell', () => {
     button.at(0).simulate('click');
     expect(mockApplyRowAction).toHaveBeenCalledTimes(1);
   });
-  test('custom SVG in button', () => {
+  it('custom SVG in button', () => {
     const actions = [
       { id: 'addAction', renderIcon: () => <svg title="my svg" />, iconDescription: 'See more' },
     ];
@@ -39,7 +39,7 @@ describe('RowActionsCell', () => {
     expect(mockApplyRowAction).toHaveBeenCalledTimes(1);
   });
 
-  test('overflow menu trigger has ID', () => {
+  it('overflow menu trigger has ID', () => {
     const actions = [
       { id: 'add', renderIcon: Add32, iconDescription: 'See more' },
       { id: 'edit', renderIcon: Edit16, isOverflow: true, labelText: 'Edit' },
@@ -50,7 +50,7 @@ describe('RowActionsCell', () => {
     expect(button).toHaveLength(1);
   });
 
-  test('actions are wrapped in special gradient background container', () => {
+  it('actions are wrapped in special gradient background container', () => {
     const action = {
       id: 'addAction',
       renderIcon: Add32,
@@ -67,7 +67,7 @@ describe('RowActionsCell', () => {
     expect(button.text()).toEqual(action.labelText);
   });
 
-  test('action container background knows when overflow menu is open (in order to stay visible)', () => {
+  it('action container background knows when overflow menu is open (in order to stay visible)', () => {
     const actions = [{ id: 'edit', renderIcon: Edit16, isOverflow: true, labelText: 'Edit' }];
     const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
 

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.test.jsx
@@ -19,7 +19,7 @@ const tableRowProps = {
 };
 
 describe('TableBodyRow', () => {
-  test('shouldExpandOnRowClick', () => {
+  it('shouldExpandOnRowClick', () => {
     // Should expand
     const tableRowExpandByDefault = mount(
       <TableBodyRow
@@ -59,7 +59,7 @@ describe('TableBodyRow', () => {
     expect(mockActions.onRowClicked).toHaveBeenCalled();
     expect(mockActions.onRowExpanded).not.toHaveBeenCalled();
   });
-  test('verify rendering with undefined column', () => {
+  it('verify rendering with undefined column', () => {
     const tableRowPropsWithUndefined = {
       tableId: 'tableId',
       totalColumns: 1,
@@ -73,7 +73,7 @@ describe('TableBodyRow', () => {
     );
     expect(wrapper).toBeDefined();
   });
-  test('verify custom cell renderer', () => {
+  it('verify custom cell renderer', () => {
     const customRenderDataFunction = ({ value, columnId, rowId, row }) => (
       <div id={value}>
         {value} {columnId} {rowId} {JSON.stringify(row)}
@@ -104,7 +104,7 @@ describe('TableBodyRow', () => {
     expect(customCell.text()).toContain('value2');
   });
 
-  test('hasRowMultiSelect', () => {
+  it('hasRowMultiSelect', () => {
     const mockRowSelection = jest.fn();
     const mockRowClicked = jest.fn();
     const tableRowPropsWithSelection = {
@@ -124,7 +124,7 @@ describe('TableBodyRow', () => {
     expect(mockRowSelection).toHaveBeenCalled();
   });
 
-  test('hasRowSingleSelection', () => {
+  it('hasRowSingleSelection', () => {
     const tableBodyRow = mount(
       <TableBodyRow
         options={{ hasRowSelection: 'single' }}

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
@@ -34,7 +34,7 @@ describe('TableCellRenderer', () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalScrollWidth);
   });
 
-  test('truncates only for truncateCellText={true}', () => {
+  it('truncates only for truncateCellText={true}', () => {
     const wrapper = mount(
       <TableCellRenderer wrapText="never" truncateCellText>
         {cellText}
@@ -50,7 +50,7 @@ describe('TableCellRenderer', () => {
     expect(wrapper2.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(0);
   });
 
-  test('does not truncat when wrapText={always}', () => {
+  it('does not truncat when wrapText={always}', () => {
     const wrapper = mount(
       <TableCellRenderer wrapText="always" truncateCellText>
         {cellText}
@@ -59,7 +59,7 @@ describe('TableCellRenderer', () => {
     expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(0);
   });
 
-  test('does not allow wrap when wrapText={never}', () => {
+  it('does not allow wrap when wrapText={never}', () => {
     const wrapper = mount(
       <TableCellRenderer wrapText="never" truncateCellText={false}>
         {cellText}
@@ -68,7 +68,7 @@ describe('TableCellRenderer', () => {
     expect(wrapper.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(1);
   });
 
-  test('allows wrap when wrapText={always}', () => {
+  it('allows wrap when wrapText={always}', () => {
     const wrapper = mount(
       <TableCellRenderer wrapText="always" truncateCellText={false}>
         {cellText}
@@ -77,7 +77,7 @@ describe('TableCellRenderer', () => {
     expect(wrapper.find(`.${iotPrefix}--table__cell-text--no-wrap`)).toHaveLength(0);
   });
 
-  test('only truncates children that are strings, numbers or booleans', () => {
+  it('only truncates children that are strings, numbers or booleans', () => {
     const wrapper = mount(
       <table>
         <tbody>
@@ -109,7 +109,7 @@ describe('TableCellRenderer', () => {
     expect(wrapper.find(`.${iotPrefix}--table__cell-text--truncate`)).toHaveLength(3);
   });
 
-  test('only shows tooltip if text is actually truncated', () => {
+  it('only shows tooltip if text is actually truncated', () => {
     setOffsetWidth(10);
     setScrollWidth(20);
 
@@ -137,7 +137,7 @@ describe('TableCellRenderer', () => {
     setScrollWidth(0);
   });
 
-  test('does not show tooltip with allowTooltip={false}', () => {
+  it('does not show tooltip with allowTooltip={false}', () => {
     setOffsetWidth(10);
     setScrollWidth(20);
 
@@ -155,7 +155,7 @@ describe('TableCellRenderer', () => {
     setScrollWidth(0);
   });
 
-  test('locale formats numbers', () => {
+  it('locale formats numbers', () => {
     const wrapper = mount(<TableCellRenderer locale="fr">{35.6}</TableCellRenderer>);
     expect(wrapper.text()).toContain('35,6'); // french locale should have commas for decimals
 

--- a/src/components/Table/TableDetailWizard/StatefulTableDetailWizard.test.jsx
+++ b/src/components/Table/TableDetailWizard/StatefulTableDetailWizard.test.jsx
@@ -13,7 +13,7 @@ const commonWizardProps = {
 };
 
 describe('StatefulWizardInline', () => {
-  test('onNext', () => {
+  it('onNext', () => {
     const mockNext = jest.fn();
     const wrapper = mount(<StatefulTableDetailWizard {...commonWizardProps} onNext={mockNext} />);
     const cancelAndNextButtons = wrapper.find('.bx--btn');
@@ -21,7 +21,7 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(2).simulate('click');
     expect(mockNext).toHaveBeenCalled();
   });
-  test('setItem', () => {
+  it('setItem', () => {
     const mockSetItem = jest.fn();
     const wrapper = mount(
       <StatefulTableDetailWizard {...commonWizardProps} setItem={mockSetItem} />
@@ -31,14 +31,14 @@ describe('StatefulWizardInline', () => {
     progressIndicatorButtons.at(1).simulate('click');
     expect(mockSetItem).toHaveBeenCalled();
   });
-  test('error', () => {
+  it('error', () => {
     const wrapper = mount(
       <StatefulTableDetailWizard {...commonWizardProps} error="I'm in error" />
     );
     const progressIndicatorButtons = wrapper.find('InlineNotification');
     expect(progressIndicatorButtons).toHaveLength(1);
   });
-  test('error clear error', () => {
+  it('error clear error', () => {
     const mockClearError = jest.fn();
     const wrapper = mount(
       <StatefulTableDetailWizard
@@ -52,7 +52,7 @@ describe('StatefulWizardInline', () => {
     clearErrorButton.simulate('click');
     expect(mockClearError).toHaveBeenCalled();
   });
-  test('setItem not triggered if invalid', () => {
+  it('setItem not triggered if invalid', () => {
     const mockSetItem = jest.fn();
     const wrapper = mount(
       <StatefulTableDetailWizard
@@ -70,7 +70,7 @@ describe('StatefulWizardInline', () => {
     progressIndicatorButtons.at(1).simulate('click');
     expect(mockSetItem).not.toHaveBeenCalled();
   });
-  test('onNext not triggered if invalid', () => {
+  it('onNext not triggered if invalid', () => {
     const mockNext = jest.fn();
     const wrapper = mount(
       <StatefulTableDetailWizard
@@ -88,7 +88,7 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(2).simulate('click');
     expect(mockNext).not.toHaveBeenCalled();
   });
-  test('onClose', () => {
+  it('onClose', () => {
     const mockClose = jest.fn();
     const wrapper = mount(<StatefulTableDetailWizard {...commonWizardProps} onClose={mockClose} />);
     const cancelAndNextButtons = wrapper.find('.bx--btn');
@@ -96,7 +96,7 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(1).simulate('click');
     expect(mockClose).toHaveBeenCalled();
   });
-  test('onClose Top', () => {
+  it('onClose Top', () => {
     const mockClose = jest.fn();
     const wrapper = mount(<StatefulTableDetailWizard {...commonWizardProps} onClose={mockClose} />);
     const cancelAndNextButtons = wrapper.find('.bx--btn');
@@ -104,7 +104,7 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(0).simulate('click');
     expect(mockClose).toHaveBeenCalled();
   });
-  test('onBack', () => {
+  it('onBack', () => {
     const mockBack = jest.fn();
     const wrapper = mount(
       <StatefulTableDetailWizard
@@ -118,12 +118,12 @@ describe('StatefulWizardInline', () => {
     backAndNextButtons.at(1).simulate('click');
     expect(mockBack).toHaveBeenCalled();
   });
-  test('Handle currentItemId empty', () => {
+  it('Handle currentItemId empty', () => {
     const wrapper = mount(<StatefulTableDetailWizard {...commonWizardProps} currentItemId="" />);
     const element = wrapper.find('ProgressIndicator__StyledProgressIndicator');
     expect(element.prop('currentIndex')).toEqual(0);
   });
-  test('onNext not triggered if nextItem is undefined', () => {
+  it('onNext not triggered if nextItem is undefined', () => {
     const mockNext = jest.fn();
     const wrapper = mount(
       <StatefulTableDetailWizard

--- a/src/components/Table/TableDetailWizard/TableDetailWizard.test.jsx
+++ b/src/components/Table/TableDetailWizard/TableDetailWizard.test.jsx
@@ -5,7 +5,7 @@ import TableDetailWizard from './TableDetailWizard';
 import { itemsAndComponents } from './TableDetailWizard.story';
 
 describe('TableDetailWizard tests', () => {
-  test('Error dialog', () => {
+  it('Error dialog', () => {
     const onClearError = jest.fn();
     const errorString = 'There is an error';
 
@@ -23,7 +23,7 @@ describe('TableDetailWizard tests', () => {
     );
     expect(wrapper.find('NotificationTextDetails').prop('title')).toEqual(errorString);
   });
-  test('Handle Clear error', () => {
+  it('Handle Clear error', () => {
     const onClearError = jest.fn();
     const errorString = 'There is an error';
 
@@ -42,7 +42,7 @@ describe('TableDetailWizard tests', () => {
     wrapper.find('NotificationButton').simulate('click');
     expect(onClearError.mock.calls).toHaveLength(1);
   });
-  test('Handle current item empty', () => {
+  it('Handle current item empty', () => {
     const wrapper = mount(
       <TableDetailWizard
         currentItemId=""

--- a/src/components/Table/TableDetailWizard/TableDetailWizard.test.jsx
+++ b/src/components/Table/TableDetailWizard/TableDetailWizard.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import TableDetailWizard from './TableDetailWizard';
 import { itemsAndComponents } from './TableDetailWizard.story';
 
-describe('TableDetailWizard tests', () => {
+describe('TableDetailWizard', () => {
   it('Error dialog', () => {
     const onClearError = jest.fn();
     const errorString = 'There is an error';

--- a/src/components/Table/TableDetailWizard/TableDetailWizardHeader/TableDetailWizardHeader.test.jsx
+++ b/src/components/Table/TableDetailWizard/TableDetailWizardHeader/TableDetailWizardHeader.test.jsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 import TableDetailWizardHeader from './TableDetailWizardHeader';
 
 describe('TableDetailWizardHeader tests', () => {
-  test('Close Header', () => {
+  it('Close Header', () => {
     const onClose = jest.fn();
 
     const wrapper = mount(

--- a/src/components/Table/TableDetailWizard/TableDetailWizardHeader/TableDetailWizardHeader.test.jsx
+++ b/src/components/Table/TableDetailWizard/TableDetailWizardHeader/TableDetailWizardHeader.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import TableDetailWizardHeader from './TableDetailWizardHeader';
 
-describe('TableDetailWizardHeader tests', () => {
+describe('TableDetailWizardHeader', () => {
   it('Close Header', () => {
     const onClose = jest.fn();
 

--- a/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
@@ -69,7 +69,7 @@ describe('TableHead', () => {
 });
 
 describe('ColumnHeaderRow test', () => {
-  test('when hasRowExpansion set to true', () => {
+  it('when hasRowExpansion set to true', () => {
     const tableHeadProps = {
       ...commonTableHeadProps,
       options: { ...commonTableHeadProps.options, hasRowExpansion: true },
@@ -82,7 +82,7 @@ describe('ColumnHeaderRow test', () => {
     expect(getByText('Column 2').textContent).toContain('Column 2');
   });
 
-  test('when ordering is empty, no columns are displayed', () => {
+  it('when ordering is empty, no columns are displayed', () => {
     const tableHeadProps = {
       ...commonTableHeadProps,
       ordering: [],
@@ -94,7 +94,7 @@ describe('ColumnHeaderRow test', () => {
     expect(renderedElement.container.innerHTML).toContain('colspan="2"');
   });
 
-  test('when hasRowActions set to true', () => {
+  it('when hasRowActions set to true', () => {
     const tableHeadProps = {
       ...commonTableHeadProps,
       options: { ...commonTableHeadProps.options, hasRowActions: true },
@@ -108,7 +108,7 @@ describe('ColumnHeaderRow test', () => {
     expect(renderedElement.container.innerHTML).toContain('colspan="3"');
   });
 
-  test('column selection config renders and fires callback on click', () => {
+  it('column selection config renders and fires callback on click', () => {
     const onColumnSelectionConfig = jest.fn();
     const tableHeadProps = {
       ...commonTableHeadProps,

--- a/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderRow/ColumnHeaderRow.test.jsx
@@ -68,7 +68,7 @@ describe('TableHead', () => {
   });
 });
 
-describe('ColumnHeaderRow test', () => {
+describe('ColumnHeaderRow', () => {
   it('when hasRowExpansion set to true', () => {
     const tableHeadProps = {
       ...commonTableHeadProps,

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.test.jsx
@@ -16,7 +16,7 @@ describe('FilterHeaderRow', () => {
     console.error.mockRestore();
   });
 
-  test('text input change updates state', () => {
+  it('text input change updates state', () => {
     const wrapper = mount(
       <FilterHeaderRow
         {...commonFilterProps}
@@ -28,7 +28,7 @@ describe('FilterHeaderRow', () => {
     expect(wrapper.state()).toEqual({ col1: 'mytext' });
   });
 
-  test('each column is marked with data-column', () => {
+  it('each column is marked with data-column', () => {
     const wrapper = mount(
       <FilterHeaderRow
         {...commonFilterProps}
@@ -40,7 +40,7 @@ describe('FilterHeaderRow', () => {
     expect(columns).toHaveLength(1);
   });
 
-  test('input blur fires apply filter callback', () => {
+  it('input blur fires apply filter callback', () => {
     const wrapper = mount(
       <FilterHeaderRow
         {...commonFilterProps}
@@ -56,7 +56,7 @@ describe('FilterHeaderRow', () => {
     expect(commonFilterProps.onApplyFilter).toHaveBeenCalledWith(desiredState);
   });
 
-  test('text input clear button clears filter', () => {
+  it('text input clear button clears filter', () => {
     const wrapper = mount(
       <FilterHeaderRow
         {...commonFilterProps}
@@ -69,7 +69,7 @@ describe('FilterHeaderRow', () => {
     expect(wrapper.state()).toEqual({ col1: '' });
   });
 
-  test('filter input is hidden when isFilterable is false', () => {
+  it('filter input is hidden when isFilterable is false', () => {
     const wrapper = mount(
       <FilterHeaderRow
         {...commonFilterProps}

--- a/src/components/Table/TableHead/TableHead.test.jsx
+++ b/src/components/Table/TableHead/TableHead.test.jsx
@@ -32,13 +32,13 @@ const commonTableHeadProps = {
 };
 
 describe('TableHead', () => {
-  test('columns should render', () => {
+  it('columns should render', () => {
     const wrapper = mount(<TableHead {...commonTableHeadProps} />);
     const tableHeaders = wrapper.find(TableHeader);
     expect(tableHeaders).toHaveLength(3);
   });
 
-  test('columns should render extra column for multi select', () => {
+  it('columns should render extra column for multi select', () => {
     const myProps = {
       ...commonTableHeadProps,
       options: {
@@ -51,7 +51,7 @@ describe('TableHead', () => {
     expect(tableHeaders).toHaveLength(4);
   });
 
-  test('hasRowActions flag creates empty TableHeader', () => {
+  it('hasRowActions flag creates empty TableHeader', () => {
     const myProps = {
       ...commonTableHeadProps,
       options: {
@@ -68,14 +68,14 @@ describe('TableHead', () => {
     expect(lastTableHeader.find('.bx--table-header-label').getDOMNode().innerHTML).toEqual('');
   });
 
-  test('make sure data-column is set for width', () => {
+  it('make sure data-column is set for width', () => {
     const myProps = { ...commonTableHeadProps };
     const wrapper = mount(<TableHead {...myProps} />);
     const tableHeaders = wrapper.find('th[data-column="col1"]');
     expect(tableHeaders).toHaveLength(1);
   });
 
-  test('activeBar set to "filter" shows FilterHeaderRow', () => {
+  it('activeBar set to "filter" shows FilterHeaderRow', () => {
     const myProps = { ...commonTableHeadProps, tableState: { ...commonTableHeadProps.tableState } };
     myProps.tableState.activeBar = 'filter';
     let wrapper = mount(<TableHead {...myProps} />);
@@ -86,14 +86,14 @@ describe('TableHead', () => {
     expect(wrapper.exists('FilterHeaderRow')).toBeFalsy();
   });
 
-  test('activeBar set to "column" shows ColumnHeaderRow', () => {
+  it('activeBar set to "column" shows ColumnHeaderRow', () => {
     const myProps = { ...commonTableHeadProps, tableState: { ...commonTableHeadProps.tableState } };
     myProps.tableState.activeBar = 'column';
     const wrapper = mount(<TableHead {...myProps} />);
     expect(wrapper.exists('ColumnHeaderRow')).toBeTruthy();
   });
 
-  test('check has resize if has resize is true ', () => {
+  it('check has resize if has resize is true ', () => {
     const myProps = { ...commonTableHeadProps, options: { hasResize: true } };
     const wrapper = mount(<TableHead {...myProps} />);
     const tableHeaders = wrapper.find(`div.${iotPrefix}--column-resize-handle`);
@@ -101,14 +101,14 @@ describe('TableHead', () => {
     expect(tableHeaders).toHaveLength(2);
   });
 
-  test('check not resize if has resize is false ', () => {
+  it('check not resize if has resize is false ', () => {
     const myProps = { ...commonTableHeadProps, options: { hasResize: false } };
     const wrapper = mount(<TableHead {...myProps} />);
     const tableHeaders = wrapper.find('div.column-resize-handle');
     expect(tableHeaders).toHaveLength(0);
   });
 
-  test('check hidden item is not shown ', () => {
+  it('check hidden item is not shown ', () => {
     const myProps = {
       ...commonTableHeadProps,
       tableState: {
@@ -127,7 +127,7 @@ describe('TableHead', () => {
     expect(tableHeaders).toHaveLength(2);
   });
 
-  test('header renders with resizing columns when columns are empty on initial render', () => {
+  it('header renders with resizing columns when columns are empty on initial render', () => {
     const wrapper = mount(
       <TableHead
         columns={[]}
@@ -159,7 +159,7 @@ describe('TableHead', () => {
     expect(tableHeaderResizeHandles).toHaveLength(2);
   });
 
-  test('fixed column widths for non-resizable columns', () => {
+  it('fixed column widths for non-resizable columns', () => {
     const myProps = {
       ...commonTableHeadProps,
       columns: [{ id: 'col1', name: 'Column 1', width: '101' }],
@@ -217,7 +217,7 @@ describe('TableHead', () => {
       Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
     });
 
-    test('toggle hide column correctly updates the column widths of visible columns', () => {
+    it('toggle hide column correctly updates the column widths of visible columns', () => {
       mockGetBoundingClientRect.mockImplementation(() => ({ width: 100 }));
 
       const wrapper = mount(<TableHead {...myProps} />);
@@ -241,7 +241,7 @@ describe('TableHead', () => {
       expect(myActions.onChangeOrdering).toHaveBeenCalledWith(orderingAfterTogleHide);
     });
 
-    test('toggle show column correctly updates the column widths of visible columns', () => {
+    it('toggle show column correctly updates the column widths of visible columns', () => {
       myProps.tableState = {
         ...myProps.tableState,
         ordering: [
@@ -274,7 +274,7 @@ describe('TableHead', () => {
       expect(myActions.onChangeOrdering).toHaveBeenCalledWith(orderingAfterTogleShow);
     });
 
-    test('the last visible column should never have a resize handle', () => {
+    it('the last visible column should never have a resize handle', () => {
       myProps.tableState = {
         ...myProps.tableState,
         ordering: [

--- a/src/components/Table/tableReducer.test.jsx
+++ b/src/components/Table/tableReducer.test.jsx
@@ -24,7 +24,7 @@ import {
 } from './tableActionCreators';
 import { initialState, tableColumns } from './Table.story';
 
-describe('table reducer testcases', () => {
+describe('table reducer', () => {
   it('nothing', () => {
     expect(tableReducer(undefined, { type: 'BOGUS' })).toEqual({});
   });
@@ -65,7 +65,7 @@ describe('table reducer testcases', () => {
       expect(updatedState.view.table.filteredData.length).toBeLessThan(initialState.data.length);
     });
   });
-  describe('pagination tests', () => {
+  describe('pagination', () => {
     it('TABLE_PAGE_CHANGE ', () => {
       const updatedState = tableReducer(initialState, tablePageChange({ page: 3, pageSize: 10 }));
       expect(updatedState.view.pagination.page).toEqual(3);

--- a/src/components/Table/tableReducer.test.jsx
+++ b/src/components/Table/tableReducer.test.jsx
@@ -25,10 +25,10 @@ import {
 import { initialState, tableColumns } from './Table.story';
 
 describe('table reducer testcases', () => {
-  test('nothing', () => {
+  it('nothing', () => {
     expect(tableReducer(undefined, { type: 'BOGUS' })).toEqual({});
   });
-  test('row action tests', () => {
+  it('row action tests', () => {
     const updatedRowActionState = tableReducer(initialState, tableRowActionStart('row-1'));
     const newRowActions = updatedRowActionState.view.table.rowActions;
     expect(newRowActions).toHaveLength(1);
@@ -51,10 +51,10 @@ describe('table reducer testcases', () => {
     expect(newRowActions3).toHaveLength(0);
   });
   describe('filter tests', () => {
-    test('TABLE_FILTER_CLEAR', () => {
+    it('TABLE_FILTER_CLEAR', () => {
       expect(tableReducer(initialState, tableFilterClear()).view.filters).toEqual([]);
     });
-    test('TABLE_FILTER_APPLY filter should filter data', () => {
+    it('TABLE_FILTER_APPLY filter should filter data', () => {
       const updatedState = tableReducer(
         initialState,
         tableFilterApply({ [tableColumns[0].id]: '1' })
@@ -66,21 +66,21 @@ describe('table reducer testcases', () => {
     });
   });
   describe('pagination tests', () => {
-    test('TABLE_PAGE_CHANGE ', () => {
+    it('TABLE_PAGE_CHANGE ', () => {
       const updatedState = tableReducer(initialState, tablePageChange({ page: 3, pageSize: 10 }));
       expect(updatedState.view.pagination.page).toEqual(3);
     });
-    test('TABLE_PAGE_CHANGE with invalid page', () => {
+    it('TABLE_PAGE_CHANGE with invalid page', () => {
       const updatedState = tableReducer(initialState, tablePageChange({ page: 65, pageSize: 10 }));
       expect(updatedState.view.pagination.page).toEqual(1);
     });
   });
   describe('toolbar actions', () => {
-    test('TABLE_TOOLBAR_TOGGLE ', () => {
+    it('TABLE_TOOLBAR_TOGGLE ', () => {
       const updatedState = tableReducer(initialState, tableToolbarToggle('column'));
       expect(updatedState.view.toolbar.activeBar).toEqual('column');
     });
-    test('TABLE_SEARCH_APPLY filter should search data', () => {
+    it('TABLE_SEARCH_APPLY filter should search data', () => {
       const searchString = 'searchString';
       const updatedState = tableReducer(initialState, tableSearchApply(searchString));
       // Apply the search
@@ -89,7 +89,7 @@ describe('table reducer testcases', () => {
     });
   });
   describe('table actions', () => {
-    test('TABLE_ACTION_CANCEL ', () => {
+    it('TABLE_ACTION_CANCEL ', () => {
       const tableWithSelection = tableReducer(initialState, tableRowSelectAll(true));
       // All should be selected
       expect(tableWithSelection.view.table.selectedIds.length).toEqual(initialState.data.length);
@@ -99,7 +99,7 @@ describe('table reducer testcases', () => {
       expect(tableAfterCancel.view.table.isSelectAllSelected).toEqual(false);
       expect(tableAfterCancel.view.table.isSelectAllIndeterminate).toEqual(false);
     });
-    test('TABLE_ACTION_APPLY ', () => {
+    it('TABLE_ACTION_APPLY ', () => {
       // Select everything first
       const tableWithSelection = tableReducer(initialState, tableRowSelectAll(true));
 
@@ -126,7 +126,7 @@ describe('table reducer testcases', () => {
     });
   });
   describe('table column actions', () => {
-    test('TABLE_COLUMN_SORT', () => {
+    it('TABLE_COLUMN_SORT', () => {
       const sortColumnAction = tableColumnSort(tableColumns[0].id);
       // First sort ASC
       expect(initialState.view.table.sort).toBeUndefined();
@@ -154,7 +154,7 @@ describe('table reducer testcases', () => {
         tableSortedNone.view.table.filteredData
       );
     });
-    test('TABLE_COLUMN_SORT custom sort function', () => {
+    it('TABLE_COLUMN_SORT custom sort function', () => {
       const sortColumnAction = tableColumnSort(tableColumns[4].id);
       const mockSortFunction = jest.fn().mockReturnValue(initialState.data);
       // Splice in our custom mock sort function
@@ -166,7 +166,7 @@ describe('table reducer testcases', () => {
       tableReducer(initialState, sortColumnAction);
       expect(mockSortFunction).toHaveBeenCalled();
     });
-    test('TABLE_COLUMN_ORDER', () => {
+    it('TABLE_COLUMN_ORDER', () => {
       expect(initialState.view.table.ordering[0].isHidden).toBe(false);
       // Hide the first column
       const columnHideAction = tableColumnOrder([{ columnId: tableColumns[0].id, isHidden: true }]);
@@ -175,7 +175,7 @@ describe('table reducer testcases', () => {
     });
   });
   describe('Table Row Operations', () => {
-    test('TABLE_ROW_SELECT', () => {
+    it('TABLE_ROW_SELECT', () => {
       expect(initialState.view.table.selectedIds).toEqual([]);
 
       // Negative case where I unselect a row
@@ -205,7 +205,7 @@ describe('table reducer testcases', () => {
       expect(tableWithUnSelectedRow.view.table.isSelectAllSelected).toEqual(false);
       expect(tableWithUnSelectedRow.view.table.isSelectAllIndeterminate).toEqual(false);
     });
-    test('TABLE_ROW_SELECT--SINGLE', () => {
+    it('TABLE_ROW_SELECT--SINGLE', () => {
       // set the table to single select
       const updatedInitialState = {
         ...initialState,
@@ -246,7 +246,7 @@ describe('table reducer testcases', () => {
       expect(tableWithPreviouslySelectedRow.view.table.isSelectAllSelected).toEqual(false);
       expect(tableWithPreviouslySelectedRow.view.table.isSelectAllIndeterminate).toEqual(true);
     });
-    test('TABLE_ROW_SELECT_ALL', () => {
+    it('TABLE_ROW_SELECT_ALL', () => {
       expect(initialState.view.table.selectedIds).toEqual([]);
       // Select all
       const tableWithSelectedAll = tableReducer(initialState, tableRowSelectAll(true));
@@ -261,7 +261,7 @@ describe('table reducer testcases', () => {
       expect(tableWithUnSelectedAll.view.table.isSelectAllIndeterminate).toEqual(false);
       expect(tableWithUnSelectedAll.view.table.isSelectAllSelected).toEqual(false);
     });
-    test('TABLE_ROW_EXPAND', () => {
+    it('TABLE_ROW_EXPAND', () => {
       expect(initialState.view.table.expandedIds).toEqual([]);
       // Expanded row
       const tableWithExpandedRow = tableReducer(initialState, tableRowExpand('row-1', true));
@@ -270,7 +270,7 @@ describe('table reducer testcases', () => {
       const tableWithCollapsedRow = tableReducer(initialState, tableRowExpand('row-1', false));
       expect(tableWithCollapsedRow.view.table.expandedIds).toEqual([]);
     });
-    test('REGISTER_TABLE', () => {
+    it('REGISTER_TABLE', () => {
       // Data should be filtered once table registers
       expect(initialState.view.table.filteredData).toBeUndefined();
       const tableWithFilteredData = tableReducer(
@@ -316,7 +316,7 @@ describe('table reducer testcases', () => {
 });
 
 describe('filter, search and sort', () => {
-  test('filterData', () => {
+  it('filterData', () => {
     const mockData = [{ values: { number: 10, node: <Add20 />, string: 'string', null: null } }];
     const stringFilter = { columnId: 'string', value: 'String' };
     const numberFilter = { columnId: 'number', value: 10 };
@@ -326,7 +326,7 @@ describe('filter, search and sort', () => {
     expect(filterData(mockData, [numberFilter])).toHaveLength(1);
   });
 
-  test('filterData with custom comparison', () => {
+  it('filterData with custom comparison', () => {
     const mockData = [{ values: { number: 10, node: <Add20 />, string: 'string', null: null } }];
     const stringFilter = { columnId: 'string', value: 'String' };
     const numberFilter = { columnId: 'number', value: 10 };
@@ -358,7 +358,7 @@ describe('filter, search and sort', () => {
     ).toHaveLength(1);
   });
 
-  test('searchData', () => {
+  it('searchData', () => {
     const mockData = [{ values: { number: 10, node: <Add20 />, string: 'string', null: null } }];
     expect(searchData(mockData, 10)).toHaveLength(1);
     expect(searchData(mockData, 'string')).toHaveLength(1);
@@ -366,7 +366,7 @@ describe('filter, search and sort', () => {
     expect(searchData(mockData, 'STRING')).toHaveLength(1);
   });
 
-  test('filterSearchAndSort', () => {
+  it('filterSearchAndSort', () => {
     const mockData = [{ values: { number: 10, node: <Add20 />, string: 'string', null: null } }];
     expect(filterSearchAndSort(mockData)).toHaveLength(1);
     expect(filterSearchAndSort(mockData, {}, { value: 10 })).toHaveLength(1);
@@ -378,7 +378,7 @@ describe('filter, search and sort', () => {
       filterSearchAndSort(mockData, {}, {}, [{ columnId: 'string', value: 'none' }])
     ).toHaveLength(0);
   });
-  test('filterSearchAndSort with custom sort function', () => {
+  it('filterSearchAndSort with custom sort function', () => {
     const mockData = [
       { values: { number: 10, node: <Add20 />, severity: 'High', null: null } },
       { values: { number: 10, node: <Add20 />, severity: 'Low', null: null } },

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -15,7 +15,7 @@ describe('TableCard', () => {
     { comparison: '>', dataSourceId: 'airflow_max', severity: 3, value: 4 },
     { comparison: '>', dataSourceId: 'airflow_max', severity: 1, value: 4.5 },
   ];
-  test('findMatchingThresholds', () => {
+  it('findMatchingThresholds', () => {
     const oneMatchingThreshold = findMatchingThresholds(
       thresholds,
       { airflow_mean: 4 },
@@ -25,7 +25,7 @@ describe('TableCard', () => {
     // The highest severity should match
     expect(oneMatchingThreshold[0].severity).toEqual(1);
   });
-  test('findMatchingThresholds multiple columns', () => {
+  it('findMatchingThresholds multiple columns', () => {
     const twoMatchingThresholds = findMatchingThresholds(thresholds, {
       airflow_mean: 4,
       airflow_max: 5,
@@ -37,7 +37,7 @@ describe('TableCard', () => {
     expect(twoMatchingThresholds[1].severity).toEqual(1);
     expect(twoMatchingThresholds[1].dataSourceId).toEqual('airflow_max');
   });
-  test('findMatchingThresholds no column', () => {
+  it('findMatchingThresholds no column', () => {
     const thresholds = [{ comparison: '<', dataSourceId: 'airflow_mean', severity: 1, value: 4.5 }];
     const oneMatchingThreshold = findMatchingThresholds(thresholds, { airflow_mean: 4 });
     expect(oneMatchingThreshold).toHaveLength(1);
@@ -54,7 +54,7 @@ describe('TableCard', () => {
     );
     expect(zeroMatchingThreshold2).toHaveLength(0);
   });
-  test('Clicked row actions', () => {
+  it('Clicked row actions', () => {
     const onCardAction = jest.fn();
 
     const tableDataWithActions = tableData.map(item => {
@@ -83,7 +83,7 @@ describe('TableCard', () => {
       .simulate('click');
     expect(onCardAction.mock.calls).toHaveLength(1);
   });
-  test('Columns displayed XLarge', () => {
+  it('Columns displayed XLarge', () => {
     const wrapper = mount(
       <TableCard
         title="Open Alerts"
@@ -96,7 +96,7 @@ describe('TableCard', () => {
     );
     expect(wrapper.find('TableHeader').length).toBe(tableColumns.length);
   });
-  test('Columns displayed Large', () => {
+  it('Columns displayed Large', () => {
     const wrapper = mount(
       <TableCard
         title="Open Alerts"
@@ -111,7 +111,7 @@ describe('TableCard', () => {
     const totalColumns = tableColumns.filter(item => item.priority === 1 || item.priority === 2);
     expect(wrapper.find('TableHeader').length).toBe(totalColumns.length);
   });
-  test('Columns displayed Large with actions', () => {
+  it('Columns displayed Large with actions', () => {
     const tableDataWithActions = tableData.map(item => {
       return {
         ...item,
@@ -133,7 +133,7 @@ describe('TableCard', () => {
     const totalColumns = tableColumns.filter(item => item.priority === 1 || item.priority === 2);
     expect(wrapper.find('TableHeader').length).toBe(totalColumns.length + 1); // +1 for action column
   });
-  test('Columns should use custom render fuction when present', () => {
+  it('Columns should use custom render fuction when present', () => {
     const mockRenderFunc = jest.fn(() => {
       return <p className="myCustomRenderedCell" />;
     });
@@ -188,7 +188,7 @@ describe('TableCard', () => {
     );
     expect(wrapper2.find('TableCell .myCustomRenderedCell').length).toBe(0);
   });
-  test('threshold columns should render in correct column regardless of order', () => {
+  it('threshold columns should render in correct column regardless of order', () => {
     // The pressure header comes after the count header, but the ordering should not matter when
     // it comes to rendering the threshold columns
     const customThresholds = [
@@ -238,7 +238,7 @@ describe('TableCard', () => {
     expect(queryByTitle('Pressure Severity')).not.toBeInTheDocument();
     expect(getByTitle('Pressure Sev')).toBeInTheDocument();
   });
-  test('threshold columns should render in correct column regardless of quantity', () => {
+  it('threshold columns should render in correct column regardless of quantity', () => {
     // If there are more than 2 thresholds, they should still render to the left of the datasource column
     const customThresholds = [
       {
@@ -302,7 +302,7 @@ describe('TableCard', () => {
     const { getByText: getByTextPressure } = within(tableHeader[pressureSeverityIndex]);
     expect(getByTextPressure('Pressure Severity')).toBeTruthy();
   });
-  test('threshold icon labels should not display when showSeverityLabel is false', () => {
+  it('threshold icon labels should not display when showSeverityLabel is false', () => {
     const customThresholds = [
       {
         dataSourceId: 'pressure',
@@ -350,7 +350,7 @@ describe('TableCard', () => {
     expect(queryByText(/Moderate/g)).not.toBeInTheDocument();
     expect(queryByText(/Low/g)).not.toBeInTheDocument();
   });
-  test('threshold icon label should not display default strings', () => {
+  it('threshold icon label should not display default strings', () => {
     const customThresholds = [
       {
         dataSourceId: 'pressure',

--- a/src/components/TileCatalog/StatefulTileCatalog.test.jsx
+++ b/src/components/TileCatalog/StatefulTileCatalog.test.jsx
@@ -20,7 +20,7 @@ const commonTileProps = {
 };
 
 describe('StatefulTileCatalog', () => {
-  test('handles Search', () => {
+  it('handles Search', () => {
     const mockSearch = jest.fn();
     const value = 'My Search String';
     const wrapper = mount(
@@ -34,7 +34,7 @@ describe('StatefulTileCatalog', () => {
     expect(mockSearch).toHaveBeenCalledTimes(1);
     expect(mockSearch).toHaveBeenCalledWith(value);
   });
-  test('handles Clicking on option', () => {
+  it('handles Clicking on option', () => {
     const wrapper = mount(<StatefulTileCatalog {...commonTileProps} />);
     // Need to use at to get a new ReactWrapper
     const tileInput = wrapper.find('input[type="radio"]').at(0);
@@ -43,7 +43,7 @@ describe('StatefulTileCatalog', () => {
     expect(mockOnSelection).toHaveBeenCalledTimes(1);
     expect(mockOnSelection).toHaveBeenCalledWith('test1');
   });
-  test('handles onPage', () => {
+  it('handles onPage', () => {
     const wrapper = mount(
       <StatefulTileCatalog {...commonTileProps} pagination={{ pageSize: 5 }} />
     );
@@ -54,14 +54,14 @@ describe('StatefulTileCatalog', () => {
     // Should be 2 tile choices on the last page
     expect(wrapper.find('input[type="radio"]')).toHaveLength(2);
   });
-  test('selectedTileId', () => {
+  it('selectedTileId', () => {
     const wrapper = mount(<StatefulTileCatalog {...commonTileProps} selectedTileId="test2" />);
     wrapper.update();
     const selectedTile = wrapper.find('input[checked=true]');
     expect(selectedTile).toHaveLength(1);
     expect(selectedTile.prop('id')).toEqual('test2');
   });
-  test('selectedTileId should change page', () => {
+  it('selectedTileId should change page', () => {
     const wrapper = mount(
       <StatefulTileCatalog
         {...commonTileProps}
@@ -73,7 +73,7 @@ describe('StatefulTileCatalog', () => {
     expect(wrapper.text()).toContain('Page 2');
   });
 
-  test('tiles prop change resets page', () => {
+  it('tiles prop change resets page', () => {
     const wrapper = mount(
       <StatefulTileCatalog {...commonTileProps} pagination={{ pageSize: 5 }} />
     );
@@ -112,7 +112,7 @@ describe('StatefulTileCatalog', () => {
     ).toEqual(true);
   });
 
-  test('tiles prop change should not select if isSelectedByDefault false', () => {
+  it('tiles prop change should not select if isSelectedByDefault false', () => {
     const wrapper = mount(
       <StatefulTileCatalog
         {...commonTileProps}

--- a/src/components/TileCatalog/TileCatalog.test.jsx
+++ b/src/components/TileCatalog/TileCatalog.test.jsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import TileCatalog from './TileCatalog';
 import { commonTileCatalogProps } from './TileCatalog.story';
 
-describe('TileCatalog tests', () => {
+describe('TileCatalog', () => {
   it('error prop', () => {
     // If we have data, never show the error state
     const wrapper = shallow(<TileCatalog {...commonTileCatalogProps} error="In error state" />);

--- a/src/components/TileCatalog/TileCatalog.test.jsx
+++ b/src/components/TileCatalog/TileCatalog.test.jsx
@@ -5,7 +5,7 @@ import TileCatalog from './TileCatalog';
 import { commonTileCatalogProps } from './TileCatalog.story';
 
 describe('TileCatalog tests', () => {
-  test('error prop', () => {
+  it('error prop', () => {
     // If we have data, never show the error state
     const wrapper = shallow(<TileCatalog {...commonTileCatalogProps} error="In error state" />);
     expect(wrapper.find('.iot--tile-catalog--empty-tile')).toHaveLength(0);

--- a/src/components/TileCatalog/tileCatalogReducer.test.js
+++ b/src/components/TileCatalog/tileCatalogReducer.test.js
@@ -45,7 +45,7 @@ const tiles = [
 ];
 
 describe('tileCatalogReducer', () => {
-  test('pageChange', () => {
+  it('pageChange', () => {
     const pageChangeAction = { type: TILE_ACTIONS.PAGE_CHANGE, payload: 2 };
     const existingState = {
       page: 1,
@@ -65,7 +65,7 @@ describe('tileCatalogReducer', () => {
     expect(newState.startingIndex).toEqual(5);
     expect(newState.endingIndex).toEqual(9);
   });
-  test('search', () => {
+  it('search', () => {
     const searchAction = { type: TILE_ACTIONS.SEARCH, payload: 'Tile6' };
     const existingState = {
       page: 2,
@@ -87,7 +87,7 @@ describe('tileCatalogReducer', () => {
     expect(newState.startingIndex).toEqual(0);
     expect(newState.endingIndex).toEqual(4);
   });
-  test('select', () => {
+  it('select', () => {
     const selectAction = { type: TILE_ACTIONS.SELECT, payload: 'test2' };
     const existingState = {
       page: 1,
@@ -113,7 +113,7 @@ describe('tileCatalogReducer', () => {
   });
 });
 describe('determineInitialState', () => {
-  test('defaults', () => {
+  it('defaults', () => {
     const initialState = determineInitialState({ tiles });
     expect(initialState.pageSize).toEqual(10);
     expect(initialState.page).toEqual(1);
@@ -121,7 +121,7 @@ describe('determineInitialState', () => {
     expect(initialState.endingIndex).toEqual(9);
     expect(initialState.selectedTileId).toEqual(tiles[0].id);
   });
-  test('setting from pagination', () => {
+  it('setting from pagination', () => {
     const initialState = determineInitialState({ tiles, pagination: { pageSize: 5, page: 2 } });
     expect(initialState.pageSize).toEqual(5);
     expect(initialState.page).toEqual(2);
@@ -129,7 +129,7 @@ describe('determineInitialState', () => {
     expect(initialState.endingIndex).toEqual(9);
     expect(initialState.selectedTileId).toEqual(tiles[5].id);
   });
-  test('setting search', () => {
+  it('setting search', () => {
     const initialState = determineInitialState({ tiles, search: { value: 'Tile6' } });
     expect(initialState.filteredTiles).toHaveLength(1);
     expect(initialState.endingIndex).toEqual(9);

--- a/src/components/TileCatalogNew/TileCatalogNew.test.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.test.jsx
@@ -17,7 +17,7 @@ const getTiles = num => {
   return tiles;
 };
 
-describe('TileCatalogNew tests', () => {
+describe('TileCatalogNew', () => {
   it('TileCatalogNew gets rendered', () => {
     const { getByText } = render(
       <TileCatalogNew

--- a/src/components/TileCatalogNew/TileCatalogNew.test.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.test.jsx
@@ -18,7 +18,7 @@ const getTiles = num => {
 };
 
 describe('TileCatalogNew tests', () => {
-  test('TileCatalogNew gets rendered', () => {
+  it('TileCatalogNew gets rendered', () => {
     const { getByText } = render(
       <TileCatalogNew
         tiles={getTiles(2, 'Tile')}
@@ -31,7 +31,7 @@ describe('TileCatalogNew tests', () => {
     expect(getByText('Tile 2')).toBeTruthy();
   });
 
-  test('TileCatalogNew placeholder tile are rendered', () => {
+  it('TileCatalogNew placeholder tile are rendered', () => {
     const { getByText } = render(
       <TileCatalogNew
         tiles={getTiles(6, 'Tile')}
@@ -44,14 +44,14 @@ describe('TileCatalogNew tests', () => {
     expect(getByText('Tile 2')).toBeTruthy();
   });
 
-  test('TileCatalogNew to have default call back function ', () => {
+  it('TileCatalogNew to have default call back function ', () => {
     expect(TileCatalogNew.defaultProps.onSearch).toBeDefined();
     expect(TileCatalogNew.defaultProps.onSort).toBeDefined();
     TileCatalogNew.defaultProps.onSearch();
     TileCatalogNew.defaultProps.onSort();
   });
 
-  test('TileCatalogNew hasSearch set to true', () => {
+  it('TileCatalogNew hasSearch set to true', () => {
     const onSearch = jest.fn();
     const { getByPlaceholderText } = render(
       <TileCatalogNew
@@ -66,7 +66,7 @@ describe('TileCatalogNew tests', () => {
     expect(onSearch).toHaveBeenCalledTimes(1);
   });
 
-  test('TileCatalogNew hasSort set to true', () => {
+  it('TileCatalogNew hasSort set to true', () => {
     const sortOptions = [
       { text: 'Choose from options', id: 'Choose from options' },
       { text: 'A-Z', id: 'A-Z' },
@@ -89,7 +89,7 @@ describe('TileCatalogNew tests', () => {
     expect(onSort).toHaveBeenCalledTimes(1);
   });
 
-  test('TileCatalogNew pagination next button', () => {
+  it('TileCatalogNew pagination next button', () => {
     const { getByText, getAllByRole } = render(
       <TileCatalogNew
         title="Test Tile Catalog"
@@ -107,7 +107,7 @@ describe('TileCatalogNew tests', () => {
     expect(getByText('Tile 8')).toBeTruthy();
   });
 
-  test('TileCatalogNew pagination previous button', () => {
+  it('TileCatalogNew pagination previous button', () => {
     const { getByText, getAllByRole } = render(
       <TileCatalogNew
         title="Test Tile Catalog"
@@ -125,7 +125,7 @@ describe('TileCatalogNew tests', () => {
     expect(getByText('Tile 4')).toBeTruthy();
   });
 
-  test('TileCatalogNew pagination number button', () => {
+  it('TileCatalogNew pagination number button', () => {
     const { getByText, getAllByRole } = render(
       <TileCatalogNew
         title="Test Tile Catalog"
@@ -143,7 +143,7 @@ describe('TileCatalogNew tests', () => {
     expect(getByText('Tile 16')).toBeTruthy();
   });
 
-  test('TileCatalogNew with large page numbers', () => {
+  it('TileCatalogNew with large page numbers', () => {
     const { getByText, getByLabelText } = render(
       <TileCatalogNew
         title="Test Tile Catalog"
@@ -159,7 +159,7 @@ describe('TileCatalogNew tests', () => {
     expect(getByText('Tile 56')).toBeTruthy();
   });
 
-  test('TileCatalogNew with large page numbers and mid page number was selected', () => {
+  it('TileCatalogNew with large page numbers and mid page number was selected', () => {
     const { getByText, getByLabelText } = render(
       <TileCatalogNew
         title="Test Tile Catalog"

--- a/src/components/TileGallery/TileGallery.test.jsx
+++ b/src/components/TileGallery/TileGallery.test.jsx
@@ -9,7 +9,7 @@ import TileGalleryViewSwitcher from './TileGalleryViewSwitcher';
 import TileGallery from './TileGallery';
 import StatefulTileGallery from './StatefulTileGallery';
 
-describe('TileGallery tests', () => {
+describe('TileGallery', () => {
   it('TileGalleryItem mode list', () => {
     const wrapper = mount(<TileGalleryItem title="title" mode="list" />);
 

--- a/src/components/TileGallery/TileGallery.test.jsx
+++ b/src/components/TileGallery/TileGallery.test.jsx
@@ -10,7 +10,7 @@ import TileGallery from './TileGallery';
 import StatefulTileGallery from './StatefulTileGallery';
 
 describe('TileGallery tests', () => {
-  test('TileGalleryItem mode list', () => {
+  it('TileGalleryItem mode list', () => {
     const wrapper = mount(<TileGalleryItem title="title" mode="list" />);
 
     expect(
@@ -20,7 +20,7 @@ describe('TileGallery tests', () => {
         .hasClass('tile-list-title')
     ).toEqual(true);
   });
-  test('TileGalleryItem mode list with node description', () => {
+  it('TileGalleryItem mode list with node description', () => {
     const descriptionNode = <div>Test node</div>;
     const wrapper = mount(
       <TileGalleryItem title="title" mode="list" description={descriptionNode} />
@@ -28,7 +28,7 @@ describe('TileGallery tests', () => {
 
     expect(wrapper.find('div.description-card').contains(descriptionNode)).toEqual(true);
   });
-  test('TileGalleryItem mode card', () => {
+  it('TileGalleryItem mode card', () => {
     const wrapper = mount(<TileGalleryItem title="title" mode="grid" />);
 
     expect(
@@ -38,7 +38,7 @@ describe('TileGallery tests', () => {
         .hasClass('tile-card-title')
     ).toEqual(true);
   });
-  test('TileGalleryItem mode card with node description', () => {
+  it('TileGalleryItem mode card with node description', () => {
     const descriptionNode = <div>Test node</div>;
 
     const wrapper = mount(
@@ -47,7 +47,7 @@ describe('TileGallery tests', () => {
 
     expect(wrapper.find('div.description-card').contains(descriptionNode)).toEqual(true);
   });
-  test('TileGalleryItem afterContent', () => {
+  it('TileGalleryItem afterContent', () => {
     const wrapper = shallow(
       <TileGalleryItem title="title" afterContent={<div>after content</div>} />
     );
@@ -59,11 +59,11 @@ describe('TileGallery tests', () => {
 
     expect(wrapper.find('div.overflow-menu')).toHaveLength(1);
   });
-  test('TileGalleryItem - have default onClick', () => {
+  it('TileGalleryItem - have default onClick', () => {
     expect(TileGalleryItem.defaultProps.onClick).toBeDefined();
     expect(TileGalleryItem.defaultProps.onClick()).toBe(undefined);
   });
-  test('TileGalleryItem - simulate onClick', () => {
+  it('TileGalleryItem - simulate onClick', () => {
     const onClick = jest.fn();
 
     const wrapper = mount(<TileGalleryItem title="title" mode="grid" onClick={onClick} />);
@@ -72,11 +72,11 @@ describe('TileGallery tests', () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
-  test('TileGallerySection - have default onClick', () => {
+  it('TileGallerySection - have default onClick', () => {
     expect(TileGallerySection.defaultProps.onClick).toBeDefined();
     expect(TileGallerySection.defaultProps.onClick()).toBe(undefined);
   });
-  test('TileGallerySection', () => {
+  it('TileGallerySection', () => {
     const onClick = jest.fn();
 
     const wrapper = mount(
@@ -94,7 +94,7 @@ describe('TileGallery tests', () => {
     expect(wrapper.find('AccordionItem').props().open).toEqual(false);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
-  test('TileGallerySection - no accordion', () => {
+  it('TileGallerySection - no accordion', () => {
     const wrapper = mount(
       <TileGallerySection>
         <TileGalleryItem title="title" />
@@ -103,11 +103,11 @@ describe('TileGallery tests', () => {
 
     expect(wrapper.find('Accordion')).toHaveLength(0);
   });
-  test('TileGallerySearch - have default onChange', () => {
+  it('TileGallerySearch - have default onChange', () => {
     expect(TileGallerySearch.defaultProps.onChange).toBeDefined();
     expect(TileGallerySearch.defaultProps.onChange()).toBe(undefined);
   });
-  test('TileGallerySearch - simulate search', () => {
+  it('TileGallerySearch - simulate search', () => {
     const onChange = jest.fn();
 
     const wrapper = mount(<TileGallerySearch onChange={onChange} />);
@@ -116,11 +116,11 @@ describe('TileGallery tests', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
   });
-  test('TileGalleryViewSwitcher - have default onChange', () => {
+  it('TileGalleryViewSwitcher - have default onChange', () => {
     expect(TileGalleryViewSwitcher.defaultProps.onChange).toBeDefined();
     expect(TileGalleryViewSwitcher.defaultProps.onChange()).toBe(undefined);
   });
-  test('TileGalleryViewSwitcher - simulate change', () => {
+  it('TileGalleryViewSwitcher - simulate change', () => {
     const onChange = jest.fn();
 
     const wrapper = mount(<TileGalleryViewSwitcher onChange={onChange} />);
@@ -132,7 +132,7 @@ describe('TileGallery tests', () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
   });
-  test('TileGallery', () => {
+  it('TileGallery', () => {
     const wrapper = mount(
       <TileGallery>
         <TileGallerySection>
@@ -143,7 +143,7 @@ describe('TileGallery tests', () => {
 
     expect(wrapper.find('TileGallerySection').props().isOpen).toEqual(true);
   });
-  test('StatefulTileGallery', () => {
+  it('StatefulTileGallery', () => {
     const searchValue = 'description';
 
     const wrapper = mount(

--- a/src/components/TimePickerSpinner/TimePickerSpinner.test.jsx
+++ b/src/components/TimePickerSpinner/TimePickerSpinner.test.jsx
@@ -20,17 +20,17 @@ describe('TimePickerSpinner', () => {
     jest.clearAllTimers();
   });
 
-  test('with spinner', () => {
+  it('with spinner', () => {
     render(<TimePickerSpinner {...timePickerProps} spinner />);
     expect(screen.queryAllByRole('button')).toHaveLength(2);
   });
 
-  test('without spinner', () => {
+  it('without spinner', () => {
     render(<TimePickerSpinner {...timePickerProps} />);
     expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 
-  test('increment/decrement value via buttons', () => {
+  it('increment/decrement value via buttons', () => {
     render(<TimePickerSpinner {...timePickerProps} spinner />);
 
     fireEvent.click(screen.queryByRole('button', { name: /Increment hours/i }));
@@ -44,7 +44,7 @@ describe('TimePickerSpinner', () => {
   // the current or expected behvaior of keyboard interaction in browsers.
   // The following test covers the keyboard interaction at a base level, but
   // needs to be improved by testing keyboard focus/interactions in-browser via cypress or similar.
-  test('increment/decrement value via keyboard', () => {
+  it('increment/decrement value via keyboard', () => {
     render(<TimePickerSpinner {...timePickerProps} spinner />);
 
     screen.getByRole('textbox').focus();
@@ -69,7 +69,7 @@ describe('TimePickerSpinner', () => {
     expect(screen.getByRole('textbox').value).toEqual('00:00');
   });
 
-  test('value is not modified on unrelated keystroke', () => {
+  it('value is not modified on unrelated keystroke', () => {
     render(<TimePickerSpinner {...timePickerProps} spinner />);
 
     screen.getByRole('textbox').focus();
@@ -82,7 +82,7 @@ describe('TimePickerSpinner', () => {
     expect(screen.getByRole('textbox').value).toEqual('');
   });
 
-  test('work with strings', () => {
+  it('work with strings', () => {
     const wrapper = mount(<TimePickerSpinner {...timePickerProps} value="xyz" spinner />);
 
     wrapper.find('input').simulate('blur');
@@ -100,7 +100,7 @@ describe('TimePickerSpinner', () => {
   // The following test covers the keyboard interaction at a base level, but
   // needs to be improved by testing keyboard focus/interactions in-browser
   // via cypress or similar.
-  test('show indicator', () => {
+  it('show indicator', () => {
     const wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
 
     const upButton = wrapper.find('.iot--time-picker__controls--btn.up-icon').first();
@@ -138,19 +138,19 @@ describe('TimePickerSpinner', () => {
     downButton.simulate('blur');
   });
 
-  test('onClick should be called', () => {
+  it('onClick should be called', () => {
     const wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
     wrapper.find('input').simulate('click');
     expect(timePickerProps.onClick).toHaveBeenCalled();
   });
 
-  test('onChange should be called', () => {
+  it('onChange should be called', () => {
     const wrapper = mount(<TimePickerSpinner {...timePickerProps} spinner />);
     wrapper.find('input').simulate('change');
     expect(timePickerProps.onChange).toHaveBeenCalled();
   });
 
-  test('12-hour picker', () => {
+  it('12-hour picker', () => {
     const wrapper = mount(
       <TimePickerSpinner {...timePickerProps} value="12:00" spinner is12hour />
     );
@@ -161,7 +161,7 @@ describe('TimePickerSpinner', () => {
     expect(wrapper.find('input').props().value).toEqual('00:00');
   });
 
-  test('default timeGroup to minutes', () => {
+  it('default timeGroup to minutes', () => {
     const wrapper = mount(
       <TimePickerSpinner
         {...timePickerProps}
@@ -177,7 +177,7 @@ describe('TimePickerSpinner', () => {
     expect(wrapper.find('input').props().value).toEqual('12:01');
   });
 
-  test('flip minutes back to 59 after hitting 0', () => {
+  it('flip minutes back to 59 after hitting 0', () => {
     const wrapper = mount(
       <TimePickerSpinner
         {...timePickerProps}

--- a/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -40,7 +40,7 @@ const timeSeriesCardProps = {
 };
 
 describe('TimeSeriesCard tests', () => {
-  test('does not show line chart when loading', () => {
+  it('does not show line chart when loading', () => {
     let wrapper = mount(
       <TimeSeriesCard {...timeSeriesCardProps} isLoading size={CARD_SIZES.MEDIUM} />
     );
@@ -51,7 +51,7 @@ describe('TimeSeriesCard tests', () => {
     expect(wrapper.find('LineChart')).toHaveLength(1);
     expect(wrapper.find('SkeletonText')).toHaveLength(0);
   });
-  test('does not fail to render if no data is given', () => {
+  it('does not fail to render if no data is given', () => {
     // For whatever reason, these devices do not give back real data so the No data message
     // should render instead of the line graph
     const emptyValues = [{ deviceid: 'robot1' }, { deviceid: 'robot2' }];
@@ -61,7 +61,7 @@ describe('TimeSeriesCard tests', () => {
 
     expect(getByText('No data is available for this time range.')).toBeInTheDocument();
   });
-  test('shows table with data when expanded', () => {
+  it('shows table with data when expanded', () => {
     const wrapper = mount(
       <TimeSeriesCard {...timeSeriesCardProps} isExpanded size={CARD_SIZES.MEDIUMTHIN} />
     );
@@ -69,12 +69,12 @@ describe('TimeSeriesCard tests', () => {
     // Carbon Table should be there
     expect(wrapper.find(Table)).toHaveLength(1);
   });
-  test('shows bar chart when chartLayout is set to bar', () => {
+  it('shows bar chart when chartLayout is set to bar', () => {
     timeSeriesCardProps.content.chartType = TIME_SERIES_TYPES.BAR;
     const wrapper = mount(<TimeSeriesCard {...timeSeriesCardProps} size={CARD_SIZES.MEDIUMWIDE} />);
     expect(wrapper.find('StackedBarChart')).toHaveLength(1);
   });
-  test('determine precision', () => {
+  it('determine precision', () => {
     expect(determinePrecision(CARD_SIZES.LARGE, 700)).toEqual(0);
     expect(determinePrecision(CARD_SIZES.SMALL, 11.45)).toEqual(0);
     expect(determinePrecision(CARD_SIZES.SMALL, 1.45, 1)).toEqual(1);
@@ -108,7 +108,7 @@ describe('TimeSeriesCard tests', () => {
     expect(updatedTooltip).toContain('<ul');
     expect(updatedTooltip).toContain('2017');
   });
-  test('show line chart when only 1 color is set', () => {
+  it('show line chart when only 1 color is set', () => {
     const timeSeriesCardWithOneColorProps = {
       title: 'Temperature',
       id: 'facility-temperature',
@@ -157,7 +157,7 @@ describe('TimeSeriesCard tests', () => {
     const wrapper = mount(<TimeSeriesCard {...timeSeriesCardWithOneColorProps} />);
     expect(wrapper.find('LineChart')).toHaveLength(1);
   });
-  test('formatChartData returns properly formatted data without dataFilter set', () => {
+  it('formatChartData returns properly formatted data without dataFilter set', () => {
     const series = [
       {
         label: 'Amsterdam',
@@ -194,7 +194,7 @@ describe('TimeSeriesCard tests', () => {
       },
     ]);
   });
-  test('formatChartData returns properly formatted data with dataFilter set', () => {
+  it('formatChartData returns properly formatted data with dataFilter set', () => {
     const series = [
       {
         label: 'Amsterdam',
@@ -257,7 +257,7 @@ describe('TimeSeriesCard tests', () => {
       },
     ]);
   });
-  test('formatChartData returns empty array if no data matches dataFilter', () => {
+  it('formatChartData returns empty array if no data matches dataFilter', () => {
     const series = [
       {
         label: 'Amsterdam',
@@ -276,7 +276,7 @@ describe('TimeSeriesCard tests', () => {
       )
     ).toEqual([]);
   });
-  test('formatColors returns correct format if series is array', () => {
+  it('formatColors returns correct format if series is array', () => {
     const series = [
       {
         label: 'Amsterdam',
@@ -295,7 +295,7 @@ describe('TimeSeriesCard tests', () => {
       scale: { Amsterdam: 'blue', 'New York': 'yellow' },
     });
   });
-  test('formatColors returns correct format if series is object', () => {
+  it('formatColors returns correct format if series is object', () => {
     const series = {
       label: 'Amsterdam',
       dataSourceId: 'particles',

--- a/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -39,7 +39,7 @@ const timeSeriesCardProps = {
   onCardAction: () => {},
 };
 
-describe('TimeSeriesCard tests', () => {
+describe('TimeSeriesCard', () => {
   it('does not show line chart when loading', () => {
     let wrapper = mount(
       <TimeSeriesCard {...timeSeriesCardProps} isLoading size={CARD_SIZES.MEDIUM} />

--- a/src/components/TimeSeriesCard/timeSeriesUtils.test.js
+++ b/src/components/TimeSeriesCard/timeSeriesUtils.test.js
@@ -8,7 +8,7 @@ import {
 } from './timeSeriesUtils';
 
 describe('timeSeriesUtils', () => {
-  test('generateSampleValues', () => {
+  it('generateSampleValues', () => {
     const sampleValues = generateSampleValues(
       [{ dataSourceId: 'temperature' }, { dataSourceId: 'pressure' }],
       'timestamp'
@@ -17,7 +17,7 @@ describe('timeSeriesUtils', () => {
     expect(sampleValues[0].temperature).toBeDefined();
     expect(sampleValues[0].pressure).toBeDefined();
   });
-  test('generateSampleValues with data Filters', () => {
+  it('generateSampleValues with data Filters', () => {
     const sampleValues = generateSampleValues(
       [
         { dataSourceId: 'temperature', dataFilter: { severity: 5 } },
@@ -31,7 +31,7 @@ describe('timeSeriesUtils', () => {
     expect(sampleValues[7].temperature).toBeDefined();
     expect(sampleValues[7].severity).toEqual(3);
   });
-  test('generateSampleValues hour', () => {
+  it('generateSampleValues hour', () => {
     const sampleValues = generateSampleValues(
       [{ dataSourceId: 'temperature' }, { dataSourceId: 'pressure' }],
       'timestamp',
@@ -70,7 +70,7 @@ describe('timeSeriesUtils', () => {
     );
     expect(sampleValues5).toHaveLength(7);
   });
-  test('generateTableSampleValues', () => {
+  it('generateTableSampleValues', () => {
     const tableSampleValues = generateTableSampleValues('test', [
       { dataSourceId: 'column1' },
       { dataSourceId: 'column2' },
@@ -83,7 +83,7 @@ describe('timeSeriesUtils', () => {
     expect(tableSampleValues[0].values).toHaveProperty('column2');
     expect(tableSampleValues[0].values).toHaveProperty('column3');
   });
-  test('formatGraphTick', () => {
+  it('formatGraphTick', () => {
     // hour different day
     expect(
       formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'hour', 'en', 1572912000000)
@@ -124,7 +124,7 @@ describe('timeSeriesUtils', () => {
       formatGraphTick(1572933600000, 1, [1, 2, 3, 4, 5, 6], 'month', 'en', 1572933600000)
     ).toEqual('');
   });
-  test('findMatchingAlertRange', () => {
+  it('findMatchingAlertRange', () => {
     const data = {
       date: new Date(1573073951),
     };

--- a/src/components/ValueCard/ValueCard.test.jsx
+++ b/src/components/ValueCard/ValueCard.test.jsx
@@ -10,7 +10,7 @@ import ValueCard from './ValueCard';
 const { iotPrefix } = settings;
 
 describe('ValueCard', () => {
-  test('fail over to vertical layouts when not enough space', () => {
+  it('fail over to vertical layouts when not enough space', () => {
     const wrapper = mount(
       <ValueCard
         content={{ attributes: [{ label: 'title', dataSourceId: 'v' }] }}
@@ -43,7 +43,7 @@ describe('ValueCard', () => {
     ).toEqual(CARD_LAYOUTS.VERTICAL);
   });
 
-  test('DataState prop shows DataState elements instead of content', () => {
+  it('DataState prop shows DataState elements instead of content', () => {
     const wrapperWithoutDataState = mount(
       <ValueCard
         title="Health score"
@@ -70,7 +70,7 @@ describe('ValueCard', () => {
     expect(wrapperWithDataState.find(`.${iotPrefix}--data-state-container`)).toHaveLength(1);
   });
 
-  test('Id is passed down to the card', () => {
+  it('Id is passed down to the card', () => {
     const wrapper = mount(
       <ValueCard
         id="myIdTest"

--- a/src/components/WizardInline/StatefulWizard.test.jsx
+++ b/src/components/WizardInline/StatefulWizard.test.jsx
@@ -13,7 +13,7 @@ const commonWizardProps = {
 };
 
 describe('StatefulWizardInline', () => {
-  test('onNext', () => {
+  it('onNext', () => {
     const mockNext = jest.fn();
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} onNext={mockNext} />);
     const cancelAndNextButtons = wrapper.find('.bx--btn');
@@ -21,7 +21,7 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(2).simulate('click');
     expect(mockNext).toHaveBeenCalled();
   });
-  test('setItem', () => {
+  it('setItem', () => {
     const mockSetItem = jest.fn();
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} setItem={mockSetItem} />);
     const progressIndicatorButtons = wrapper.find('.bx--progress-step-button');
@@ -29,12 +29,12 @@ describe('StatefulWizardInline', () => {
     progressIndicatorButtons.at(1).simulate('click');
     expect(mockSetItem).toHaveBeenCalled();
   });
-  test('error', () => {
+  it('error', () => {
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} error="I'm in error" />);
     const progressIndicatorButtons = wrapper.find('InlineNotification');
     expect(progressIndicatorButtons).toHaveLength(1);
   });
-  test('error clear error', () => {
+  it('error clear error', () => {
     const mockClearError = jest.fn();
     const wrapper = mount(
       <StatefulWizardInline
@@ -48,7 +48,7 @@ describe('StatefulWizardInline', () => {
     clearErrorButton.simulate('click');
     expect(mockClearError).toHaveBeenCalled();
   });
-  test('setItem not triggered if invalid', () => {
+  it('setItem not triggered if invalid', () => {
     const mockSetItem = jest.fn();
     const wrapper = mount(
       <StatefulWizardInline
@@ -66,7 +66,7 @@ describe('StatefulWizardInline', () => {
     progressIndicatorButtons.at(1).simulate('click');
     expect(mockSetItem).not.toHaveBeenCalled();
   });
-  test('onNext not triggered if invalid', () => {
+  it('onNext not triggered if invalid', () => {
     const mockNext = jest.fn();
     const wrapper = mount(
       <StatefulWizardInline
@@ -84,7 +84,7 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(1).simulate('click');
     expect(mockNext).not.toHaveBeenCalled();
   });
-  test('onClose', () => {
+  it('onClose', () => {
     const mockClose = jest.fn();
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} onClose={mockClose} />);
     const cancelAndNextButtons = wrapper.find('.bx--btn');
@@ -92,7 +92,7 @@ describe('StatefulWizardInline', () => {
     cancelAndNextButtons.at(1).simulate('click');
     expect(mockClose).toHaveBeenCalled();
   });
-  test('onBack', () => {
+  it('onBack', () => {
     const mockBack = jest.fn();
     const wrapper = mount(
       <StatefulWizardInline
@@ -106,11 +106,11 @@ describe('StatefulWizardInline', () => {
     backAndNextButtons.at(1).simulate('click');
     expect(mockBack).toHaveBeenCalled();
   });
-  test('renders with inference of current item when currentItemId is not set', () => {
+  it('renders with inference of current item when currentItemId is not set', () => {
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} currentItemId={null} />);
     expect(wrapper.find('StatefulWizardInline')).toHaveLength(1);
   });
-  test('renders with no next item when currentItem is the last item', () => {
+  it('renders with no next item when currentItem is the last item', () => {
     const wrapper = mount(
       <StatefulWizardInline
         {...commonWizardProps}
@@ -119,13 +119,13 @@ describe('StatefulWizardInline', () => {
     );
     expect(wrapper.find('StatefulWizardInline')).toHaveLength(1);
   });
-  test('handleNext advances to next with no onNext callback', () => {
+  it('handleNext advances to next with no onNext callback', () => {
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} />);
     const nextButton = wrapper.find('.bx--btn').at(2);
     nextButton.simulate('click');
     expect(wrapper.find('WizardInline').props().currentItemId).toBe(itemsAndComponents[1].id);
   });
-  test('handleBack goes to previous with no onBack callback', () => {
+  it('handleBack goes to previous with no onBack callback', () => {
     const wrapper = mount(
       <StatefulWizardInline {...commonWizardProps} currentItemId={itemsAndComponents[2].id} />
     );
@@ -133,7 +133,7 @@ describe('StatefulWizardInline', () => {
     backButton.simulate('click');
     expect(wrapper.find('WizardInline').props().currentItemId).toBe(itemsAndComponents[1].id);
   });
-  test('setItem advances to the set item with no setItem callback', () => {
+  it('setItem advances to the set item with no setItem callback', () => {
     const wrapper = mount(<StatefulWizardInline {...commonWizardProps} />);
     const progressIndicatorButtons = wrapper.find('.bx--progress-step-button');
     progressIndicatorButtons.at(3).simulate('click');

--- a/src/components/WizardInline/WizardFooter/WizardFooter.test.jsx
+++ b/src/components/WizardInline/WizardFooter/WizardFooter.test.jsx
@@ -20,7 +20,7 @@ const commonFooterProps = {
 };
 
 describe('WizardFooter', () => {
-  test('check footer buttons', () => {
+  it('check footer buttons', () => {
     const cancelAndNextButtons = mount(<WizardFooter {...commonFooterProps} hasPrev={false} />);
     // should only have Cancel and Next button
     expect(cancelAndNextButtons.find('.bx--btn')).toHaveLength(2);

--- a/src/components/WizardInline/WizardInline.test.jsx
+++ b/src/components/WizardInline/WizardInline.test.jsx
@@ -8,7 +8,7 @@ import { itemsAndComponents } from './WizardInline.story';
 const fakeBlurb = faker.lorem.sentence();
 
 describe('WizardInline tests', () => {
-  test('blurb prop', () => {
+  it('blurb prop', () => {
     let wrapper = shallow(
       <WizardInline
         title="Wizard Title"
@@ -29,7 +29,7 @@ describe('WizardInline tests', () => {
     );
     expect(wrapper.find('WizardHeader').prop('blurb')).toEqual(fakeBlurb);
   });
-  test('deprecation notice', () => {
+  it('deprecation notice', () => {
     // globally this is false, but we need it true so the warning pops
     global.__DEV__ = true;
 

--- a/src/components/WizardInline/WizardInline.test.jsx
+++ b/src/components/WizardInline/WizardInline.test.jsx
@@ -7,7 +7,7 @@ import { itemsAndComponents } from './WizardInline.story';
 
 const fakeBlurb = faker.lorem.sentence();
 
-describe('WizardInline tests', () => {
+describe('WizardInline', () => {
   it('blurb prop', () => {
     let wrapper = shallow(
       <WizardInline

--- a/src/components/WizardModal/WizardModal.test.jsx
+++ b/src/components/WizardModal/WizardModal.test.jsx
@@ -10,7 +10,7 @@ const commonWizardProps = {
 };
 
 describe('WizardModal', () => {
-  test('handleNext', () => {
+  it('handleNext', () => {
     const mockValidateStepFunction = jest.fn();
     const wrapper = mount(
       <WizardModal
@@ -34,7 +34,7 @@ describe('WizardModal', () => {
     expect(wrapper.state('step')).toEqual(0);
     expect(mockValidateStepFunction).not.toHaveBeenCalled();
   });
-  test('validation', () => {
+  it('validation', () => {
     const wrapper = mount(
       <WizardModal
         {...commonWizardProps}
@@ -65,7 +65,7 @@ describe('WizardModal', () => {
     // step be allowed to go backwards
     expect(wrapper.state('step')).toEqual(0);
   });
-  test('submit', () => {
+  it('submit', () => {
     const mockValidateStepFunction = jest.fn();
     const wrapper = mount(
       <WizardModal
@@ -93,7 +93,7 @@ describe('WizardModal', () => {
     wrapper.instance().handleSubmit();
     expect(mockValidateStepFunction).toHaveBeenCalled();
   });
-  test('footer and buttons', () => {
+  it('footer and buttons', () => {
     const wrapper = mount(
       <WizardModal
         {...commonWizardProps}
@@ -135,7 +135,7 @@ describe('WizardModal', () => {
     expect(wrapper.find('.bx--btn--primary')).toHaveLength(1);
     wrapper.setState({ step: 2 });
   });
-  test('sendingData', () => {
+  it('sendingData', () => {
     const wrapper = mount(
       <WizardModal
         {...commonWizardProps}

--- a/src/utils/__tests__/cardUtilityFunctions.test.js
+++ b/src/utils/__tests__/cardUtilityFunctions.test.js
@@ -7,16 +7,16 @@ import {
 } from '../cardUtilityFunctions';
 
 describe('cardUtilityFunctions', () => {
-  test('determineCardRange', () => {
+  it('determineCardRange', () => {
     expect(determineCardRange('last24Hours').type).toEqual('rolling');
     expect(determineCardRange('thisWeek').type).toEqual('periodToDate');
   });
-  test('compareGrains', () => {
+  it('compareGrains', () => {
     expect(compareGrains('day', 'day')).toEqual(0);
     expect(compareGrains('hour', 'day')).toEqual(-1);
     expect(compareGrains('week', 'day')).toEqual(1);
   });
-  test('GetUpdatedCardSize', () => {
+  it('GetUpdatedCardSize', () => {
     expect(getUpdatedCardSize('XSMALL')).toEqual('SMALL');
     expect(getUpdatedCardSize('XSMALLWIDE')).toEqual('SMALLWIDE');
     expect(getUpdatedCardSize('WIDE')).toEqual('MEDIUMWIDE');
@@ -24,13 +24,13 @@ describe('cardUtilityFunctions', () => {
     expect(getUpdatedCardSize('XLARGE')).toEqual('LARGEWIDE');
     expect(getUpdatedCardSize('MEDIUM')).toEqual('MEDIUM');
   });
-  test('formatNumberWithPrecision', () => {
+  it('formatNumberWithPrecision', () => {
     expect(formatNumberWithPrecision(3.45, 1, 'fr')).toEqual('3,5'); // decimal separator should be comma
     expect(formatNumberWithPrecision(3.45, 2, 'en')).toEqual('3.45'); // decimal separator should be period
     expect(formatNumberWithPrecision(35000, 2, 'en')).toEqual('35.00K'); // K separator
     expect(formatNumberWithPrecision(35000, null, 'en')).toEqual('35K'); // K separator
   });
-  test('handleCardVariables updates value cards with variables', () => {
+  it('handleCardVariables updates value cards with variables', () => {
     const valueCardPropsWithVariables = {
       title: 'Fuel {variable} flow',
       content: {
@@ -206,7 +206,7 @@ describe('cardUtilityFunctions', () => {
       ...others,
     });
   });
-  test('handleCardVariables updates table cards with variables', () => {
+  it('handleCardVariables updates table cards with variables', () => {
     const tableCardPropsWithVariables = {
       title: 'Max and {minimum} speed',
       content: {
@@ -351,7 +351,7 @@ describe('cardUtilityFunctions', () => {
       ...others,
     });
   });
-  test('handleCardVariables returns original card when no value cardVariables are specified', () => {
+  it('handleCardVariables returns original card when no value cardVariables are specified', () => {
     const valueCardProps = {
       id: 'fuel_flow',
       size: 'SMALL',
@@ -460,7 +460,7 @@ describe('cardUtilityFunctions', () => {
       ...others,
     });
   });
-  test('handleCardVariables returns original card when no table cardVariables are specified', () => {
+  it('handleCardVariables returns original card when no table cardVariables are specified', () => {
     const tableCardProps = {
       title: 'Max and min speed',
       content: {
@@ -545,7 +545,7 @@ describe('cardUtilityFunctions', () => {
       ...others,
     });
   });
-  test('handleCardVariables updates cards with variables when there are case discrepancies in cardVariables', () => {
+  it('handleCardVariables updates cards with variables when there are case discrepancies in cardVariables', () => {
     const timeSeriesCardPropsWithVariables = {
       title: 'timeSeries {device}',
       content: {
@@ -591,7 +591,7 @@ describe('cardUtilityFunctions', () => {
       ...others,
     });
   });
-  test('handleCardVariables updates timeseries cards with variables', () => {
+  it('handleCardVariables updates timeseries cards with variables', () => {
     const timeSeriesCardPropsWithVariables = {
       title: 'timeSeries {device}',
       content: {
@@ -637,7 +637,7 @@ describe('cardUtilityFunctions', () => {
       ...others,
     });
   });
-  test('handleCardVariables returns original card when no cardVariables are specified', () => {
+  it('handleCardVariables returns original card when no cardVariables are specified', () => {
     const timeSeriesCardProps = {
       title: 'timeSeries',
       content: {

--- a/src/utils/__tests__/componentUtilityFunctions.test.js
+++ b/src/utils/__tests__/componentUtilityFunctions.test.js
@@ -41,7 +41,7 @@ const mockCsvData = [
 ];
 
 describe('componentUtilityFunctions', () => {
-  test('getSortedData', () => {
+  it('getSortedData', () => {
     expect(getSortedData(mockData, 'string', 'DESC')[0].values.string).toEqual('string3');
     expect(getSortedData(mockData, 'string', 'ASC')[0].values.string).toEqual('string');
     expect(getSortedData(mockData, 'number', 'DESC')[0].values.number).toEqual(100);
@@ -54,7 +54,7 @@ describe('componentUtilityFunctions', () => {
     expect(getSortedData(mockData, 'null', 'ASC')[1].values.null).toEqual(3);
     expect(getSortedData(mockData, 'null', 'ASC')[2].values.null).toBeUndefined();
   });
-  test('canFit', () => {
+  it('canFit', () => {
     expect(canFit(0, 0, 1, 1, [[1, 1, 1, 1], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]])).toEqual(
       false
     );
@@ -62,7 +62,7 @@ describe('componentUtilityFunctions', () => {
       true
     );
   });
-  test('filterValidAttributes allow HTML attributes, event handlers, react lib', () => {
+  it('filterValidAttributes allow HTML attributes, event handlers, react lib', () => {
     // HTML
     expect(filterValidAttributes({ alt: 'my alt text', draggable: 'true' })).toEqual({
       alt: 'my alt text',
@@ -86,7 +86,7 @@ describe('componentUtilityFunctions', () => {
     // Other props
     expect(filterValidAttributes({ myProp: 'test', someProp: 'test2' })).toEqual({});
   });
-  test('csv should display 0 value', () => {
+  it('csv should display 0 value', () => {
     const csv = generateCsv(mockCsvData);
     const splitCsv = csv.split(',');
 


### PR DESCRIPTION
~Relies on #1168 - once that one is merged the files changed on this PR will make more sense to show the reduced changeset~ 👍  _Now ready for review_

**Summary**

- configure eslint to standardize testing format - `it` should be used inside `describe` blocks. If no `describe` block, use `test`

**Change List (commits, features, bugs, etc)**

- add the eslint rule
- reformat tests to comply with new rule (bulk of the changeset)
- remove redundant `tests`, `testcases`, etc. verbiage in describe blocks

**Acceptance Test (how to verify the PR)**

- Status checks should be enough here, basically all I did was a find all and replace.
