### PR TITLE
fix(valuecard): always use precision if passed

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -317,7 +317,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -406,7 +406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -2522,7 +2522,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -2611,7 +2611,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -4759,7 +4759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -4848,7 +4848,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -9453,7 +9453,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -9542,7 +9542,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -11641,7 +11641,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="103.2 ˚F"
                               value={103.2}
                             >
-                              103
+                              103.2
                             </span>
                           </div>
                           <span
@@ -11727,7 +11727,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="107324.3 kJ"
                               value={107324.3}
                             >
-                              107K
+                              107.3K
                             </span>
                           </div>
                           <span
@@ -11813,7 +11813,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              2M
+                              1.7M
                             </span>
                           </div>
                           <span
@@ -12323,7 +12323,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="103.2 ˚F"
                               value={103.2}
                             >
-                              103
+                              103.2
                             </span>
                           </div>
                           <span
@@ -12409,7 +12409,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="107324.3 kJ"
                               value={107324.3}
                             >
-                              107K
+                              107.3K
                             </span>
                           </div>
                           <span
@@ -12495,7 +12495,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="1709384.1 people"
                               value={1709384.1}
                             >
-                              2M
+                              1.7M
                             </span>
                           </div>
                           <span
@@ -12835,7 +12835,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="65.3 ˚F"
                               value={65.3}
                             >
-                              65
+                              65.3
                             </span>
                           </div>
                           <span
@@ -12921,7 +12921,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="48.7 ˚F"
                               value={48.7}
                             >
-                              49
+                              48.7
                             </span>
                           </div>
                           <span
@@ -13010,7 +13010,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="88.1 ˚F"
                               value={88.1}
                             >
-                              88
+                              88.1
                             </span>
                           </div>
                           <span
@@ -13096,7 +13096,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="103.2 ˚F"
                               value={103.2}
                             >
-                              103
+                              103.2
                             </span>
                           </div>
                           <span
@@ -13250,7 +13250,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="65.3 ˚F"
                               value={65.3}
                             >
-                              65
+                              65.3
                             </span>
                           </div>
                           <span
@@ -13336,7 +13336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="48.7 ˚F"
                               value={48.7}
                             >
-                              49
+                              48.7
                             </span>
                           </div>
                           <span
@@ -13425,7 +13425,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="88.1 ˚F"
                               value={88.1}
                             >
-                              88
+                              88.1
                             </span>
                           </div>
                           <span
@@ -13511,7 +13511,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="103.2 ˚F"
                               value={103.2}
                             >
-                              103
+                              103.2
                             </span>
                           </div>
                           <span
@@ -13665,7 +13665,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="38.2 %"
                               value={38.2}
                             >
-                              38
+                              38.2
                             </span>
                           </div>
                           <span
@@ -13777,7 +13777,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="65.3 %"
                               value={65.3}
                             >
-                              65
+                              65.3
                             </span>
                           </div>
                           <span
@@ -13889,7 +13889,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="77.7 %"
                               value={77.7}
                             >
-                              78
+                              77.7
                             </span>
                           </div>
                           <span
@@ -14178,7 +14178,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="38.2 %"
                               value={38.2}
                             >
-                              38
+                              38.2
                             </span>
                           </div>
                           <span
@@ -14290,7 +14290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="65.3 %"
                               value={65.3}
                             >
-                              65
+                              65.3
                             </span>
                           </div>
                           <span
@@ -14402,7 +14402,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                               title="77.7 %"
                               value={77.7}
                             >
-                              78
+                              77.7
                             </span>
                           </div>
                           <span
@@ -23782,7 +23782,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span
@@ -23871,7 +23871,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             title="62.1 %"
                             value={62.1}
                           >
-                            62
+                            62.1
                           </span>
                         </div>
                         <span

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -22,6 +22,7 @@ import {
   getUpdatedCardSize,
   formatNumberWithPrecision,
   handleCardVariables,
+  determinePrecision,
 } from '../../utils/cardUtilityFunctions';
 
 import { generateSampleValues, formatGraphTick, findMatchingAlertRange } from './timeSeriesUtils';
@@ -61,26 +62,6 @@ const LineChartWrapper = styled.div`
     }
   }
 `;
-
-/**
- * Determines how many decimals to show for a value based on the value, the available size of the card
- * @param {string} size constant that describes the size of the Table card
- * @param {any} value will be checked to determine how many decimals to show
- * @param {*} defaultPrecision Desired decimal precision, but may be overridden based on the value type or card size
- */
-export const determinePrecision = (size, value, defaultPrecision) => {
-  // If it's an integer don't return extra values
-  if (Number.isInteger(value)) {
-    return 0;
-  }
-  // If the card is xsmall we don't have room for decimals!
-  switch (size) {
-    case CARD_SIZES.SMALL:
-      return Math.abs(value) > 9 ? 0 : defaultPrecision;
-    default:
-  }
-  return defaultPrecision;
-};
 
 /**
  * Translates our raw data into a language the carbon-charts understand

--- a/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.test.jsx
@@ -9,7 +9,6 @@ import { CARD_SIZES, COLORS, TIME_SERIES_TYPES } from '../../constants/LayoutCon
 import { barChartData } from '../../utils/barChartDataSample';
 
 import TimeSeriesCard, {
-  determinePrecision,
   valueFormatter,
   handleTooltip,
   formatChartData,
@@ -73,12 +72,6 @@ describe('TimeSeriesCard', () => {
     timeSeriesCardProps.content.chartType = TIME_SERIES_TYPES.BAR;
     const wrapper = mount(<TimeSeriesCard {...timeSeriesCardProps} size={CARD_SIZES.MEDIUMWIDE} />);
     expect(wrapper.find('StackedBarChart')).toHaveLength(1);
-  });
-  it('determine precision', () => {
-    expect(determinePrecision(CARD_SIZES.LARGE, 700)).toEqual(0);
-    expect(determinePrecision(CARD_SIZES.SMALL, 11.45)).toEqual(0);
-    expect(determinePrecision(CARD_SIZES.SMALL, 1.45, 1)).toEqual(1);
-    expect(determinePrecision(CARD_SIZES.LARGE, 1.45, 1)).toEqual(1);
   });
   it('valueFormatter', () => {
     // Small should get 3 precision

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -5,7 +5,11 @@ import isNil from 'lodash/isNil';
 import classNames from 'classnames';
 
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
-import { getUpdatedCardSize, formatNumberWithPrecision } from '../../utils/cardUtilityFunctions';
+import {
+  getUpdatedCardSize,
+  formatNumberWithPrecision,
+  determinePrecision,
+} from '../../utils/cardUtilityFunctions';
 import { settings } from '../../constants/Settings';
 
 const { iotPrefix } = settings;
@@ -81,20 +85,6 @@ const AttributeValue = styled.span`
 const StyledBoolean = styled.span`
   text-transform: capitalize;
 `;
-
-const determinePrecision = (size, value, precision) => {
-  // If it's an integer don't return extra values
-  if (Number.isInteger(value)) {
-    return 0;
-  }
-  // If the card is xsmall we don't have room for decimals!
-  switch (size) {
-    case CARD_SIZES.SMALL:
-      return Math.abs(value) > 9 ? 0 : precision;
-    default:
-  }
-  return precision;
-};
 
 /**
  * This components job is determining how to render different kinds of card values.

--- a/src/utils/__tests__/cardUtilityFunctions.test.js
+++ b/src/utils/__tests__/cardUtilityFunctions.test.js
@@ -13,7 +13,7 @@ describe('cardUtilityFunctions', () => {
     // default precisions
     expect(determinePrecision(CARD_SIZES.SMALL, 11.45)).toEqual(0);
     expect(determinePrecision(CARD_SIZES.SMALL, 0.125)).toBeUndefined();
-    //For small card sizes always trust the passed precision
+    // For small card sizes always trust the passed precision
     expect(determinePrecision(CARD_SIZES.SMALL, 11.45, 1)).toEqual(1);
     expect(determinePrecision(CARD_SIZES.SMALL, 0.125, 2)).toEqual(2);
     // For integers no precision

--- a/src/utils/__tests__/cardUtilityFunctions.test.js
+++ b/src/utils/__tests__/cardUtilityFunctions.test.js
@@ -1,12 +1,25 @@
 import {
+  determinePrecision,
   determineCardRange,
   compareGrains,
   getUpdatedCardSize,
   formatNumberWithPrecision,
   handleCardVariables,
 } from '../cardUtilityFunctions';
+import { CARD_SIZES } from '../../constants/LayoutConstants';
 
 describe('cardUtilityFunctions', () => {
+  it('determine precision', () => {
+    // default precisions
+    expect(determinePrecision(CARD_SIZES.SMALL, 11.45)).toEqual(0);
+    expect(determinePrecision(CARD_SIZES.SMALL, 0.125)).toBeUndefined();
+    //For small card sizes always trust the passed precision
+    expect(determinePrecision(CARD_SIZES.SMALL, 11.45, 1)).toEqual(1);
+    expect(determinePrecision(CARD_SIZES.SMALL, 0.125, 2)).toEqual(2);
+    // For integers no precision
+    expect(determinePrecision(CARD_SIZES.LARGE, 700)).toEqual(0);
+    expect(determinePrecision(CARD_SIZES.LARGE, 1.45, 1)).toEqual(1);
+  });
   it('determineCardRange', () => {
     expect(determineCardRange('last24Hours').type).toEqual('rolling');
     expect(determineCardRange('thisWeek').type).toEqual('periodToDate');

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -259,3 +259,23 @@ export const handleCardVariables = (title, content, values, card) => {
 
   return replaceVariables(variablesArray, cardVariables, updatedCard);
 };
+
+/**
+ * Determines how many decimals to show for a value based on the value, the available size of the card
+ * @param {string} size constant that describes the size of the Table card
+ * @param {any} value will be checked to determine how many decimals to show
+ * @param {*} precision Desired decimal precision, will be used if specified
+ */
+export const determinePrecision = (size, value, precision) => {
+  // If it's an integer don't return extra values
+  if (Number.isInteger(value)) {
+    return 0;
+  }
+  // If the card is xsmall we don't have room for decimals!
+  switch (size) {
+    case CARD_SIZES.SMALL:
+      return !isNil(precision) ? precision : Math.abs(value) > 9 ? 0 : undefined;
+    default:
+  }
+  return precision;
+};


### PR DESCRIPTION
Closes #1184

**Summary**

- Value Card was ignoring the passed precision for small cards. We should always respect it

**Change List (commits, features, bugs, etc)**

- refactor(TimeSeriesCard): migrate the determinePrecision to the shared utils function instead of having a copy in both ValueRenderer and TimeSeriesCard

**Acceptance Test (how to verify the PR)**

- Verify that the testcases pass, it's okay that the Dashboard story updated because we have enough room to render the slightly more precise values.
