### PR TITLE
fix(table): empty state button always shows

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1717,6 +1717,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
+                                <button
+                                  className="bx--btn bx--btn--primary"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                />
                               </div>
                             </td>
                           </tr>
@@ -3922,6 +3929,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
+                                <button
+                                  className="bx--btn bx--btn--primary"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                />
                               </div>
                             </td>
                           </tr>
@@ -6159,6 +6173,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
+                                <button
+                                  className="bx--btn bx--btn--primary"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                />
                               </div>
                             </td>
                           </tr>
@@ -10851,6 +10872,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   __There is no data__
                                 </p>
+                                <button
+                                  className="bx--btn bx--btn--primary"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                />
                               </div>
                             </td>
                           </tr>
@@ -25182,6 +25210,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
+                                <button
+                                  className="bx--btn bx--btn--primary"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  type="button"
+                                />
                               </div>
                             </td>
                           </tr>

--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1717,13 +1717,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
-                                <button
-                                  className="bx--btn bx--btn--primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                />
                               </div>
                             </td>
                           </tr>
@@ -3929,13 +3922,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
-                                <button
-                                  className="bx--btn bx--btn--primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                />
                               </div>
                             </td>
                           </tr>
@@ -6173,13 +6159,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
-                                <button
-                                  className="bx--btn bx--btn--primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                />
                               </div>
                             </td>
                           </tr>
@@ -10872,13 +10851,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   __There is no data__
                                 </p>
-                                <button
-                                  className="bx--btn bx--btn--primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                />
                               </div>
                             </td>
                           </tr>
@@ -25210,13 +25182,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                                 <p>
                                   There are no alerts in this range.
                                 </p>
-                                <button
-                                  className="bx--btn bx--btn--primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  tabIndex={0}
-                                  type="button"
-                                />
                               </div>
                             </td>
                           </tr>

--- a/src/components/Table/EmptyTable/EmptyTable.jsx
+++ b/src/components/Table/EmptyTable/EmptyTable.jsx
@@ -69,9 +69,9 @@ const EmptyTable = ({
           <div className="empty-table-cell--default">
             <Bee32 />
             <p>{isFiltered && messageWithFilters ? messageWithFilters : message}</p>
-            {buttonLabel && onEmptyStateAction ? (
+            {onEmptyStateAction ? (
               <Button onClick={onEmptyStateAction}>
-                {isFiltered && buttonLabelWithFilters ? buttonLabelWithFilters : buttonLabel}
+                {isFiltered ? buttonLabelWithFilters : buttonLabel}
               </Button>
             ) : null}
           </div>

--- a/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
+++ b/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
@@ -1,0 +1,73 @@
+import EmptyTable from '../EmptyTable';
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+const commonTableProps = {
+  id: 'tableid',
+  totalColumns: 3,
+  isFiltered: false,
+};
+
+describe('EmptyTable', () => {
+  it('custom empty state', () => {
+    const { queryAllByText } = render(
+      <EmptyTable {...commonTableProps} emptyState={<span>my custom element</span>} />
+    );
+    expect(queryAllByText('my custom element')).toHaveLength(1);
+  });
+  it('no empty state action does not render button', () => {
+    const { queryAllByText } = render(
+      <EmptyTable
+        {...commonTableProps}
+        emptyState={{ message: 'I am empty', buttonLabel: 'clickme' }}
+      />
+    );
+    expect(queryAllByText('I am empty')).toHaveLength(1);
+    expect(queryAllByText('clickme')).toHaveLength(0);
+  });
+  it('empty state action with custom button', () => {
+    const { queryAllByText } = render(
+      <EmptyTable
+        {...commonTableProps}
+        emptyState={{
+          message: 'I am empty',
+          buttonLabel: 'clickme',
+        }}
+        onEmptyStateAction={jest.fn()}
+      />
+    );
+    expect(queryAllByText('I am empty')).toHaveLength(1);
+    expect(queryAllByText('clickme')).toHaveLength(1);
+  });
+  it('empty state action with custom filtered button', () => {
+    const { queryAllByText } = render(
+      <EmptyTable
+        {...commonTableProps}
+        isFiltered
+        emptyState={{
+          message: 'I am empty',
+          buttonLabelWithFilters: 'clickme',
+        }}
+        onEmptyStateAction={jest.fn()}
+      />
+    );
+    expect(queryAllByText('I am empty')).toHaveLength(1);
+    expect(queryAllByText('clickme')).toHaveLength(1);
+  });
+  it('empty state action with custom filtered button', () => {
+    const { queryAllByText } = render(
+      <EmptyTable
+        {...commonTableProps}
+        isFiltered
+        emptyState={{
+          message: 'I am empty',
+          buttonLabelWithFilters: 'clickmyfilters',
+        }}
+        onEmptyStateAction={jest.fn()}
+      />
+    );
+    expect(queryAllByText('I am empty')).toHaveLength(1);
+    expect(queryAllByText('clickmyfilters')).toHaveLength(1);
+  });
+});

--- a/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
+++ b/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
@@ -1,7 +1,7 @@
-import EmptyTable from '../EmptyTable';
-
 import React from 'react';
 import { render } from '@testing-library/react';
+
+import EmptyTable from '../EmptyTable';
 
 const commonTableProps = {
   id: 'tableid',
@@ -33,21 +33,6 @@ describe('EmptyTable', () => {
         emptyState={{
           message: 'I am empty',
           buttonLabel: 'clickme',
-        }}
-        onEmptyStateAction={jest.fn()}
-      />
-    );
-    expect(queryAllByText('I am empty')).toHaveLength(1);
-    expect(queryAllByText('clickme')).toHaveLength(1);
-  });
-  it('empty state action with custom filtered button', () => {
-    const { queryAllByText } = render(
-      <EmptyTable
-        {...commonTableProps}
-        isFiltered
-        emptyState={{
-          message: 'I am empty',
-          buttonLabelWithFilters: 'clickme',
         }}
         onEmptyStateAction={jest.fn()}
       />

--- a/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
+++ b/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
@@ -42,7 +42,7 @@ describe('EmptyTable', () => {
     fireEvent.click(screen.getByText('clickme'));
     expect(mockEmptyStateAction).toHaveBeenCalled();
   });
-  it('empty state action with custom filtered button calls onEmptyStateAction', () => {
+  it('empty state action with custom filtered button', () => {
     const mockEmptyStateAction = jest.fn();
     render(
       <EmptyTable

--- a/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
+++ b/src/components/Table/EmptyTable/__tests__/EmptyTable.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import EmptyTable from '../EmptyTable';
 
@@ -11,37 +11,40 @@ const commonTableProps = {
 
 describe('EmptyTable', () => {
   it('custom empty state', () => {
-    const { queryAllByText } = render(
-      <EmptyTable {...commonTableProps} emptyState={<span>my custom element</span>} />
-    );
-    expect(queryAllByText('my custom element')).toHaveLength(1);
+    render(<EmptyTable {...commonTableProps} emptyState={<span>my custom element</span>} />);
+    expect(screen.queryAllByText('my custom element')).toHaveLength(1);
   });
   it('no empty state action does not render button', () => {
-    const { queryAllByText } = render(
+    render(
       <EmptyTable
         {...commonTableProps}
         emptyState={{ message: 'I am empty', buttonLabel: 'clickme' }}
       />
     );
-    expect(queryAllByText('I am empty')).toHaveLength(1);
-    expect(queryAllByText('clickme')).toHaveLength(0);
+    expect(screen.queryAllByText('I am empty')).toHaveLength(1);
+    expect(screen.queryAllByText('clickme')).toHaveLength(0);
   });
   it('empty state action with custom button', () => {
-    const { queryAllByText } = render(
+    const mockEmptyStateAction = jest.fn();
+    render(
       <EmptyTable
         {...commonTableProps}
         emptyState={{
           message: 'I am empty',
           buttonLabel: 'clickme',
         }}
-        onEmptyStateAction={jest.fn()}
+        onEmptyStateAction={mockEmptyStateAction}
       />
     );
-    expect(queryAllByText('I am empty')).toHaveLength(1);
-    expect(queryAllByText('clickme')).toHaveLength(1);
+
+    expect(screen.queryAllByText('I am empty')).toHaveLength(1);
+    expect(screen.queryAllByText('clickme')).toHaveLength(1);
+    fireEvent.click(screen.getByText('clickme'));
+    expect(mockEmptyStateAction).toHaveBeenCalled();
   });
-  it('empty state action with custom filtered button', () => {
-    const { queryAllByText } = render(
+  it('empty state action with custom filtered button calls onEmptyStateAction', () => {
+    const mockEmptyStateAction = jest.fn();
+    render(
       <EmptyTable
         {...commonTableProps}
         isFiltered
@@ -49,10 +52,12 @@ describe('EmptyTable', () => {
           message: 'I am empty',
           buttonLabelWithFilters: 'clickmyfilters',
         }}
-        onEmptyStateAction={jest.fn()}
+        onEmptyStateAction={mockEmptyStateAction}
       />
     );
-    expect(queryAllByText('I am empty')).toHaveLength(1);
-    expect(queryAllByText('clickmyfilters')).toHaveLength(1);
+    expect(screen.queryAllByText('I am empty')).toHaveLength(1);
+    expect(screen.queryAllByText('clickmyfilters')).toHaveLength(1);
+    fireEvent.click(screen.getByText('clickmyfilters'));
+    expect(mockEmptyStateAction).toHaveBeenCalled();
   });
 });

--- a/src/components/Table/StatefulTable.jsx
+++ b/src/components/Table/StatefulTable.jsx
@@ -169,9 +169,11 @@ const StatefulTable = ({ data: initialData, expandedData, ...other }) => {
         dispatch(tableRowActionComplete(rowId));
         callbackParent(onClearRowError, rowId);
       },
-      onEmptyStateAction: () =>
-        // This action doesn't update our table state, it's up to the user
-        callbackParent(onEmptyStateAction),
+      onEmptyStateAction: onEmptyStateAction
+        ? () =>
+            // This action doesn't update our table state, it's up to the user
+            callbackParent(onEmptyStateAction)
+        : null,
       onChangeOrdering: ordering => {
         dispatch(tableColumnOrder(ordering));
         callbackParent(onChangeOrdering, ordering);

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -231,7 +231,7 @@ export const defaultProps = baseProps => ({
       onRowExpanded: defaultFunction('actions.table.onRowExpanded'),
       onRowClicked: defaultFunction('actions.table.onRowClicked'),
       onApplyRowAction: defaultFunction('actions.table.onApplyRowAction'),
-      onEmptyStateAction: defaultFunction('actions.table.onEmptyStateAction'),
+      onEmptyStateAction: null,
       onChangeOrdering: defaultFunction('actions.table.onChangeOrdering'),
       onColumnSelectionConfig: defaultFunction('actions.table.onColumnSelectionConfig'),
       onColumnResize: defaultFunction('actions.table.onColumnResize'),

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -275,7 +275,6 @@ export const defaultProps = baseProps => ({
     emptyMessage: 'There is no data',
     emptyMessageWithFilters: 'No results match the current filters',
     emptyButtonLabel: 'Create some data',
-    emptyButtonLabelWithFilters: 'Clear all filters',
     downloadIconDescription: 'Download table content',
     filterNone: 'Unsort rows by this header',
     filterAscending: 'Sort rows by this header in ascending order',
@@ -554,7 +553,11 @@ const Table = props => {
                     }
               }
               onEmptyStateAction={
-                isFiltered ? handleClearFilters : actions.table.onEmptyStateAction
+                isFiltered && i18n.emptyButtonLabelWithFilters
+                  ? handleClearFilters // show clear filters
+                  : !isFiltered && actions.table.onEmptyStateAction
+                  ? actions.table.onEmptyStateAction
+                  : undefined // if not filtered then show normal empty state
               }
             />
           )}

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -212,6 +212,7 @@ describe('Table', () => {
         data={[]}
         actions={mockActions}
         options={options}
+        i18n={{ emptyButtonLabelWithFilters: 'Clear all filters' }}
         view={merge({}, view, {
           filters: [{ columnId: 'col', value: 'value' }],
           table: { emptyState: <div id="customEmptyState">emptyState</div> },

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -9735,6 +9735,13 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <p>
                           There is no data for this time range.
                         </p>
+                        <button
+                          className="bx--btn bx--btn--primary"
+                          disabled={false}
+                          onClick={[Function]}
+                          tabIndex={0}
+                          type="button"
+                        />
                       </div>
                     </td>
                   </tr>

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -9735,13 +9735,6 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <p>
                           There is no data for this time range.
                         </p>
-                        <button
-                          className="bx--btn bx--btn--primary"
-                          disabled={false}
-                          onClick={[Function]}
-                          tabIndex={0}
-                          type="button"
-                        />
                       </div>
                     </td>
                   </tr>

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -319,7 +319,6 @@ Map {
         "downloadIconDescription": "Download table content",
         "editButtonAria": "Edit rows",
         "emptyButtonLabel": "Create some data",
-        "emptyButtonLabelWithFilters": "Clear all filters",
         "emptyMessage": "There is no data",
         "emptyMessageWithFilters": "No results match the current filters",
         "filterAria": "Filter",

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -293,7 +293,7 @@ Map {
           "onChangeSort": [Function],
           "onColumnResize": [Function],
           "onColumnSelectionConfig": [Function],
-          "onEmptyStateAction": [Function],
+          "onEmptyStateAction": null,
           "onRowClicked": [Function],
           "onRowExpanded": [Function],
         },


### PR DESCRIPTION
Closes #1187

**Summary**

- There's no good way to hide the Create New or Clear All Filters Button in the emptyState of the table.

**Change List (commits, features, bugs, etc)**

- fix(Table): change onEmptyStateAction to actually be optional if not passed, so the button doesn't render if it's not passed
- fix(Table): change buttonLabelWithFilters to be optionally set, if it's not set and the table is filtered, don't show the button (I did this for backwards compatibility, I'd love to hide the button for all filtered tables for everybody, but in-case some user really wanted it, I allow them to set buttonLabelWithFilters to render a custom button)

**Acceptance Test (how to verify the PR)**

- Verify that if onEmptyStateAction is passed the button shows, but otherwise it doesn't show.  This story shows that button is now missing
http://127.0.0.1:3000/?path=/story/watson-iot-table--with-no-results
Verify custom empty state still works:
http://127.0.0.1:3000/?path=/story/watson-iot-table--with-no-data-and-custom-empty-state
Verify no data with onEmptyStateAction function still shows the button:
http://127.0.0.1:3000/?path=/story/watson-iot-table--with-no-data
