### PR TITLE
fix(timeseriescard): fullscreen should put table in bottom half

### DIFF
--- a/src/components/TimeSeriesCard/_time-series-card.scss
+++ b/src/components/TimeSeriesCard/_time-series-card.scss
@@ -3,6 +3,6 @@
 .#{$iot-prefix}--time-series-card--stateful-table {
   padding: 0 $spacing-05 $spacing-05;
   position: absolute;
-  top: 50%;
+  top: 55%;
   width: 100%;
 }

--- a/src/components/TimeSeriesCard/_time-series-card.scss
+++ b/src/components/TimeSeriesCard/_time-series-card.scss
@@ -3,6 +3,6 @@
 .#{$iot-prefix}--time-series-card--stateful-table {
   padding: 0 $spacing-05 $spacing-05;
   position: absolute;
+  top: 50%;
   width: 100%;
-  height: 100%;
 }


### PR DESCRIPTION
Closes #1164

**Summary**

- Save the top 50% of the expanded card for the chart

![image](https://user-images.githubusercontent.com/6663002/82244458-e6d82580-9906-11ea-82af-2f40b093fe45.png)


**Change List (commits, features, bugs, etc)**

- limit the table to the bottom 50% of the card when in expanded mode

**Acceptance Test (how to verify the PR)**

- Verify the TimeSeriesCard is expanded testcases in here: 
http://127.0.0.1:3000/?path=/story/watson-iot-dashboard--full-screen-bar-chart-card
http://127.0.0.1:3000/?path=/story/watson-iot-dashboard--full-screen-line-card
