### PR TITLE
fix(sidenav): need to override carbon-components active style of menu item

### DIFF
--- a/src/components/SideNav/_side-nav.scss
+++ b/src/components/SideNav/_side-nav.scss
@@ -50,10 +50,12 @@
       outline-offset: -2px;
     }
   }
-
-  .#{$prefix}--side-nav__link--current {
+  // need to override the carbon-components new aria-current page because it's assuming a white theme
+  & a.#{$prefix}--side-nav__link[aria-current='page'] {
     background-color: $gray-70;
-    color: $ui-02;
+    .#{$prefix}--side-nav__link-text {
+      color: $ui-02;
+    }
   }
 
   &:not(.#{$prefix}--side-nav--expanded) {


### PR DESCRIPTION
Closes #1195

**Summary**

- Due to a change in carbon-components for sidenav, we need to have a more specific background color and color override to make our SideNav Menu items be dark themed

![image](https://user-images.githubusercontent.com/6663002/82485916-bed0f980-9aa1-11ea-8dc0-23148b86b154.png)

**Change List (commits, features, bugs, etc)**

- fix(sidenav): make our background color and color for active elements be more specific

**Acceptance Test (how to verify the PR)**

- It's actually hard to verify the fix because the error doesn't occur until after you've imported carbon-addons-iot-react
