### PR TITLE
feat(table): incorrect title of row actions

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -366,6 +366,11 @@ export const initialState = {
         iconDescription: 'Delete',
         isDelete: true,
       },
+      {
+        id: 'textOnly',
+        labelText: 'Text only dummy action',
+        isOverflow: true,
+      },
     ].filter(i => i),
   })),
   expandedData: tableData.map(data => ({

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -131,7 +131,6 @@ class RowActionsCell extends React.Component {
   }
 
   componentDidUpdate(prevProp, prevState) {
-    
     const isLtr = document.dir === 'ltr';
     if (prevState.ltr !== isLtr) {
       this.setState(state => ({ ltr: !state.ltr }));
@@ -232,18 +231,14 @@ class RowActionsCell extends React.Component {
                           className={`${iotPrefix}--action-overflow-item`}
                           key={`${id}-row-actions-button-${action.id}`}
                           onClick={e => onClick(e, id, action.id, onApplyRowAction)}
-                          requireTitle
+                          requireTitle={!action.renderIcon}
                           hasDivider={action.hasDivider}
                           isDelete={action.isDelete}
                           itemText={
                             action.renderIcon ? (
-                              <OverflowMenuContent>
+                              <OverflowMenuContent title={action.labelText}>
                                 {typeof action.renderIcon === 'string' ? (
-                                  <Icon
-                                    icon={action.renderIcon}
-                                    description={action.labelText}
-                                    iconTitle={action.labelText}
-                                  />
+                                  <Icon icon={action.renderIcon} description={action.labelText} />
                                 ) : (
                                   <action.renderIcon />
                                 )}

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -197,10 +197,10 @@ class RowActionsCell extends React.Component {
               <Fragment>
                 {actions
                   .filter(action => !action.isOverflow)
-                  .map(({ id: actionId, labelText, ...others }) => (
+                  .map(({ id: actionId, labelText, iconDescription, ...others }) => (
                     <Button
                       {...omit(others, ['isOverflow'])}
-                      iconDescription={overflowMenuAria}
+                      iconDescription={labelText || iconDescription}
                       key={`${tableId}-${id}-row-actions-button-${actionId}`}
                       data-testid={`${tableId}-${id}-row-actions-button-${actionId}`}
                       kind="ghost"
@@ -240,7 +240,7 @@ class RowActionsCell extends React.Component {
                                 {typeof action.renderIcon === 'string' ? (
                                   <Icon icon={action.renderIcon} description={action.labelText} />
                                 ) : (
-                                  <action.renderIcon />
+                                  <action.renderIcon description={action.labelText} />
                                 )}
                                 {action.labelText}
                               </OverflowMenuContent>

--- a/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -32,6 +32,9 @@
 }
 
 .#{$iot-prefix}--action-overflow-item {
+  div {
+    width: 100%;
+  }
   svg {
     margin-right: $spacing-03;
 

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -44,7 +44,7 @@ storiesOf('Watson IoT/TableBodyRow', module)
     <TableBodyRow
       {...tableBodyRowProps}
       isExpanded={boolean('isExpanded', false)}
-      rowActions={[{ id: 'add', renderIcon: Add32 }]}
+      rowActions={[{ id: 'add', renderIcon: Add32, iconDescription: 'Add' }]}
       options={{ ...tableBodyRowProps.options, hasRowActions: true, hasRowExpansion: true }}
     />
   ))
@@ -53,7 +53,7 @@ storiesOf('Watson IoT/TableBodyRow', module)
       {...tableBodyRowProps}
       isExpanded={boolean('isExpanded', false)}
       rowActions={[
-        { id: 'add', renderIcon: Add32 },
+        { id: 'add', renderIcon: Add32, iconDescription: 'Add' },
         { id: 'edit', renderIcon: Edit16, isOverflow: true, labelText: 'Edit' },
         {
           id: 'test1',
@@ -79,21 +79,21 @@ storiesOf('Watson IoT/TableBodyRow', module)
     <TableBodyRow
       {...tableBodyRowProps}
       isSelectable={boolean('isSelectable', false)}
-      rowActions={[{ id: 'add', renderIcon: Add32 }]}
+      rowActions={[{ id: 'add', renderIcon: Add32, iconDescription: 'Add' }]}
       options={{ ...tableBodyRowProps.options, hasRowActions: true, hasRowSelection: 'multi' }}
     />
   ))
   .add('is selectable', () => (
     <TableBodyRow
       {...tableBodyRowProps}
-      rowActions={[{ id: 'add', renderIcon: Add32 }]}
+      rowActions={[{ id: 'add', renderIcon: Add32, iconDescription: 'Add' }]}
       options={{ ...tableBodyRowProps.options, hasRowActions: true, hasRowSelection: 'multi' }}
     />
   ))
   .add('rowActions running', () => (
     <TableBodyRow
       {...tableBodyRowProps}
-      rowActions={[{ id: 'add', renderIcon: Add32 }]}
+      rowActions={[{ id: 'add', renderIcon: Add32, iconDescription: 'Add' }]}
       options={{ ...tableBodyRowProps.options, hasRowActions: true, hasRowExpansion: true }}
       isRowActionRunning
       isExpanded={boolean('isExpanded', false)}
@@ -102,7 +102,7 @@ storiesOf('Watson IoT/TableBodyRow', module)
   .add('rowActions error', () => (
     <TableBodyRow
       {...tableBodyRowProps}
-      rowActions={[{ id: 'add', renderIcon: Add32 }]}
+      rowActions={[{ id: 'add', renderIcon: Add32, iconDescription: 'Add' }]}
       options={{ ...tableBodyRowProps.options, hasRowActions: true, hasRowExpansion: true }}
       rowActionsError={{
         title: 'Import failed:',

--- a/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -96,7 +96,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <svg
                       aria-hidden="true"
-                      aria-label="More actions"
+                      aria-label="Add"
                       className="bx--btn__icon"
                       focusable="false"
                       height={32}
@@ -241,7 +241,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <svg
                       aria-hidden="true"
-                      aria-label="More actions"
+                      aria-label="Add"
                       className="bx--btn__icon"
                       focusable="false"
                       height={32}
@@ -458,7 +458,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <svg
                       aria-hidden="true"
-                      aria-label="More actions"
+                      aria-label="Add"
                       className="bx--btn__icon"
                       focusable="false"
                       height={32}
@@ -600,7 +600,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <svg
                       aria-hidden="true"
-                      aria-label="More actions"
+                      aria-label="Add"
                       className="bx--btn__icon"
                       focusable="false"
                       height={32}


### PR DESCRIPTION
Closes #1177

**Summary**
The title that appears on hover on the overflow button's menu items is [object, object]. This was due to the fact that the `labelText` prop is used as title in Carbon, but we pass in JSX instead of a string.

**Change List (commits, features, bugs, etc)**
- requiredTitle is only used for string values
- added our own title for JSX menu items
- updated the story for better testing

**Acceptance Test (how to verify the PR)**
1. Go to story watson-iot-table--stateful-example-with-row-nesting-and-fixed-columns
2. Click row action overflow button
3. Verify that all menu items have the correct title on hover
