### PR TITLE
458 table scalability

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -369,7 +369,6 @@ const Table = props => {
       style={style}
       className={classNames(className, `${iotPrefix}--table-container`)}
     >
-      {console.log('render fired')}
       {/* If there is no items being rendered in the toolbar, don't render the toolbar */
       options.hasFilter ||
       options.hasSearch ||
@@ -570,7 +569,10 @@ const Table = props => {
       visibleData &&
       visibleData.length ? ( // don't show pagination row while loading
         <Pagination
-          {...paginationProps}
+          pageSize={paginationProps.pageSize}
+          pageSizes={paginationProps.pageSizes}
+          page={paginationProps.page}
+          isItemPerPageHidden={paginationProps.isItemPerPageHidden}
           totalItems={paginationProps.totalItems < maxPages ? paginationProps.totalItems : maxPages}
           onChange={actions.pagination.onChangePage}
           backwardText={i18n.pageBackwardAria}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -42,6 +42,10 @@ const propTypes = {
   columns: TableColumnsPropTypes.isRequired,
   /** Row value data for the body of the table */
   data: TableRowPropTypes.isRequired,
+  /** Number of total data rows to limit the table by */
+  dataRowLimit: PropTypes.number,
+  /** Callback that is called when table is limited by dataRowLimit prop */
+  dataRowLimitCallback: PropTypes.func,
   /** Expanded data for the table details */
   expandedData: ExpandedRowsPropTypes,
   /** Optional properties to customize how the table should be rendered */
@@ -174,6 +178,8 @@ export const defaultProps = baseProps => ({
   useZebraStyles: false,
   lightweight: false,
   title: null,
+  dataRowLimit: 50,
+  dataRowLimitCallback: null,
   tooltip: null,
   secondaryTitle: null,
   options: {
@@ -197,7 +203,7 @@ export const defaultProps = baseProps => ({
       pageSize: 10,
       pageSizes: [10, 20, 30],
       page: 1,
-      totalItems: baseProps.data && baseProps.data.length,
+      totalItems: 1,
       isItemPerPageHidden: false,
     },
     filters: [],
@@ -288,6 +294,8 @@ const Table = props => {
     id,
     columns,
     data,
+    dataRowLimit,
+    dataRowLimitCallback,
     expandedData,
     locale,
     view,
@@ -304,6 +312,31 @@ const Table = props => {
   } = merge({}, defaultProps(props), props);
 
   const [, forceUpdateCellTextWidth] = useState(0);
+  // const [loadedData, setLoadedData] = useState(data.slice(0, view.pagination.pageSize));
+  // console.log({ loadedData, dataLength: data.length });
+  // useLayoutEffect(
+  //   () => {
+  //     console.log('fired', { dataLength: data.length });
+  //     if (data.length > 1) {
+  //       if (dataRowLimit && data.length > dataRowLimit) {
+  //         setLoadedData(data.slice(0, dataRowLimit));
+  //         // setLoadedData(data);
+  //         console.log('firing off limited data', {
+  //           dataRowLimit,
+  //           lenght: data.length,
+  //           evaluates: dataRowLimit && data.length > dataRowLimit,
+  //         });
+  //       } else {
+  //         setLoadedData(data);
+  //       }
+  //     }
+  //   },
+  //   [data.length, dataRowLimit]
+  // );
+
+  if (dataRowLimitCallback && dataRowLimit && data.length > dataRowLimit) {
+    dataRowLimitCallback();
+  }
 
   const useCellTextTruncate = useMemo(
     () =>
@@ -338,6 +371,8 @@ const Table = props => {
   const maxItemInView =
     options.hasPagination && !options.hasOnlyPageData && view.pagination
       ? view.pagination.page * view.pagination.pageSize
+      : dataRowLimit
+      ? dataRowLimit
       : data.length;
   const visibleData = data.slice(minItemInView, maxItemInView);
 
@@ -365,6 +400,7 @@ const Table = props => {
       style={style}
       className={classNames(className, `${iotPrefix}--table-container`)}
     >
+      {console.log('render fired')}
       {/* If there is no items being rendered in the toolbar, don't render the toolbar */
       options.hasFilter ||
       options.hasSearch ||
@@ -566,6 +602,7 @@ const Table = props => {
       visibleData.length ? ( // don't show pagination row while loading
         <Pagination
           {...view.pagination}
+          totalItems={dataRowLimit || data.length}
           onChange={actions.pagination.onChangePage}
           backwardText={i18n.pageBackwardAria}
           forwardText={i18n.pageForwardAria}
@@ -586,3 +623,10 @@ Table.propTypes = propTypes;
 Table.defaultProps = defaultProps({});
 
 export default Table;
+/*
+
+- dataRowLimit (integer) && in useEffect hoook
+- limit data that is passed to table and pagination total items
+- pop toast
+
+*/

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -200,7 +200,7 @@ export const defaultProps = baseProps => ({
       pageSizes: [10, 20, 30],
       page: 1,
       totalItems: baseProps.data && baseProps.data.length,
-      maxPages: 1000,
+      maxPages: 100,
       isItemPerPageHidden: false,
     },
     filters: [],
@@ -576,7 +576,11 @@ const Table = props => {
           pageSizes={paginationProps.pageSizes}
           page={paginationProps.page}
           isItemPerPageHidden={paginationProps.isItemPerPageHidden}
-          totalItems={paginationProps.totalItems < maxPages ? paginationProps.totalItems : maxPages}
+          totalItems={
+            paginationProps.totalItems < maxPages * paginationProps.pageSize
+              ? paginationProps.totalItems
+              : maxPages * paginationProps.pageSize
+          }
           onChange={actions.pagination.onChangePage}
           backwardText={i18n.pageBackwardAria}
           forwardText={i18n.pageForwardAria}

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -516,6 +516,13 @@ storiesOf('Watson IoT/Table', module)
       <FullWidthWrapper>
         <StatefulTable
           {...initialState}
+          view={{
+            ...initialState.view,
+            pagination: {
+              ...initialState.view.pagination,
+              maxPages: 30,
+            },
+          }}
           secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}
           actions={{
             ...actions,

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -242,7 +242,7 @@ const getNewRow = (idx, suffix = '', withActions = false) => ({
   id: `row-${idx}${suffix ? `_${suffix}` : ''}`,
   values: {
     string: getSentence(idx) + suffix,
-    date: new Date(100000000000 + 1000000000 * idx * idx).toISOString(),
+    date: new Date(100000000000 + 100 * idx * idx).toISOString(),
     select: selectData[idx % 3].id,
     secretField: getString(idx, 10) + suffix,
     number: idx * idx,
@@ -269,9 +269,12 @@ const getNewRow = (idx, suffix = '', withActions = false) => ({
     : undefined,
 });
 
-const tableData = Array(100)
+const tableData = Array(10000)
   .fill(0)
-  .map((i, idx) => getNewRow(idx));
+  .map((i, idx) => {
+    console.log('newRow', { idx });
+    return getNewRow(idx);
+  });
 
 /** Sample expanded row component */
 const RowExpansionContent = ({ rowId }) => (
@@ -804,7 +807,7 @@ storiesOf('Watson IoT/Table', module)
       info: {
         text: `
 
-        This table has editable rows. It is wrapped in a component that handles the state of the table data and 
+        This table has editable rows. It is wrapped in a component that handles the state of the table data and
         the active bar to serve as a simple example of how to use the 'hasRowEdit' functionality with your own data store.
 
         Each column that should have editable row cells must have an editDataFunction prop defined.
@@ -824,16 +827,16 @@ storiesOf('Watson IoT/Table', module)
           toolbar: { onShowRowEdit: () => {
             // Update your state
           } },
-        }        
+        }
 
         options = { hasRowEdit: true }
 
         columns={columns.map(i => ({
           ...i,
-          editDataFunction: () => { 
-            // Your edit data function here.. 
+          editDataFunction: () => {
+            // Your edit data function here..
           },
-        }))}             
+        }))}
 
         The editDataFunction is called with this payload
         {
@@ -872,11 +875,11 @@ storiesOf('Watson IoT/Table', module)
         text: `
 
         For basic table support, you can render the functional <Table/> component with only the columns and data props.  This table does not have any state management built in.  If you want that, use the <StatefulTable/> component or you will need to implement your own listeners and state management.  You can reuse our tableReducer and tableActions with the useReducer hook to update state.
-        
+
         <br />
 
         To enable simple search on a table, simply set the prop options.hasSearch=true.  We wouldn't recommend enabling column filters on a table and simple search for UX reasons, but it is supported.
-        
+
         <br />
 
         Warning: Searching, filtering, and sorting is only enabled for strings, numbers, and booleans.

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -242,7 +242,7 @@ const getNewRow = (idx, suffix = '', withActions = false) => ({
   id: `row-${idx}${suffix ? `_${suffix}` : ''}`,
   values: {
     string: getSentence(idx) + suffix,
-    date: new Date(100000000000 + 100 * idx * idx).toISOString(),
+    date: new Date(100000000000 + 1000000000 * idx * idx).toISOString(),
     select: selectData[idx % 3].id,
     secretField: getString(idx, 10) + suffix,
     number: idx * idx,
@@ -269,12 +269,9 @@ const getNewRow = (idx, suffix = '', withActions = false) => ({
     : undefined,
 });
 
-const tableData = Array(10000)
+const tableData = Array(100)
   .fill(0)
-  .map((i, idx) => {
-    console.log('newRow', { idx });
-    return getNewRow(idx);
-  });
+  .map((i, idx) => getNewRow(idx));
 
 /** Sample expanded row component */
 const RowExpansionContent = ({ rowId }) => (

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -511,7 +511,7 @@ storiesOf('Watson IoT/Table', module)
     }
   )
   .add(
-    'Stateful Example with expansion and column resize',
+    'Stateful Example with expansion, maxPages, and column resize',
     () => (
       <FullWidthWrapper>
         <StatefulTable

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -164,7 +164,7 @@ describe('Table', () => {
         expandedData={expandedData}
         actions={mockActions}
         options={{ hasPagination: true }}
-        view={{ ...view, pagination: { ...view.pagination, maxPages: 50 } }}
+        view={{ ...view, pagination: { ...view.pagination, maxPages: 5 } }}
       />
     );
     expect(wrapper.find('.bx--select-option')).toHaveLength(5);

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -88,6 +88,19 @@ const tableData = Array(20)
     },
   }));
 
+const largeTableData = Array(100)
+  .fill(0)
+  .map((i, idx) => ({
+    id: `row-${idx}`,
+    values: {
+      string: getSentence(idx),
+      node: <Add20 />,
+      date: new Date(100000000000 + 1000000000 * idx * idx).toISOString(),
+      select: selectData[idx % 3].id,
+      number: idx * idx,
+    },
+  }));
+
 const RowExpansionContent = ({ rowId }) => (
   <div key={`${rowId}-expansion`} style={{ padding: 20 }}>
     <h3 key={`${rowId}-title`}>{rowId}</h3>
@@ -141,6 +154,21 @@ describe('Table', () => {
       content: <RowExpansionContent rowId="row-1" />,
     },
   ];
+
+  it('limits the number of pagination select options', () => {
+    // 100 records should have 10 pages. With max pages option we expect 5.
+    const wrapper = mount(
+      <Table
+        columns={tableColumns}
+        data={largeTableData}
+        expandedData={expandedData}
+        actions={mockActions}
+        options={{ hasPagination: true }}
+        view={{ ...view, pagination: { ...view.pagination, maxPages: 50 } }}
+      />
+    );
+    expect(wrapper.find('.bx--select-option')).toHaveLength(5);
+  });
 
   it('handles row collapse', () => {
     const wrapper = mount(

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -370,7 +370,7 @@ Map {
         "filters": Array [],
         "pagination": Object {
           "isItemPerPageHidden": false,
-          "maxPages": 1000,
+          "maxPages": 100,
           "page": 1,
           "pageSize": 10,
           "pageSizes": Array [

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -371,6 +371,7 @@ Map {
         "filters": Array [],
         "pagination": Object {
           "isItemPerPageHidden": false,
+          "maxPages": 1000,
           "page": 1,
           "pageSize": 10,
           "pageSizes": Array [
@@ -950,6 +951,9 @@ Map {
                 Object {
                   "isItemPerPageHidden": Object {
                     "type": "bool",
+                  },
+                  "maxPages": Object {
+                    "type": "number",
                   },
                   "page": Object {
                     "type": "number",


### PR DESCRIPTION
Closes #458 

**Summary**

- There is an issue with our pagination that when the table is loaded with a large data set it will try to make select options for the dropdown for each page. This causes the table to crash and never render. 

**Change List (commits, features, bugs, etc)**

- Introduction of a `maxPages` prop that is passed along with the `view.pagination` object. This prop will limit the amount of pages that the dropdown will try to render. 
- Updated story to include a maxPages prop so we can see the page limit in the story. 


**Acceptance Test (how to verify the PR)**

- Go to [Table story](?path=/story/watson-iot-table--stateful-example-with-expansion-and-column-resize)
- see the pagination size is limited to 2 because of filters.
- Remove filters and see that maxPages is limiting the amount of pages to 3. 
