### PR TITLE
fix(tablecard): update find matching thresholds

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -166,7 +166,7 @@ export const findMatchingThresholds = (thresholds, item, columnId) => {
         case '>':
           return parseFloat(item[dataSourceId]) > value;
         case '=':
-          return parseFloat(item[dataSourceId]) === value;
+          return parseFloat(item[dataSourceId]) === value || item[dataSourceId] === value; // need to handle the string case
         case '<=':
           return !isNil(item[dataSourceId]) && parseFloat(item[dataSourceId]) <= value;
         case '>=':

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -14,12 +14,23 @@ describe('TableCard', () => {
     { comparison: '>', dataSourceId: 'airflow_mean', severity: 1, value: 2.2 },
     { comparison: '>', dataSourceId: 'airflow_max', severity: 3, value: 4 },
     { comparison: '>', dataSourceId: 'airflow_max', severity: 1, value: 4.5 },
+    { comparison: '=', dataSourceId: 'airflow_status', severity: 1, value: 'High' },
   ];
   it('findMatchingThresholds', () => {
     const oneMatchingThreshold = findMatchingThresholds(
       thresholds,
       { airflow_mean: 4 },
       'airflow_mean'
+    );
+    expect(oneMatchingThreshold).toHaveLength(1);
+    // The highest severity should match
+    expect(oneMatchingThreshold[0].severity).toEqual(1);
+  });
+  it('findMatchingThresholds string value', () => {
+    const oneMatchingThreshold = findMatchingThresholds(
+      thresholds,
+      { airflow_status: 'High' },
+      'airflow_status'
     );
     expect(oneMatchingThreshold).toHaveLength(1);
     // The highest severity should match
@@ -458,7 +469,7 @@ describe('TableCard', () => {
           thresholds: customThresholds,
         }}
         values={tableData}
-        size={CARD_SIZES.LARGETHIN}
+        size={CARD_SIZES.LARGE}
       />
     );
 


### PR DESCRIPTION
Closes #1206

**Summary**

- A tablecard threshold could only match a numeric threshold

**Change List (commits, features, bugs, etc)**

- fix(tablecard): support case where threshold value matches exact string

**Acceptance Test (how to verify the PR)**

- Verify that none of the existing table card snapshots have changed, but that the new testcase has passed.
