### PR TITLE
fix(table-card): support links in expanded rows

### DIFF
--- a/src/components/TableCard/TableCard.jsx
+++ b/src/components/TableCard/TableCard.jsx
@@ -230,7 +230,7 @@ export const createColumnsWithFormattedLinks = (columns, cardVariables) => {
         // eslint-disable-next-line react/prop-types
         renderDataFunction: ({ value, row }) => {
           let variableLink;
-          // if we have variables the value based on its own row's context
+          // if we have variables the value is based on its own row's context
           if (variables && variables.length) {
             variableLink = linkTemplate.href;
             variables.forEach(variable => {
@@ -251,6 +251,48 @@ export const createColumnsWithFormattedLinks = (columns, cardVariables) => {
     }
     return column;
   });
+};
+
+/**
+ * Updates expandedRow to have us-able links if any hrefs are found. If href variables are on a table that has row specific values, the user
+ * should not pass in a cardVariables object as each variable with have multiple values.
+ * @param {object} row - Object containing each value present on the row
+ * @param {array} expandedRow - Array of data to display when the row is expanded
+ * @param {object} cardVariables - object of cardVariables
+ * @return {array} Array of data with formatted links to display when the row is expanded
+ */
+export const handleExpandedItemLinks = (row, expandedRow, cardVariables) => {
+  // if the user has given us variable values, we can assume that they don't want them to be row specific
+  if (cardVariables) {
+    return expandedRow;
+  }
+
+  const updatedExpandedRow = [];
+
+  expandedRow.forEach(item => {
+    const { linkTemplate } = item;
+    const variables = linkTemplate?.href ? getVariables(linkTemplate.href) : [];
+    let variableLink;
+    // if we have variables the value is based on its own row's context
+    if (variables && variables.length) {
+      variableLink = linkTemplate.href;
+      variables.forEach(variable => {
+        const variableValue = row[variable];
+        variableLink = variableLink.replace(`{${variable}}`, variableValue);
+      });
+    }
+    if (linkTemplate) {
+      updatedExpandedRow.push({
+        ...item,
+        linkTemplate: {
+          href: variableLink || linkTemplate.href,
+        },
+      });
+    } else {
+      updatedExpandedRow.push(item);
+    }
+  });
+  return updatedExpandedRow;
 };
 
 const TableCard = ({
@@ -608,6 +650,13 @@ const TableCard = ({
               .map(value => expandedRows.filter(item => item.id === value)[0])
               .filter(i => i);
 
+            // add links and link variables to the expandedItem
+            const formattedExpandedItems = handleExpandedItemLinks(
+              dataItem.values,
+              expandedItem,
+              others.cardVariables
+            );
+
             return {
               rowId: dataItem.id,
               content: (
@@ -615,16 +664,35 @@ const TableCard = ({
                   key={`${dataItem.id}-expanded`}
                   className={`${iotPrefix}--table-card--expanded-row-content`}
                 >
-                  {expandedItem.length ? (
-                    expandedItem.map((item, index) => (
+                  {formattedExpandedItems.length ? (
+                    formattedExpandedItems.map((item, index) => (
                       <div
                         key={`${item.id}-expanded-${index}`}
                         className={`${iotPrefix}--table-card--expanded`}
                       >
-                        <p key={`${item.id}-label`} style={{ marginRight: '5px' }}>
-                          {item ? item.label : '--'}
-                        </p>
-                        <span>{item ? dataItem.values[item.id] : null}</span>
+                        {item.linkTemplate ? (
+                          <>
+                            <p key={`${item.id}-label`} style={{ marginRight: '5px' }}>
+                              {item ? item.label : '--'}
+                            </p>
+                            <Link
+                              key={`${item.id}-link`}
+                              href={item.linkTemplate.href}
+                              target={item.linkTemplate.target ? item.linkTemplate.target : null}
+                            >
+                              {dataItem.values[item.id]}
+                            </Link>
+                          </>
+                        ) : (
+                          <>
+                            <p key={`${item.id}-label`} style={{ marginRight: '5px' }}>
+                              {item ? item.label : '--'}
+                            </p>
+                            <span key={`${item.id}-value`}>
+                              {item ? dataItem.values[item.id] : null}
+                            </span>
+                          </>
+                        )}
                       </div>
                     ))
                   ) : (
@@ -641,7 +709,7 @@ const TableCard = ({
             };
           })
         : [],
-    [expandedRows, tableData]
+    [expandedRows, others.cardVariables, tableData]
   );
 
   // is columns recieved is different from the columnsToRender show card expand

--- a/src/components/TableCard/TableCard.story.jsx
+++ b/src/components/TableCard/TableCard.story.jsx
@@ -617,6 +617,101 @@ storiesOf('Watson IoT/TableCard', module)
       </div>
     );
   })
+  .add(
+    'table with row expansion and link variables',
+    () => {
+      const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
+
+      return (
+        <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+          <TableCard
+            title="Open Alerts"
+            id="table-list"
+            tooltip="Here's a Tooltip"
+            content={{
+              columns: tableColumns,
+              expandedRows: [
+                {
+                  id: 'long_description',
+                  label: 'Description',
+                  linkTemplate: {
+                    href: text('href', 'http://ibm.com/{variable}'),
+                  },
+                },
+                {
+                  id: 'other_description',
+                  label: 'Other content to show',
+                },
+              ],
+            }}
+            values={tableData}
+            cardVariables={object('Dynamic link variable', {
+              variable: 'variable-value',
+            })}
+            onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
+            size={size}
+          />
+        </div>
+      );
+    },
+    {
+      info: {
+        text: ` # Passing variables
+      To pass a variable into your card, identify a variable to be used by wrapping it in curly brackets.
+      Make sure you have added a prop called 'cardVariables' to your card that is an object with key value pairs such that the key is the variable name and the value is the value to replace it with.
+      Optionally you may use a callback as the cardVariables value that will be given the variable and the card as arguments.
+      Note: if using row-specific variables in a TableCard href (ie a variable that has a different value per row),
+            do NOT pass the cardVariables prop and be sure that your table has reference to the proper value in another column
+      `,
+      },
+    }
+  )
+  .add(
+    'table with row expansion and row specific link variables',
+    () => {
+      const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
+
+      return (
+        <div style={{ width: `${getCardMinSize('lg', size).x}px`, margin: 20 }}>
+          <TableCard
+            title="Open Alerts"
+            id="table-list"
+            tooltip="Here's a Tooltip"
+            content={{
+              columns: tableColumns,
+              expandedRows: [
+                {
+                  id: 'long_description',
+                  label: 'Description',
+                  linkTemplate: {
+                    href: text('href', 'http://ibm.com/{pressure}'),
+                  },
+                },
+                {
+                  id: 'other_description',
+                  label: 'Other content to show',
+                },
+              ],
+            }}
+            values={tableData}
+            onCardAction={(id, type, payload) => action('onCardAction', id, type, payload)}
+            size={size}
+          />
+        </div>
+      );
+    },
+    {
+      info: {
+        text: ` # Passing variables
+      To pass a variable into your card, identify a variable to be used by wrapping it in curly brackets.
+      Make sure you have added a prop called 'cardVariables' to your card that is an object with key value pairs such that the key is the variable name and the value is the value to replace it with.
+      Optionally you may use a callback as the cardVariables value that will be given the variable and the card as arguments.
+      Note: if using row-specific variables in a TableCard href (ie a variable that has a different value per row),
+            do NOT pass the cardVariables prop and be sure that your table has reference to the proper value in another column
+      `,
+      },
+    }
+  )
   .add('no row actions', () => {
     const size = select('size', [CARD_SIZES.LARGE, CARD_SIZES.LARGEWIDE], CARD_SIZES.LARGE);
 

--- a/src/components/TableCard/TableCard.test.jsx
+++ b/src/components/TableCard/TableCard.test.jsx
@@ -6,7 +6,11 @@ import '@testing-library/jest-dom';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 import { tableColumns, tableData, actions2, tableColumnsWithLinks } from '../../utils/sample';
 
-import TableCard, { findMatchingThresholds, createColumnsWithFormattedLinks } from './TableCard';
+import TableCard, {
+  findMatchingThresholds,
+  createColumnsWithFormattedLinks,
+  handleExpandedItemLinks,
+} from './TableCard';
 
 describe('TableCard', () => {
   const thresholds = [
@@ -69,6 +73,64 @@ describe('TableCard', () => {
     const columnsWithFormattedLinks = createColumnsWithFormattedLinks(tableColumnsWithLinks);
     const columnsWithlinks = columnsWithFormattedLinks.filter(column => column.renderDataFunction);
     expect(columnsWithlinks).toHaveLength(1);
+  });
+  it('handleExpandedItemLinks correctly applies linkTemplates and variables', () => {
+    const row = {
+      alert: 'some-alert',
+      count: 6,
+      hour: 126432112000,
+      pressure: 3,
+      deviceId: 73000,
+    };
+    const expandedRow = [
+      {
+        id: 'count',
+        label: 'Count',
+      },
+      {
+        id: 'deviceId',
+        label: 'Device link',
+        linkTemplate: {
+          href: 'http://ibm.com/{deviceId}',
+        },
+      },
+      {
+        id: 'alert',
+        label: 'Alert Description',
+        linkTemplate: {
+          href: 'http://ibm.com/',
+        },
+      },
+    ];
+    const cardVariables = {
+      variable: 'variable-value',
+    };
+
+    // with row specific variables
+    const updatedRowSpecificExpandedItems = handleExpandedItemLinks(row, expandedRow);
+    expect(updatedRowSpecificExpandedItems).toEqual([
+      {
+        id: 'count',
+        label: 'Count',
+      },
+      {
+        id: 'deviceId',
+        label: 'Device link',
+        linkTemplate: {
+          href: 'http://ibm.com/73000',
+        },
+      },
+      {
+        id: 'alert',
+        label: 'Alert Description',
+        linkTemplate: {
+          href: 'http://ibm.com/',
+        },
+      },
+    ]);
+    // if cardVariables are given, then this function should return its original data
+    const updatedExpandedItems = handleExpandedItemLinks(row, expandedRow, cardVariables);
+    expect(updatedExpandedItems).toEqual(expandedRow);
   });
   it('Row specific link variables populate correctly', () => {
     const tableLinkColumns = [

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -7261,8 +7261,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-32"
-                  id="bx-pagination-select-32-count-label"
+                  htmlFor="bx-pagination-select-34"
+                  id="bx-pagination-select-34-count-label"
                 >
                   Items per page:
                 </label>
@@ -7281,7 +7281,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32"
+                          id="bx-pagination-select-34"
                           onChange={[Function]}
                           value={10}
                         >
@@ -7345,7 +7345,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-32-right"
+                      htmlFor="bx-pagination-select-34-right"
                     >
                       Page number, of 1 pages
                     </label>
@@ -7358,7 +7358,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-32-right"
+                          id="bx-pagination-select-34-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -8959,8 +8959,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-33"
-                  id="bx-pagination-select-33-count-label"
+                  htmlFor="bx-pagination-select-35"
+                  id="bx-pagination-select-35-count-label"
                 >
                   Items per page:
                 </label>
@@ -8979,7 +8979,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33"
+                          id="bx-pagination-select-35"
                           onChange={[Function]}
                           value={10}
                         >
@@ -9043,7 +9043,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-33-right"
+                      htmlFor="bx-pagination-select-35-right"
                     >
                       Page number, of 1 pages
                     </label>
@@ -9056,7 +9056,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-33-right"
+                          id="bx-pagination-select-35-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -12098,8 +12098,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-34"
-                  id="bx-pagination-select-34-count-label"
+                  htmlFor="bx-pagination-select-36"
+                  id="bx-pagination-select-36-count-label"
                 >
                   Items per page:
                 </label>
@@ -12118,7 +12118,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34"
+                          id="bx-pagination-select-36"
                           onChange={[Function]}
                           value={10}
                         >
@@ -12182,7 +12182,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-34-right"
+                      htmlFor="bx-pagination-select-36-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -12195,7 +12195,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-34-right"
+                          id="bx-pagination-select-36-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -13511,8 +13511,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <label
                   className="bx--pagination__text"
-                  htmlFor="bx-pagination-select-31"
-                  id="bx-pagination-select-31-count-label"
+                  htmlFor="bx-pagination-select-33"
+                  id="bx-pagination-select-33-count-label"
                 >
                   Items per page:
                 </label>
@@ -13531,7 +13531,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31"
+                          id="bx-pagination-select-33"
                           onChange={[Function]}
                           value={10}
                         >
@@ -13595,7 +13595,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   >
                     <label
                       className="bx--label bx--visually-hidden"
-                      htmlFor="bx-pagination-select-31-right"
+                      htmlFor="bx-pagination-select-33-right"
                     >
                       Page number, of 2 pages
                     </label>
@@ -13608,7 +13608,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       >
                         <select
                           className="bx--select-input"
-                          id="bx-pagination-select-31-right"
+                          id="bx-pagination-select-33-right"
                           onChange={[Function]}
                           value={1}
                         >
@@ -20368,6 +20368,3460 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <select
                           className="bx--select-input"
                           id="bx-pagination-select-30-right"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polygon
+                      points="20,24 10,16 20,8"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polygon
+                      points="12,8 22,16 12,24"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and link variables 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="table-list"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-0 hICOrC iot--table-container bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions iot--table-batch-actions"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-table-for-card-table-list"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="8.5,11 8.5,6.5 6.5,6.5 6.5,7.5 7.5,7.5 7.5,11 6,11 6,12 10,12 10,11"
+                      />
+                      <path
+                        d="M8,3.5c-0.4,0-0.8,0.3-0.8,0.8S7.6,5,8,5c0.4,0,0.8-0.3,0.8-0.8S8.4,3.5,8,3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+              >
+                <div
+                  className="iot--table-toolbar-search"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
+                >
+                  <div
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    tabIndex="0"
+                  >
+                    <div
+                      aria-labelledby="table-for-card-table-list-toolbar-search-search"
+                      className="bx--search bx--search--sm table-toolbar-search"
+                      role="search"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--search-magnifier"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                        />
+                      </svg>
+                      <label
+                        className="bx--label"
+                        htmlFor="table-for-card-table-list-toolbar-search"
+                        id="table-for-card-table-list-toolbar-search-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="table-for-card-table-list-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        tabIndex="-1"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="24 9.4 22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="download-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Download table content"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    />
+                    <path
+                      d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="filter-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--card--toolbar"
+                >
+                  <div
+                    className="iot--card--toolbar-date-range-wrapper"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="iot--card--toolbar-action iot--card--toolbar-date-range-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                      title="Open and close list of options"
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={20}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                        />
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        />
+                        <path
+                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      description="Expand to fullscreen"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      title="Expand to fullscreen"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                      />
+                      <path
+                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <table
+                className="bx--data-table bx--data-table--no-border"
+                title={null}
+              >
+                <thead
+                  onMouseMove={null}
+                  onMouseUp={null}
+                >
+                  <tr>
+                    <th
+                      className="bx--table-expand"
+                      scope="col"
+                    />
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="alert"
+                        id="column-alert"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Alert"
+                          >
+                            Alert
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="hour"
+                        id="column-hour"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Hour"
+                          >
+                            Hour
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="pressure"
+                        id="column-pressure"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Pressure"
+                          >
+                            Pressure
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  aria-live="polite"
+                >
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="1"
+                        >
+                          1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI005 Asset failure"
+                        >
+                          AHI005 Asset failure
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI003 process need to optimize adjust X variables"
+                        >
+                          AHI003 process need to optimize adjust X variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="2"
+                        >
+                          2
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize."
+                        >
+                          AHI001 proccess need to optimize.
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="68"
+                        >
+                          68
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10"
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize"
+                        >
+                          AHI001 proccess need to optimize
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10"
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              disabled={false}
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-31"
+                  id="bx-pagination-select-31-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-31"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-31-right"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-31-right"
+                          onChange={[Function]}
+                          value={1}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={1}
+                          >
+                            1
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={2}
+                          >
+                            2
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1 of 2 pages
+                </span>
+                <button
+                  aria-label="Previous page"
+                  className="bx--pagination__button bx--pagination__button--backward bx--pagination__button--no-index"
+                  disabled={true}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polygon
+                      points="20,24 10,16 20,8"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Next page"
+                  className="bx--pagination__button bx--pagination__button--forward"
+                  disabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polygon
+                      points="12,8 22,16 12,24"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/TableCard table with row expansion and row specific link variables 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="table-list"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "624px",
+          }
+        }
+      >
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "576px",
+            }
+          }
+        >
+          <div
+            className="TableCard__StyledStatefulTable-q9l5bz-0 hICOrC iot--table-container bx--data-table-container"
+          >
+            <section
+              aria-label="data table toolbar"
+              className="bx--table-toolbar"
+            >
+              <div
+                className="bx--batch-actions iot--table-batch-actions"
+              >
+                <div
+                  className="bx--action-list"
+                >
+                  <button
+                    className="bx--batch-summary__cancel bx--btn bx--btn--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+                <div
+                  className="bx--batch-summary"
+                >
+                  <p
+                    className="bx--batch-summary__para"
+                  >
+                    <span>
+                      0 item selected
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <label
+                className="iot--table-toolbar-secondary-title"
+              >
+                Open Alerts
+              </label>
+              <div
+                className="iot--table-tooltip-container"
+              >
+                <div
+                  className="bx--tooltip__label"
+                  id="card-tooltip-trigger-table-for-card-table-list"
+                >
+                  
+                  <div
+                    aria-describedby={null}
+                    className="bx--tooltip__trigger"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      description={null}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      role={null}
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="8.5,11 8.5,6.5 6.5,6.5 6.5,7.5 7.5,7.5 7.5,11 6,11 6,12 10,12 10,11"
+                      />
+                      <path
+                        d="M8,3.5c-0.4,0-0.8,0.3-0.8,0.8S7.6,5,8,5c0.4,0,0.8-0.3,0.8-0.8S8.4,3.5,8,3.5z"
+                      />
+                      <path
+                        d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--toolbar-content iot--table-toolbar-content"
+              >
+                <div
+                  className="iot--table-toolbar-search"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex="-1"
+                >
+                  <div
+                    className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    tabIndex="0"
+                  >
+                    <div
+                      aria-labelledby="table-for-card-table-list-toolbar-search-search"
+                      className="bx--search bx--search--sm table-toolbar-search"
+                      role="search"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="bx--search-magnifier"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                        />
+                      </svg>
+                      <label
+                        className="bx--label"
+                        htmlFor="table-for-card-table-list-toolbar-search"
+                        id="table-for-card-table-list-toolbar-search-search"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-hidden={true}
+                        autoComplete="off"
+                        className="bx--search-input"
+                        id="table-for-card-table-list-toolbar-search"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        placeholder="Search"
+                        role="searchbox"
+                        tabIndex="-1"
+                        type="text"
+                        value=""
+                      />
+                      <button
+                        aria-label="Clear search input"
+                        className="bx--search-close bx--search-close--hidden"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="24 9.4 22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="download-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Download table content"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    />
+                    <path
+                      d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--tooltip-svg-wrapper"
+                  data-testid="filter-button"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    description="Filters"
+                    focusable="false"
+                    height={20}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 32 32"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M18,28H14a2,2,0,0,1-2-2V18.41L4.59,11A2,2,0,0,1,4,9.59V6A2,2,0,0,1,6,4H26a2,2,0,0,1,2,2V9.59A2,2,0,0,1,27.41,11L20,18.41V26A2,2,0,0,1,18,28ZM6,6V9.59l8,8V26h4V17.59l8-8V6Z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  className="iot--card--toolbar"
+                >
+                  <div
+                    className="iot--card--toolbar-date-range-wrapper"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="iot--card--toolbar-action iot--card--toolbar-date-range-action bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                      title="Open and close list of options"
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={20}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={20}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
+                        />
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        />
+                        <path
+                          d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                  <button
+                    className="iot--card--toolbar-action iot--card--toolbar-svg-wrapper"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      description="Expand to fullscreen"
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      role="img"
+                      title="Expand to fullscreen"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M28,4H10A2.0059,2.0059,0,0,0,8,6V20a2.0059,2.0059,0,0,0,2,2H28a2.0059,2.0059,0,0,0,2-2V6A2.0059,2.0059,0,0,0,28,4Zm0,16H10V6H28Z"
+                      />
+                      <path
+                        d="M18,26H4V16H6V14H4a2.0059,2.0059,0,0,0-2,2V26a2.0059,2.0059,0,0,0,2,2H18a2.0059,2.0059,0,0,0,2-2V24H18Z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </section>
+            <div
+              className="addons-iot-table-container"
+            >
+              <table
+                className="bx--data-table bx--data-table--no-border"
+                title={null}
+              >
+                <thead
+                  onMouseMove={null}
+                  onMouseUp={null}
+                >
+                  <tr>
+                    <th
+                      className="bx--table-expand"
+                      scope="col"
+                    />
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="alert"
+                        id="column-alert"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Alert"
+                          >
+                            Alert
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="hour"
+                        id="column-hour"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Hour"
+                          >
+                            Hour
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      scope="col"
+                      style={
+                        Object {
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <button
+                        align="start"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        data-column="pressure"
+                        id="column-pressure"
+                        onClick={[Function]}
+                        width=""
+                      >
+                        <span
+                          className="bx--table-header-label"
+                        >
+                          <span
+                            className=""
+                            title="Pressure"
+                          >
+                            Pressure
+                          </span>
+                        </span>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          />
+                        </svg>
+                        <svg
+                          aria-label="Sort rows by this header in ascending order"
+                          className="bx--table-sort__icon-unsorted"
+                          focusable="false"
+                          height={20}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 32 32"
+                          width={20}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  aria-live="polite"
+                >
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-11-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="1"
+                        >
+                          1
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI010 proccess need to optimize adjust Y variables"
+                        >
+                          AHI010 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-10-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI005 Asset failure"
+                        >
+                          AHI005 Asset failure
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-1-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI003 process need to optimize adjust X variables"
+                        >
+                          AHI003 process need to optimize adjust X variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-2-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="2"
+                        >
+                          2
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize."
+                        >
+                          AHI001 proccess need to optimize.
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-6-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="68"
+                        >
+                          68
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-4-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-8-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-9-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="0"
+                        >
+                          0
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize adjust Y variables"
+                        >
+                          AHI001 proccess need to optimize adjust Y variables
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-3-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10"
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <tr
+                    className="bx--parent-row iot--expanded-tablerow TableBodyRow__StyledTableExpandRow-sc-103itxu-2 dndkEF"
+                    data-child-count={0}
+                    data-nesting-offset={0}
+                    data-parent-row={true}
+                    data-row-nesting={false}
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="bx--table-expand"
+                      headers="expand"
+                    >
+                      <button
+                        aria-label="Click to expand content"
+                        className="bx--table-expand__button"
+                        onClick={[Function]}
+                        title="Click to expand content"
+                      >
+                        <svg
+                          aria-label="Click to expand content"
+                          className="bx--table-expand__svg"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3"
+                          />
+                        </svg>
+                      </button>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="alert"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-alert"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="AHI001 proccess need to optimize"
+                        >
+                          AHI001 proccess need to optimize
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="hour"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-hour"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10/28/2018 07:34"
+                        >
+                          10/28/2018 07:34
+                        </span>
+                      </span>
+                    </td>
+                    <td
+                      align="start"
+                      className="data-table-start"
+                      data-column="pressure"
+                      data-offset={0}
+                      id="cell-table-for-card-table-list-row-5-pressure"
+                      offset={0}
+                      width=""
+                    >
+                      <span
+                        className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
+                      >
+                        <span
+                          className=""
+                          title="10"
+                        >
+                          10
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              className="bx--pagination iot--pagination iot--pagination--hide-page"
+              disabled={false}
+              style={
+                Object {
+                  "--pagination-text-display": "flex",
+                }
+              }
+            >
+              <div
+                className="bx--pagination__left"
+              >
+                <label
+                  className="bx--pagination__text"
+                  htmlFor="bx-pagination-select-32"
+                  id="bx-pagination-select-32-count-label"
+                >
+                  Items per page:
+                </label>
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__item-count"
+                  >
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-32"
+                          onChange={[Function]}
+                          value={10}
+                        >
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={10}
+                          >
+                            10
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={25}
+                          >
+                            25
+                          </option>
+                          <option
+                            className="bx--select-option"
+                            disabled={false}
+                            hidden={false}
+                            value={100}
+                          >
+                            100
+                          </option>
+                        </select>
+                        <svg
+                          aria-hidden={true}
+                          className="bx--select__arrow"
+                          focusable="false"
+                          height={16}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polygon
+                            points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className="bx--pagination__text"
+                >
+                  1–10 of 11 items
+                </span>
+              </div>
+              <div
+                className="bx--pagination__right"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select bx--select--inline bx--select__page-number"
+                  >
+                    <label
+                      className="bx--label bx--visually-hidden"
+                      htmlFor="bx-pagination-select-32-right"
+                    >
+                      Page number, of 2 pages
+                    </label>
+                    <div
+                      className="bx--select-input--inline__wrapper"
+                    >
+                      <div
+                        className="bx--select-input__wrapper"
+                        data-invalid={null}
+                      >
+                        <select
+                          className="bx--select-input"
+                          id="bx-pagination-select-32-right"
                           onChange={[Function]}
                           value={1}
                         >


### PR DESCRIPTION
Closes #1216 

**Summary**

Add a handleExpandedItemLinks function to update expanded row data with links

**Change List (commits, features, bugs, etc)**

Add HandleExpandedItemLinks function
Add stories and test cases

**Acceptance Test (how to verify the PR)**

In the stories `table with row expansion and link variables` and `table with row expansion and row specific link variables`, verify that the links in the expanded rows navigate you to a new page based on the href value in the expanded rows data.

Fill in row specific variables (ie 'count', 'pressure', 'hour', or 'alert') in the href knob to see the link dynamically change based on row context.

![Screen Shot 2020-05-22 at 2 52 39 PM](https://user-images.githubusercontent.com/53092833/82706717-fb3a5c00-9c3f-11ea-8852-d9c52262a955.png)

