### PR TITLE
fix(table): keyboard navigation not working on row actions

### DIFF
--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -168,7 +168,9 @@ class RowActionsCell extends React.Component {
       inProgressText,
     } = this.props;
     const { isOpen, ltr } = this.state;
-    const hasOverflow = actions && actions.filter(action => action.isOverflow).length > 0;
+    const overflowActions = actions ? actions.filter(action => action.isOverflow) : [];
+    const hasOverflow = overflowActions.length > 0;
+    const firstSelectableItemIndex = overflowActions.findIndex(action => !action.disabled);
     return actions && actions.length > 0 ? (
       <StyledTableCell key={`${id}-row-actions-cell`}>
         <RowActionsContainer
@@ -224,33 +226,33 @@ class RowActionsCell extends React.Component {
                     onOpen={this.handleOpen}
                     onClose={this.handleClose}
                   >
-                    {actions
-                      .filter(action => action.isOverflow)
-                      .map(action => (
-                        <OverflowMenuItem
-                          className={`${iotPrefix}--action-overflow-item`}
-                          key={`${id}-row-actions-button-${action.id}`}
-                          onClick={e => onClick(e, id, action.id, onApplyRowAction)}
-                          requireTitle={!action.renderIcon}
-                          hasDivider={action.hasDivider}
-                          isDelete={action.isDelete}
-                          itemText={
-                            action.renderIcon ? (
-                              <OverflowMenuContent title={action.labelText}>
-                                {typeof action.renderIcon === 'string' ? (
-                                  <Icon icon={action.renderIcon} description={action.labelText} />
-                                ) : (
-                                  <action.renderIcon description={action.labelText} />
-                                )}
-                                {action.labelText}
-                              </OverflowMenuContent>
-                            ) : (
-                              action.labelText
-                            )
-                          }
-                          disabled={action.disabled}
-                        />
-                      ))}
+                    {overflowActions.map((action, actionIndex) => (
+                      <OverflowMenuItem
+                        // We need to focus a MenuItem for the keyboard navigation to work
+                        primaryFocus={actionIndex === firstSelectableItemIndex}
+                        className={`${iotPrefix}--action-overflow-item`}
+                        key={`${id}-row-actions-button-${action.id}`}
+                        onClick={e => onClick(e, id, action.id, onApplyRowAction)}
+                        requireTitle={!action.renderIcon}
+                        hasDivider={action.hasDivider}
+                        isDelete={action.isDelete}
+                        itemText={
+                          action.renderIcon ? (
+                            <OverflowMenuContent title={action.labelText}>
+                              {typeof action.renderIcon === 'string' ? (
+                                <Icon icon={action.renderIcon} description={action.labelText} />
+                              ) : (
+                                <action.renderIcon description={action.labelText} />
+                              )}
+                              {action.labelText}
+                            </OverflowMenuContent>
+                          ) : (
+                            action.labelText
+                          )
+                        }
+                        disabled={action.disabled}
+                      />
+                    ))}
                   </StyledOverflowMenu>
                 ) : null}
               </Fragment>

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
@@ -92,4 +92,30 @@ describe('RowActionsCell', () => {
     );
     expect(container).toHaveLength(0);
   });
+
+  it('autoselects the first enabled alternative when the overflow menu is opened', () => {
+    const actions = [
+      { disabled: true, id: 'add', isOverflow: true, labelText: 'Add' },
+      { disabled: false, id: 'edit', renderIcon: Edit16, isOverflow: true, labelText: 'Edit' },
+    ];
+
+    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
+    const container = wrapper.find(
+      `.${iotPrefix}--row-actions-container .${iotPrefix}--row-actions-container__background--overflow-menu-open`
+    );
+    expect(container).toHaveLength(0);
+
+    const overflowMenu = wrapper.find('OverflowMenu');
+    overflowMenu.simulate('click');
+    overflowMenu.props().onOpen();
+    wrapper.update();
+    const menuItems = wrapper.find(
+      `.${iotPrefix}--row-actions-container .${iotPrefix}--action-overflow-item`
+    );
+    const firstMenuOption = menuItems.first();
+    const firstEnabledMenuOption = menuItems.at(2);
+
+    expect(firstMenuOption.props().primaryFocus).toEqual(false);
+    expect(firstEnabledMenuOption.props().primaryFocus).toEqual(true);
+  });
 });

--- a/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -66,7 +66,7 @@
     @include backgroundGradient($hover-selected-ui);
   }
 
-  &.bx--data-table--selected:not(:hover) {
+  &.#{$prefix}--data-table--selected:not(:hover) {
     .#{$iot-prefix}--row-actions-container__background--overflow-menu-open,
     .#{$iot-prefix}--row-actions-container__background:focus-within {
       @include backgroundGradient($carbon--gray-20);

--- a/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -45,6 +45,12 @@
   }
 }
 
+.#{$iot-prefix}--row-actions-container__background:focus-within {
+  opacity: 1;
+  @include backgroundGradient($ui-01);
+  transition: opacity $duration--fast-02 motion(entrance, productive);
+}
+
 .#{$prefix}--data-table tbody tr:hover .#{$iot-prefix}--row-actions-container__background,
 .#{$iot-prefix}--row-actions-container__background--overflow-menu-open {
   opacity: 1;
@@ -60,9 +66,11 @@
     @include backgroundGradient($hover-selected-ui);
   }
 
-  &.bx--data-table--selected:not(:hover)
-    .#{$iot-prefix}--row-actions-container__background--overflow-menu-open {
-    @include backgroundGradient($carbon--gray-20);
+  &.bx--data-table--selected:not(:hover) {
+    .#{$iot-prefix}--row-actions-container__background--overflow-menu-open,
+    .#{$iot-prefix}--row-actions-container__background:focus-within {
+      @include backgroundGradient($carbon--gray-20);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1217

**Summary**
Keyboard navigation fixed for row actions in overflow button.

**Change List (commits, features, bugs, etc)**
- made sure overflow button is visible when it has focus
- preselect a menu item so that keyboard navigation works when opening the overflow menu using keyboard (enter key when focused)
- add unit tests

**Acceptance Test (how to verify the PR)**
1. Go to story [watson-iot-table--stateful-example-with-expansion-and-column-resize](https://deploy-preview-1221--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--stateful-example-with-expansion-maxpages-and-column-resize)
2. Click on a row or use tab to navigate to a row. 
3. Verify that the you can use tab to focus the row actions overflow button and that it becomes visible
4. Press "enter" or "space" to open the menu
5. Verify that it is possible to navigate the menu using the keyboard (arrow up/down)
6. Select an item using the keyboard (enter/space) and verify that it was triggered in the 
