### PR TITLE
1222- Add info to Max Pages story

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -525,7 +525,7 @@ storiesOf('Watson IoT/Table', module)
             ...initialState.view,
             pagination: {
               ...initialState.view.pagination,
-              maxPages: 30,
+              maxPages: 5,
             },
           }}
           secondaryTitle={text('Secondary Title', `Row count: ${initialState.data.length}`)}

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -563,6 +563,12 @@ storiesOf('Watson IoT/Table', module)
           hasRowExpansion:true
         }
 
+        view={{
+          pagination: {
+            maxPages: 5,
+          }
+        }}
+
         ~~~
 
         <br />


### PR DESCRIPTION
Closes #1222 

**Summary**

Our current story does not show off the `maxPages` feature. This PR lowers the threshold and adds the prop to the info section of the story.  

**Change List (commits, features, bugs, etc)**

- Changed the `maxPages` to 5 and added the prop to the info section in the `table.story.jsx`

**Acceptance Test (how to verify the PR)**

- Go to [this story](https://deploy-preview-1223--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--stateful-example-with-expansion-maxpages-and-column-resize)
- Clear filter
- See that the pages in the pagination select dropdown equal 5
