### PR TITLE
fix(table): filter dropdown overflow should be visible

### DIFF
--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -17,7 +17,6 @@ const StyledTableHeader = styled(({ isSelectColumn, ...others }) => <TableHeader
   &&& {
     span.bx--table-header-label {
       padding-top: 0;
-      overflow: inherit;
     }
 
     .bx--form-item input {

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -17,6 +17,7 @@ const StyledTableHeader = styled(({ isSelectColumn, ...others }) => <TableHeader
   &&& {
     span.bx--table-header-label {
       padding-top: 0;
+      overflow: inherit;
     }
 
     .bx--form-item input {

--- a/src/components/Table/TableHead/_table-head.scss
+++ b/src/components/Table/TableHead/_table-head.scss
@@ -71,7 +71,7 @@
     min-width: 40px;
   }
 
-  .#{$iot-prefix}--tableheader-filter > #{$prefix}--table-header-label {
+  .#{$iot-prefix}--table-header-filter > #{$prefix}--table-header-label {
     overflow: visible;
   }
 }


### PR DESCRIPTION
Closes #1108

**Summary**

- super small fix, just needed to override an `overflow: hidden` coming from Carbon styles.