### PR TITLE
Migrate TileCatalogNew to grid

### DIFF
--- a/src/components/TileCatalogNew/TileCatalogNew.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.jsx
@@ -40,6 +40,7 @@ const propTypes = {
   /** Set to true if filter is needed */
   i18n: PropTypes.shape({
     placeHolderText: PropTypes.string,
+    error: PropTypes.string,
   }),
 };
 
@@ -55,7 +56,7 @@ const defaultProps = {
   minTileWidth: null,
   numColumns: 3,
   numRows: 3,
-  i18n: { searchPlaceHolderText: 'Enter a value' },
+  i18n: { searchPlaceHolderText: 'Enter a value', error: 'An error has occurred' },
 };
 
 const TileCatalogNew = ({
@@ -113,14 +114,6 @@ const TileCatalogNew = ({
 
   return (
     <div className={className}>
-      {/* <div>
-        {persistentSearch ? (
-          <div className="tile-catalog--persistent-search">
-            <Search placeHolderText="" onChange="'" size="sm" value="" labelText="" />
-          </div>
-        ) : null}
-        <div />
-      </div> */}
       <div className={`${iotPrefix}--tile-catalog--canvas-container`}>
         <div className={`${iotPrefix}--tile-catalog--tile-canvas`}>
           {/* {featuredTile ? (
@@ -161,7 +154,7 @@ const TileCatalogNew = ({
               {error || (
                 <>
                   <Bee32 />
-                  <p>An error has occurred</p>
+                  <p>{i18n.error}</p>
                 </>
               )}
             </Tile>

--- a/src/components/TileCatalogNew/TileCatalogNew.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.jsx
@@ -76,29 +76,6 @@ const TileCatalogNew = ({
   className,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
-  // const [tileHeight, setTileHeight] = useState(0);
-
-  // const onSize = ({ height }) => {
-  //   setTileHeight(height);
-  // };
-
-  // const HeightMonitor = sizeMe({
-  //   monitorHeight: true,
-  // })(({ content }) => <div>{content}</div>);
-
-  // const getTile = (rowIdx, colIdx) => {
-  //   const numTilesPerPage = numRows * numColumns;
-  //   const tileIndex = rowIdx * numColumns + colIdx + (currentPage - 1) * numTilesPerPage;
-
-  //   if (tileIndex === 0) {
-  //     return <HeightMonitor content={tiles[0]} onSize={onSize} />;
-  //   }
-  //   return tiles[tileIndex] !== undefined ? (
-  //     tiles[tileIndex]
-  //   ) : (
-  //     <div style={{ height: tileHeight }} />
-  //   );
-  // };
 
   // determine how many tiles to render per page
   const isInCurrentPageRange = i =>

--- a/src/components/TileCatalogNew/TileCatalogNew.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.jsx
@@ -12,7 +12,7 @@ const { iotPrefix } = settings;
 
 const propTypes = {
   /** Title for the product */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   /** Min width of each tile if no col/row nums are specified */
   minTileWidth: PropTypes.string,
   /** Number of columns to be rendered per page */
@@ -45,6 +45,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  title: '',
   hasSort: false,
   hasSearch: false,
   onSearch: () => {},
@@ -125,7 +126,11 @@ const TileCatalogNew = ({
             </div>
           ) : null} */}
           <div className={`${iotPrefix}--tile-catalog--tile-canvas--header`}>
-            <div className={`${iotPrefix}--tile-catalog--tile-canvas--header--title`}> {title}</div>
+            {title ? (
+              <div className={`${iotPrefix}--tile-catalog--tile-canvas--header--title`}>
+                {title}
+              </div>
+            ) : null}
             {hasSearch ? (
               <TableToolbarSearch
                 placeHolderText={i18n.searchPlaceHolderText}

--- a/src/components/TileCatalogNew/TileCatalogNew.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.jsx
@@ -57,7 +57,10 @@ const defaultProps = {
   minTileWidth: null,
   numColumns: 3,
   numRows: 3,
-  i18n: { searchPlaceHolderText: 'Enter a value', error: 'An error has occurred' },
+  i18n: {
+    searchPlaceHolderText: 'Enter a value',
+    error: 'An error has occurred. Please make sure your catalog has content.',
+  },
 };
 
 const TileCatalogNew = ({
@@ -156,12 +159,10 @@ const TileCatalogNew = ({
             <div className={`${iotPrefix}--tile-catalog--tile-canvas--content`}>{renderGrid()}</div>
           ) : (
             <Tile className={`${iotPrefix}--tile-catalog--empty-tile`}>
-              {error || (
-                <>
-                  <Bee32 />
-                  <p>{i18n.error}</p>
-                </>
-              )}
+              <>
+                <Bee32 />
+                <p>{error || i18n.error}</p>
+              </>
             </Tile>
           )}
 

--- a/src/components/TileCatalogNew/TileCatalogNew.story.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.story.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { number, boolean } from '@storybook/addon-knobs';
+import { number, boolean, text } from '@storybook/addon-knobs';
 
 import TileCatalogNew from './TileCatalogNew';
 import SampleTile from './SampleTile';
@@ -25,8 +25,8 @@ const getTiles = num => {
 };
 
 storiesOf('Watson IoT Experimental/TileCatalogNew', module)
-  .add('Base', () => {
-    const numOfTiles = number('number of tiles', 10);
+  .add('Base with col / row specified', () => {
+    const numOfTiles = number('number of tiles', 7);
     return (
       <div style={{ width: '60rem' }}>
         <TileCatalogNew
@@ -35,7 +35,56 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
             numOfTiles,
             <SampleTile title="Sample product tile" description="This is a sample product tile" />
           )}
-          numColumns={number('numColumns', 4)}
+          numColumns={number('numColumns', 2)}
+          numRows={number('numRows', 2)}
+          hasSearch={boolean('hasSearch', true)}
+          hasSort={boolean('hasSort', true)}
+        />
+      </div>
+    );
+  })
+  .add('Base with tile width specification', () => {
+    const numOfTiles = number('number of tiles', 5);
+    return (
+      <div style={{ width: '60rem' }}>
+        <TileCatalogNew
+          title="Product name"
+          tiles={getTiles(
+            numOfTiles,
+            <SampleTile title="Sample product tile" description="This is a sample product tile" />
+          )}
+          minTileWidth={text('minTileWidth', '15rem')}
+          hasSearch={boolean('hasSearch', true)}
+          hasSort={boolean('hasSort', true)}
+        />
+      </div>
+    );
+  })
+  .add('Loading', () => {
+    const numOfTiles = number('number of tiles', 4);
+    return (
+      <div style={{ width: '60rem' }}>
+        <TileCatalogNew
+          title="Product name"
+          tiles={getTiles(
+            numOfTiles,
+            <SampleTile title="Sample product tile" description="This is a sample product tile" />
+          )}
+          numColumns={number('numColumns', 2)}
+          numRows={number('numRows', 2)}
+          hasSearch={boolean('hasSearch', true)}
+          hasSort={boolean('hasSort', true)}
+          isLoading
+        />
+      </div>
+    );
+  })
+  .add('Error', () => {
+    return (
+      <div style={{ width: '60rem' }}>
+        <TileCatalogNew
+          title="Product name"
+          numColumns={number('numColumns', 2)}
           numRows={number('numRows', 2)}
           hasSearch={boolean('hasSearch', true)}
           hasSort={boolean('hasSort', true)}

--- a/src/components/TileCatalogNew/TileCatalogNew.story.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.story.jsx
@@ -81,6 +81,7 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
   })
   .add('Error', () => {
     return (
+      // Not passing in any tiles triggers an error
       <div style={{ width: '60rem' }}>
         <TileCatalogNew
           title="Product name"

--- a/src/components/TileCatalogNew/TileCatalogNew.story.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.story.jsx
@@ -43,10 +43,10 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
       </div>
     );
   })
-  .add('Base with tile width specification', () => {
+  .add('Dynamic resize with tile width specification', () => {
     const numOfTiles = number('number of tiles', 5);
     return (
-      <div style={{ width: '60rem' }}>
+      <div>
         <TileCatalogNew
           title="Product name"
           tiles={getTiles(

--- a/src/components/TileCatalogNew/TileCatalogNew.test.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import TileCatalogNew from './TileCatalogNew';
 import SampleTile from './SampleTile';
@@ -19,7 +19,7 @@ const getTiles = num => {
 
 describe('TileCatalogNew', () => {
   it('TileCatalogNew gets rendered', () => {
-    const { getByText } = render(
+    render(
       <TileCatalogNew
         tiles={getTiles(2, 'Tile')}
         title="Test Tile Catalog"
@@ -27,12 +27,12 @@ describe('TileCatalogNew', () => {
         numColumns={2}
       />
     );
-    expect(getByText('Tile 1')).toBeTruthy();
-    expect(getByText('Tile 2')).toBeTruthy();
+    expect(screen.getByText('Tile 1')).toBeTruthy();
+    expect(screen.getByText('Tile 2')).toBeTruthy();
   });
 
   it('TileCatalogNew placeholder tile are rendered', () => {
-    const { getByText } = render(
+    render(
       <TileCatalogNew
         tiles={getTiles(6, 'Tile')}
         title="Test Tile Catalog"
@@ -40,8 +40,8 @@ describe('TileCatalogNew', () => {
         numColumns={2}
       />
     );
-    expect(getByText('Tile 1')).toBeTruthy();
-    expect(getByText('Tile 2')).toBeTruthy();
+    expect(screen.getByText('Tile 1')).toBeTruthy();
+    expect(screen.getByText('Tile 2')).toBeTruthy();
   });
 
   it('TileCatalogNew to have default call back function ', () => {
@@ -53,7 +53,7 @@ describe('TileCatalogNew', () => {
 
   it('TileCatalogNew hasSearch set to true', () => {
     const onSearch = jest.fn();
-    const { getByPlaceholderText } = render(
+    render(
       <TileCatalogNew
         tiles={getTiles(8, 'Tile')}
         numColumns={2}
@@ -62,7 +62,7 @@ describe('TileCatalogNew', () => {
         onSearch={onSearch}
       />
     );
-    fireEvent.change(getByPlaceholderText('Enter a value'), { target: { value: '5' } });
+    fireEvent.change(screen.getByPlaceholderText('Enter a value'), { target: { value: '5' } });
     expect(onSearch).toHaveBeenCalledTimes(1);
   });
 
@@ -75,7 +75,7 @@ describe('TileCatalogNew', () => {
     const selectedSortOption = 'Choose from options';
     const onSort = jest.fn();
 
-    const { getByDisplayValue } = render(
+    render(
       <TileCatalogNew
         tiles={getTiles(2, 'Tile')}
         hasSort="true"
@@ -85,12 +85,12 @@ describe('TileCatalogNew', () => {
         hasSearch="true"
       />
     );
-    fireEvent.change(getByDisplayValue('Choose from options'), { target: { value: 'Z-A' } });
+    fireEvent.change(screen.getByDisplayValue('Choose from options'), { target: { value: 'Z-A' } });
     expect(onSort).toHaveBeenCalledTimes(1);
   });
 
   it('TileCatalogNew pagination next button', () => {
-    const { getByText, getAllByRole } = render(
+    render(
       <TileCatalogNew
         title="Test Tile Catalog"
         tiles={getTiles(8, 'Tile')}
@@ -99,16 +99,16 @@ describe('TileCatalogNew', () => {
       />
     );
 
-    const buttons = getAllByRole('button');
+    const buttons = screen.getAllByRole('button');
     fireEvent.click(buttons[buttons.length - 1]);
-    expect(getByText('Tile 5')).toBeTruthy();
-    expect(getByText('Tile 6')).toBeTruthy();
-    expect(getByText('Tile 7')).toBeTruthy();
-    expect(getByText('Tile 8')).toBeTruthy();
+    expect(screen.getByText('Tile 6')).toBeTruthy();
+    expect(screen.getByText('Tile 5')).toBeTruthy();
+    expect(screen.getByText('Tile 7')).toBeTruthy();
+    expect(screen.getByText('Tile 8')).toBeTruthy();
   });
 
   it('TileCatalogNew pagination previous button', () => {
-    const { getByText, getAllByRole } = render(
+    render(
       <TileCatalogNew
         title="Test Tile Catalog"
         tiles={getTiles(8, 'Tile')}
@@ -116,17 +116,17 @@ describe('TileCatalogNew', () => {
         numRows={2}
       />
     );
-    const buttons = getAllByRole('button');
+    const buttons = screen.getAllByRole('button');
     fireEvent.click(buttons[buttons.length - 1]);
     fireEvent.click(buttons[0]);
-    expect(getByText('Tile 1')).toBeTruthy();
-    expect(getByText('Tile 2')).toBeTruthy();
-    expect(getByText('Tile 3')).toBeTruthy();
-    expect(getByText('Tile 4')).toBeTruthy();
+    expect(screen.getByText('Tile 1')).toBeTruthy();
+    expect(screen.getByText('Tile 2')).toBeTruthy();
+    expect(screen.getByText('Tile 3')).toBeTruthy();
+    expect(screen.getByText('Tile 4')).toBeTruthy();
   });
 
   it('TileCatalogNew pagination number button', () => {
-    const { getByText, getAllByRole } = render(
+    render(
       <TileCatalogNew
         title="Test Tile Catalog"
         tiles={getTiles(20, 'Tile')}
@@ -134,17 +134,17 @@ describe('TileCatalogNew', () => {
         numRows={2}
       />
     );
-    const buttons = getAllByRole('button');
+    const buttons = screen.getAllByRole('button');
     fireEvent.click(buttons[buttons.length - 2]);
     fireEvent.click(buttons[0]);
-    expect(getByText('Tile 13')).toBeTruthy();
-    expect(getByText('Tile 14')).toBeTruthy();
-    expect(getByText('Tile 15')).toBeTruthy();
-    expect(getByText('Tile 16')).toBeTruthy();
+    expect(screen.getByText('Tile 13')).toBeTruthy();
+    expect(screen.getByText('Tile 14')).toBeTruthy();
+    expect(screen.getByText('Tile 15')).toBeTruthy();
+    expect(screen.getByText('Tile 16')).toBeTruthy();
   });
 
   it('TileCatalogNew pagination does not render with only one page', () => {
-    const { queryByText } = render(
+    render(
       <TileCatalogNew
         title="Test Tile Catalog"
         tiles={getTiles(4, 'Tile')}
@@ -153,19 +153,19 @@ describe('TileCatalogNew', () => {
       />
     );
 
-    expect(queryByText('Next page')).toBeNull();
+    expect(screen.queryByText('Next page')).toBeNull();
   });
 
   it('TileCatalogNew pagination does not render with minTileWidth', () => {
-    const { queryByText } = render(
+    render(
       <TileCatalogNew title="Test Tile Catalog" tiles={getTiles(4, 'Tile')} minTileWidth="20rem" />
     );
 
-    expect(queryByText('Next page')).toBeNull();
+    expect(screen.queryByText('Next page')).toBeNull();
   });
 
   it('TileCatalogNew renders loading state', () => {
-    const { queryByText } = render(
+    render(
       <TileCatalogNew
         title="Test Tile Catalog"
         tiles={getTiles(4, 'Tile')}
@@ -174,22 +174,20 @@ describe('TileCatalogNew', () => {
         isLoading
       />
     );
-    expect(queryByText('Tile 1')).toBeNull();
-    expect(queryByText('Tile 2')).toBeNull();
-    expect(queryByText('Tile 3')).toBeNull();
-    expect(queryByText('Tile 4')).toBeNull();
+    expect(screen.queryByText('Tile 1')).toBeNull();
+    expect(screen.queryByText('Tile 2')).toBeNull();
+    expect(screen.queryByText('Tile 3')).toBeNull();
+    expect(screen.queryByText('Tile 4')).toBeNull();
   });
 
   it('TileCatalogNew renders error state', () => {
     // trigger an error by not giving the catalog tiles
-    const { getByText } = render(
-      <TileCatalogNew title="Test Tile Catalog" numColumns={2} numRows={2} />
-    );
-    expect(getByText('An error has occurred')).toBeTruthy();
+    render(<TileCatalogNew title="Test Tile Catalog" numColumns={2} numRows={2} />);
+    expect(screen.getByText('An error has occurred')).toBeTruthy();
   });
 
   it('TileCatalogNew with large page numbers', () => {
-    const { getByText, getByLabelText } = render(
+    render(
       <TileCatalogNew
         title="Test Tile Catalog"
         tiles={getTiles(60, 'Tile')}
@@ -197,15 +195,15 @@ describe('TileCatalogNew', () => {
         numRows={2}
       />
     );
-    fireEvent.change(getByLabelText('select page number'), { target: { value: 14 } });
-    expect(getByText('Tile 53')).toBeTruthy();
-    expect(getByText('Tile 54')).toBeTruthy();
-    expect(getByText('Tile 55')).toBeTruthy();
-    expect(getByText('Tile 56')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('select page number'), { target: { value: 14 } });
+    expect(screen.getByText('Tile 53')).toBeTruthy();
+    expect(screen.getByText('Tile 54')).toBeTruthy();
+    expect(screen.getByText('Tile 55')).toBeTruthy();
+    expect(screen.getByText('Tile 56')).toBeTruthy();
   });
 
   it('TileCatalogNew with large page numbers and mid page number was selected', () => {
-    const { getByText, getByLabelText } = render(
+    render(
       <TileCatalogNew
         title="Test Tile Catalog"
         tiles={getTiles(60, 'Tile')}
@@ -213,10 +211,10 @@ describe('TileCatalogNew', () => {
         numRows={2}
       />
     );
-    fireEvent.change(getByLabelText('select page number'), { target: { value: 7 } });
-    expect(getByText('Tile 25')).toBeTruthy();
-    expect(getByText('Tile 26')).toBeTruthy();
-    expect(getByText('Tile 27')).toBeTruthy();
-    expect(getByText('Tile 28')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('select page number'), { target: { value: 7 } });
+    expect(screen.getByText('Tile 25')).toBeTruthy();
+    expect(screen.getByText('Tile 26')).toBeTruthy();
+    expect(screen.getByText('Tile 27')).toBeTruthy();
+    expect(screen.getByText('Tile 28')).toBeTruthy();
   });
 });

--- a/src/components/TileCatalogNew/TileCatalogNew.test.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.test.jsx
@@ -183,7 +183,9 @@ describe('TileCatalogNew', () => {
   it('TileCatalogNew renders error state', () => {
     // trigger an error by not giving the catalog tiles
     render(<TileCatalogNew title="Test Tile Catalog" numColumns={2} numRows={2} />);
-    expect(screen.getByText('An error has occurred')).toBeTruthy();
+    expect(
+      screen.getByText('An error has occurred. Please make sure your catalog has content.')
+    ).toBeTruthy();
   });
 
   it('TileCatalogNew with large page numbers', () => {

--- a/src/components/TileCatalogNew/TileCatalogNew.test.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.test.jsx
@@ -143,6 +143,51 @@ describe('TileCatalogNew', () => {
     expect(getByText('Tile 16')).toBeTruthy();
   });
 
+  it('TileCatalogNew pagination does not render with only one page', () => {
+    const { queryByText } = render(
+      <TileCatalogNew
+        title="Test Tile Catalog"
+        tiles={getTiles(4, 'Tile')}
+        numColumns={2}
+        numRows={2}
+      />
+    );
+
+    expect(queryByText('Next page')).toBeNull();
+  });
+
+  it('TileCatalogNew pagination does not render with minTileWidth', () => {
+    const { queryByText } = render(
+      <TileCatalogNew title="Test Tile Catalog" tiles={getTiles(4, 'Tile')} minTileWidth="20rem" />
+    );
+
+    expect(queryByText('Next page')).toBeNull();
+  });
+
+  it('TileCatalogNew renders loading state', () => {
+    const { queryByText } = render(
+      <TileCatalogNew
+        title="Test Tile Catalog"
+        tiles={getTiles(4, 'Tile')}
+        numColumns={2}
+        numRows={2}
+        isLoading
+      />
+    );
+    expect(queryByText('Tile 1')).toBeNull();
+    expect(queryByText('Tile 2')).toBeNull();
+    expect(queryByText('Tile 3')).toBeNull();
+    expect(queryByText('Tile 4')).toBeNull();
+  });
+
+  it('TileCatalogNew renders error state', () => {
+    // trigger an error by not giving the catalog tiles
+    const { getByText } = render(
+      <TileCatalogNew title="Test Tile Catalog" numColumns={2} numRows={2} />
+    );
+    expect(getByText('An error has occurred')).toBeTruthy();
+  });
+
   it('TileCatalogNew with large page numbers', () => {
     const { getByText, getByLabelText } = render(
       <TileCatalogNew

--- a/src/components/TileCatalogNew/_tile-catalog.scss
+++ b/src/components/TileCatalogNew/_tile-catalog.scss
@@ -133,3 +133,9 @@
     @include type-style('label-01');
   }
 }
+
+.#{$iot-prefix}--tile-catalog--grid-container {
+  display: grid;
+  grid-template-columns: var(--columns);
+  gap: 1rem;
+}

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4210,7 +4210,7 @@ Map {
       "hasSearch": false,
       "hasSort": false,
       "i18n": Object {
-        "error": "An error has occurred",
+        "error": "An error has occurred. Please make sure your catalog has content.",
         "searchPlaceHolderText": "Enter a value",
       },
       "isLoading": false,

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4206,19 +4206,25 @@ Map {
   },
   "TileCatalogNew" => Object {
     "defaultProps": Object {
+      "error": "",
       "hasSearch": false,
       "hasSort": false,
       "i18n": Object {
         "searchPlaceHolderText": "Enter a value",
       },
-      "numColumns": 1,
-      "numRows": 1,
+      "isLoading": false,
+      "minTileWidth": null,
+      "numColumns": 3,
+      "numRows": 3,
       "onSearch": [Function],
       "onSort": [Function],
       "selectedSortOption": "",
       "sortOptions": Array [],
     },
     "propTypes": Object {
+      "error": Object {
+        "type": "string",
+      },
       "hasSearch": Object {
         "type": "bool",
       },
@@ -4234,6 +4240,12 @@ Map {
           },
         ],
         "type": "shape",
+      },
+      "isLoading": Object {
+        "type": "bool",
+      },
+      "minTileWidth": Object {
+        "type": "string",
       },
       "numColumns": Object {
         "type": "number",

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4210,6 +4210,7 @@ Map {
       "hasSearch": false,
       "hasSort": false,
       "i18n": Object {
+        "error": "An error has occurred",
         "searchPlaceHolderText": "Enter a value",
       },
       "isLoading": false,
@@ -4234,6 +4235,9 @@ Map {
       "i18n": Object {
         "args": Array [
           Object {
+            "error": Object {
+              "type": "string",
+            },
             "placeHolderText": Object {
               "type": "string",
             },

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4221,6 +4221,7 @@ Map {
       "onSort": [Function],
       "selectedSortOption": "",
       "sortOptions": Array [],
+      "title": "",
     },
     "propTypes": Object {
       "error": Object {
@@ -4284,7 +4285,6 @@ Map {
         "type": "arrayOf",
       },
       "title": Object {
-        "isRequired": true,
         "type": "string",
       },
     },


### PR DESCRIPTION
Closes #1239

**Summary**

Migrates `TileCatalogNew` to use css grid instead of a flex box matrix to allow for responsive realignment.

**Change List (commits, features, bugs, etc)**

- Add isLoading state
- Add error state
- Add `minTileWidth` prop to allow users to set their own grid
- Use css grid instead of flex
- Make pagination conditional upon whether there are enough tiles to have 2 or more pages
- Add classname prop

**Acceptance Test (how to verify the PR)**

Click through the stories and change knobs to see the various changes in action.
