### PR TITLE
fix(card): avoid clipping data state renderer error tooltip

### DIFF
--- a/src/components/Card/DataStateRenderer.jsx
+++ b/src/components/Card/DataStateRenderer.jsx
@@ -29,14 +29,14 @@ TooltipContent.propTypes = { tooltipContent: ValueCardPropTypes.dataState.isRequ
 const DataStateRenderer = ({ dataState, size, id }) => {
   const { label, description } = dataState;
 
-  const withTooltip = (element, triggerId) => {
+  const withTooltip = (element, triggerId, tooltipDirection) => {
     return (
       <Tooltip
         showIcon={false}
         triggerText={element}
         triggerId={triggerId}
         tooltipId={`${triggerId}-tooltip`}
-        direction="right"
+        direction={tooltipDirection || 'bottom'}
       >
         <TooltipContent tooltipContent={dataState} />
       </Tooltip>
@@ -45,7 +45,7 @@ const DataStateRenderer = ({ dataState, size, id }) => {
 
   const renderDataStateGridIcon = () => {
     const { type } = dataState;
-    let { icon } = dataState;
+    let { icon, tooltipDirection } = dataState;
     if (!icon) {
       if (type === CARD_DATA_STATE.ERROR) {
         icon = <ErrorFilled24 className={`${dsPrefix}-default-error-icon`} />;
@@ -54,7 +54,7 @@ const DataStateRenderer = ({ dataState, size, id }) => {
       }
     }
 
-    return withTooltip(icon, `${dsPrefix}-grid__icon-${id}`);
+    return withTooltip(icon, `${dsPrefix}-grid__icon-${id}`, tooltipDirection);
   };
 
   const renderDataStateGridItems = () => {

--- a/src/components/Card/DataStateRenderer.jsx
+++ b/src/components/Card/DataStateRenderer.jsx
@@ -36,6 +36,7 @@ const DataStateRenderer = ({ dataState, size, id }) => {
         triggerText={element}
         triggerId={triggerId}
         tooltipId={`${triggerId}-tooltip`}
+        direction="right"
       >
         <TooltipContent tooltipContent={dataState} />
       </Tooltip>

--- a/src/components/Card/DataStateRenderer.jsx
+++ b/src/components/Card/DataStateRenderer.jsx
@@ -44,8 +44,8 @@ const DataStateRenderer = ({ dataState, size, id }) => {
   };
 
   const renderDataStateGridIcon = () => {
-    const { type } = dataState;
-    let { icon, tooltipDirection } = dataState;
+    const { type, tooltipDirection } = dataState;
+    let { icon } = dataState;
     if (!icon) {
       if (type === CARD_DATA_STATE.ERROR) {
         icon = <ErrorFilled24 className={`${dsPrefix}-default-error-icon`} />;

--- a/src/components/ValueCard/ValueCard.story.jsx
+++ b/src/components/ValueCard/ValueCard.story.jsx
@@ -883,6 +883,35 @@ storiesOf('Watson IoT/ValueCard', module)
       </div>
     );
   })
+  .add('data state - error - small - tooltip direction right', () => {
+    const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
+    const dataStateType = select(
+      'dataStateType',
+      Object.keys(CARD_DATA_STATE),
+      CARD_DATA_STATE.ERROR
+    );
+    return (
+      <div style={{ width: text('cardWidth', `${getCardMinSize('sm', size).x}px`), margin: 20 }}>
+        <ValueCard
+          title={text('title', 'Health score')}
+          id="myStoryId"
+          content={{ attributes: [{ label: 'Monthly summary', dataSourceId: 'monthlySummary' }] }}
+          dataState={{
+            type: dataStateType,
+            label: 'No data available',
+            description: 'There is no available data for this score at this time',
+            extraTooltipText:
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.  ',
+            learnMoreURL: 'http://www.ibm.com',
+            learnMoreText: 'Learn more',
+            tooltipDirection: 'right',
+          }}
+          breakpoint="sm"
+          size={size}
+        />
+      </div>
+    );
+  })
   .add('long titles and values', () => {
     const size = select('size', Object.keys(CARD_SIZES), CARD_SIZES.SMALL);
     return (

--- a/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
+++ b/src/components/ValueCard/__snapshots__/ValueCard.story.storyshot
@@ -180,6 +180,146 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Value
 </div>
 `;
 
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard data state - error - small - tooltip direction right 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "232px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="myStoryId"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "144px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Health score"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Health score
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "96px",
+            }
+          }
+        >
+          <div
+            className="ValueCard__ContentWrapper-hyxf2q-0 kwZDrJ"
+          >
+            <div
+              className="iot--data-state-container"
+              style={
+                Object {
+                  "--container-padding": "16px",
+                }
+              }
+            >
+              <p
+                className="iot--data-state-dashes"
+              >
+                --
+              </p>
+              <div
+                className="iot--data-state-grid"
+              >
+                <div
+                  aria-describedby={null}
+                  aria-labelledby="iot--data-state-grid__icon-myStoryId"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__icon-myStoryId"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="iot--data-state-default-error-icon"
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12,1C5.9,1,1,5.9,1,12s4.9,11,11,11s11-4.9,11-11S18.1,1,12,1z M16.3,17.5L6.5,7.7l1.2-1.2l9.8,9.8L16.3,17.5z"
+                    />
+                    <path
+                      d="M16.3,17.5L6.5,7.7l1.2-1.2l9.8,9.8L16.3,17.5z"
+                      data-icon-path="inner-path"
+                      fill="none"
+                      opacity="0"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
 exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/ValueCard data state - error - small 1`] = `
 <div
   className="storybook-container"

--- a/src/constants/CardPropTypes.js
+++ b/src/constants/CardPropTypes.js
@@ -70,6 +70,7 @@ export const ValueCardPropTypes = {
     description: PropTypes.string.isRequired,
     extraTooltipText: PropTypes.string,
     learnMoreElement: PropTypes.element,
+    tooltipDirection: PropTypes.oneOf(['bottom', 'top', 'left', 'right']),
   }),
   cardVariables: PropTypes.objectOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.number, PropTypes.bool])

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -7798,6 +7798,17 @@ Map {
             "learnMoreElement": Object {
               "type": "element",
             },
+            "tooltipDirection": Object {
+              "args": Array [
+                Array [
+                  "bottom",
+                  "top",
+                  "left",
+                  "right",
+                ],
+              ],
+              "type": "oneOf",
+            },
             "type": Object {
               "args": Array [
                 Array [


### PR DESCRIPTION
Closes #1198

**Summary**

- Change the direction that data state tooltips are rendered on cards

**Change List (commits, features, bugs, etc)**

- items_here

**Acceptance Test (how to verify the PR)**

- view https://deploy-preview-1278--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-valuecard--data-state-error-small 
- also view the other data state stories
- the tooltip should render `right` instead of `bottom`
