### PR TITLE
1262 table cells will overflow under some conditions

### DIFF
--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -466,6 +466,23 @@ describe('Table', () => {
     );
     expect(wrapper2.find(TableBodyRow).prop('options').truncateCellText).toBeTruthy();
     expect(wrapper2.find(TableHead).prop('options').truncateCellText).toBeTruthy();
+
+    const wrapper3 = mount(
+      <Table
+        columns={tableColumns.map(col => ({
+          ...col,
+          width: undefined,
+          renderDataFunction: () => 'hello this is a custom rendered long string',
+        }))}
+        data={[tableData[0]]}
+        options={{ hasResize: false, wrapCellText: 'auto' }}
+      />
+    );
+    expect(
+      wrapper3
+        .find('TableCell .iot--table__cell--truncate .iot--table__cell-text--truncate')
+        .first()
+    ).toHaveLength(1);
   });
 
   it('cells should wrap (not truncate) with wrapCellText:auto if no resize nor fixed col widths', () => {

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -430,19 +430,15 @@ const TableBodyRow = ({
                   rowId: id,
                   row: values,
                 })
-              ) : col.renderDataFunction ? (
-                col.renderDataFunction({
-                  // Call the column renderer if it's provided
-                  value: values[col.columnId],
-                  columnId: col.columnId,
-                  rowId: id,
-                  row: values,
-                })
               ) : (
                 <TableCellRenderer
                   wrapText={wrapCellText}
                   truncateCellText={truncateCellText}
                   locale={locale}
+                  renderDataFunction={col.renderDataFunction}
+                  columnId={col.columnId}
+                  rowId={id}
+                  row={values}
                 >
                   {values[col.columnId]}
                 </TableCellRenderer>

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -211,8 +211,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -278,8 +278,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -344,8 +344,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -359,8 +359,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -404,8 +407,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -419,8 +422,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -464,8 +470,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -479,8 +485,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -524,8 +533,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -539,8 +548,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -584,8 +596,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -599,8 +611,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -644,8 +659,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -659,8 +674,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -745,7 +763,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -779,13 +801,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -865,50 +891,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 1 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 1 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            11112 Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              11112 Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -943,13 +973,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1028,7 +1062,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -1062,13 +1100,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1148,50 +1190,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 2 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 2 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            11112 Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              11112 Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -1226,13 +1272,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1312,50 +1362,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 68 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 68 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            11112 Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              11112 Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -1390,13 +1444,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1476,50 +1534,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            11112 Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              11112 Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -1554,13 +1616,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1639,7 +1705,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -1673,13 +1743,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1758,7 +1832,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -1792,13 +1870,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1877,7 +1959,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -1911,13 +1997,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -1997,50 +2087,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            11112 Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              11112 Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -2075,13 +2169,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -2529,8 +2627,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -2596,8 +2694,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -2662,8 +2760,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -2677,8 +2775,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -2722,8 +2823,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -2737,8 +2838,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -2784,13 +2888,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -2830,13 +2938,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -2876,13 +2988,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -2922,13 +3038,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -2968,13 +3088,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -3014,13 +3138,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -3060,13 +3188,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -3106,13 +3238,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -3152,13 +3288,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -3198,13 +3338,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/11112"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/11112"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -3652,8 +3796,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -3719,8 +3863,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -3785,8 +3929,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -3800,8 +3944,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -3845,8 +3992,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -3860,8 +4007,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -3905,8 +4055,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -3920,8 +4070,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -3965,8 +4118,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -3980,8 +4133,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -4025,8 +4181,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -4040,8 +4196,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -4085,8 +4244,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -4100,8 +4259,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -4145,8 +4307,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -4160,8 +4322,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -4246,7 +4411,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -4300,13 +4469,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73003"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73003"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -4386,50 +4559,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 1 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 1 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -4484,13 +4661,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73005"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73005"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -4569,7 +4750,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -4623,13 +4808,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73000"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73000"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -4709,50 +4898,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 2 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 2 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -4807,13 +5000,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73000"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73000"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -4893,50 +5090,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 68 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 68 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -4991,13 +5192,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73004"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73004"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -5077,50 +5282,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -5175,13 +5384,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73001"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73001"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -5260,7 +5473,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -5314,13 +5531,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73000"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73000"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -5399,7 +5620,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -5453,13 +5678,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73003"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73003"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -5538,7 +5767,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -5592,13 +5825,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73005"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73005"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -5678,50 +5915,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 1"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 1"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -5776,13 +6017,17 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <a
-                          className="bx--link"
-                          href="https://ibm.com/73002"
-                          target="_blank"
+                        <span
+                          className=""
                         >
-                          Link
-                        </a>
+                          <a
+                            className="bx--link"
+                            href="https://ibm.com/73002"
+                            target="_blank"
+                          >
+                            Link
+                          </a>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -6231,8 +6476,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -6367,8 +6612,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -6382,8 +6627,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -6427,8 +6675,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -6442,8 +6690,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -6487,8 +6738,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -6502,8 +6753,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -7600,8 +7854,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -7740,8 +7994,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -7755,8 +8009,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -7800,8 +8057,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -7815,8 +8072,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -7860,8 +8120,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -7875,8 +8135,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -9282,8 +9545,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -9349,8 +9612,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -9439,8 +9702,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -9454,8 +9717,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -9499,8 +9765,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -9514,8 +9780,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -9559,8 +9828,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -9574,8 +9843,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -9605,7 +9877,19 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
+                            d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
+                          />
+                          <path
+                            d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
+                          />
+                          <path
+                            d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
+                          />
+                          <path
+                            d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
+                          />
+                          <path
+                            d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
                           />
                         </svg>
                         <p>
@@ -9859,8 +10143,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -9926,8 +10210,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -9992,8 +10276,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -10007,8 +10291,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -10052,8 +10339,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -10067,8 +10354,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -10112,8 +10402,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -10127,8 +10417,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -10172,8 +10465,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -10187,8 +10480,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -10232,8 +10528,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -10247,8 +10543,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -10292,8 +10591,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -10307,8 +10606,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -10354,52 +10656,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 2 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 2 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -10453,7 +10759,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -10511,7 +10821,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -10564,7 +10878,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -10623,52 +10941,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1,204 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1,204 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -10722,7 +11044,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -10781,52 +11107,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1,103 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1,103 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -10880,7 +11210,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -10939,50 +11273,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 30 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 30 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -11037,50 +11375,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 68 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 68 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -11140,52 +11482,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 3 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -11240,50 +11586,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -11342,7 +11692,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -11395,7 +11749,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -11454,50 +11812,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 7 = 7"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 7 = 7"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
-                                  fill="#FC7B1E"
-                                  id="background-color"
-                                />
-                                <path
-                                  d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
+                                    fill="#FC7B1E"
+                                    id="background-color"
+                                  />
+                                  <path
+                                    d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Moderate
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Moderate
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -11551,7 +11913,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -11610,52 +11976,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 0 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 0 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -11709,7 +12079,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -11768,50 +12142,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -11866,50 +12244,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -12377,8 +12759,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -12444,8 +12826,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -12534,8 +12916,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -12549,8 +12931,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -12594,8 +12979,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -12609,8 +12994,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -12654,8 +13042,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -12669,8 +13057,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -13774,8 +14165,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -13841,8 +14232,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -13907,8 +14298,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -13922,8 +14313,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -13967,8 +14361,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -13982,8 +14376,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -14027,8 +14424,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -14042,8 +14439,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -14087,8 +14487,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -14102,8 +14502,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -15407,8 +15810,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -15474,8 +15877,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -15564,8 +15967,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -15579,8 +15982,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -15624,8 +16030,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -15639,8 +16045,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -15684,8 +16093,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -15699,8 +16108,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -16804,8 +17216,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -16871,8 +17283,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -16961,8 +17373,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -16976,8 +17388,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -17021,8 +17436,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -17036,8 +17451,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -17081,8 +17499,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -17096,8 +17514,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -17207,44 +17628,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -17324,44 +17749,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -17441,44 +17870,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -17558,44 +17991,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -17675,44 +18112,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -17792,44 +18233,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -17909,44 +18354,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -18026,44 +18475,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -18143,44 +18596,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -18260,44 +18717,48 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <button
-                          aria-expanded={false}
-                          aria-haspopup={true}
-                          aria-label="Menu"
-                          className="iot--table-card--overflow-menu bx--overflow-menu"
-                          onClick={[Function]}
-                          onClose={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          tabIndex={0}
+                        <span
+                          className=""
                         >
-                          <svg
-                            aria-hidden={true}
-                            fill="#5a6872"
-                            focusable="false"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="iot--table-card--overflow-menu bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            tabIndex={0}
                           >
-                            <circle
-                              cx="16"
-                              cy="8"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="2"
-                            />
-                            <circle
-                              cx="16"
-                              cy="24"
-                              r="2"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden={true}
+                              fill="#5a6872"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                            </svg>
+                          </button>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -18745,8 +19206,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -18812,8 +19273,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -18906,8 +19367,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -18921,8 +19382,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -18966,8 +19430,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -18981,8 +19445,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -19026,8 +19493,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -19041,8 +19508,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -20456,8 +20926,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -20523,8 +20993,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -20617,8 +21087,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -20632,8 +21102,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -20677,8 +21150,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -20692,8 +21165,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -20737,8 +21213,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -20752,8 +21228,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -22167,8 +22646,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -22234,8 +22713,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -22328,8 +22807,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -22343,8 +22822,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -22388,8 +22870,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -22403,8 +22885,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -22448,8 +22933,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -22463,8 +22948,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -23878,8 +24366,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -23945,8 +24433,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -24035,8 +24523,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -24050,8 +24538,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -24095,8 +24586,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -24110,8 +24601,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -24155,8 +24649,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -24170,8 +24664,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -24281,22 +24778,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -24376,22 +24883,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -24471,22 +24988,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -24566,22 +25093,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -24661,22 +25198,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -24756,22 +25303,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -24851,22 +25408,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -24946,22 +25513,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -25041,22 +25618,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -25136,22 +25723,32 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <svg
-                          aria-label="open"
-                          className="iot--table-card--action-icon"
-                          focusable="false"
-                          height={16}
-                          onClick={[Function]}
-                          preserveAspectRatio="xMidYMid meet"
-                          role="img"
-                          viewBox="0 0 32 32"
-                          width={16}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <span
+                          className=""
                         >
-                          <path
-                            d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
-                          />
-                        </svg>
+                          <svg
+                            aria-label="open"
+                            className="iot--table-card--action-icon"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            role="img"
+                            viewBox="0 0 32 32"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <rect
+                              height="2"
+                              width="28"
+                              x="2"
+                              y="26"
+                            />
+                            <path
+                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                            />
+                          </svg>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -25599,8 +26196,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -25666,8 +26263,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -25732,8 +26329,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -25747,8 +26344,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -25792,8 +26392,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -25807,8 +26407,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -25852,8 +26455,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -25867,8 +26470,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -25912,8 +26518,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -25927,8 +26533,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -25972,8 +26581,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -25987,8 +26596,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -26032,8 +26644,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -26047,8 +26659,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -26094,52 +26709,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 2 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 2 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -26193,7 +26812,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -26251,7 +26874,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -26304,7 +26931,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -26363,52 +26994,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.2039201932 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1.2039201932 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -26462,7 +27097,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -26521,52 +27160,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.10329291 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1.10329291 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -26620,7 +27263,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -26679,50 +27326,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 30 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 30 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Custom Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Custom Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -26777,50 +27428,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 68 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 68 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -26880,52 +27535,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 3 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -26980,50 +27639,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -27082,7 +27745,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -27135,7 +27802,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -27194,50 +27865,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 7 = 7"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 7 = 7"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
-                                  fill="#FC7B1E"
-                                  id="background-color"
-                                />
-                                <path
-                                  d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
+                                    fill="#FC7B1E"
+                                    id="background-color"
+                                  />
+                                  <path
+                                    d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Moderate
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Moderate
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -27291,7 +27966,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -27350,52 +28029,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 0 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 0 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -27449,7 +28132,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -27508,50 +28195,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Custom Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Custom Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -27606,50 +28297,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -28117,8 +28812,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -28184,8 +28879,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -28250,8 +28945,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -28265,8 +28960,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -28310,8 +29008,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -28325,8 +29023,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -28370,8 +29071,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -28385,8 +29086,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -28430,8 +29134,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -28445,8 +29149,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -28512,52 +29219,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 2 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 2 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -28571,7 +29282,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -28629,7 +29344,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -28642,7 +29361,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -28701,52 +29424,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.2039201932 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1.2039201932 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -28760,7 +29487,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -28819,52 +29550,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.10329291 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1.10329291 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -28878,7 +29613,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -28937,50 +29676,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 30 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 30 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Custom Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Custom Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -28995,50 +29738,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 68 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 68 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -29098,52 +29845,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 3 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -29158,50 +29909,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -29260,7 +30015,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -29273,7 +30032,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -29332,50 +30095,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 7 = 7"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 7 = 7"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
-                                  fill="#FC7B1E"
-                                  id="background-color"
-                                />
-                                <path
-                                  d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
+                                    fill="#FC7B1E"
+                                    id="background-color"
+                                  />
+                                  <path
+                                    d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Moderate
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Moderate
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -29389,7 +30156,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -29448,52 +30219,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 0 < 5"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 0 < 5"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -29507,7 +30282,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                   </tr>
                   <tr
@@ -29566,50 +30345,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Custom Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Custom Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -29624,50 +30407,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="pressure: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                   </tr>
@@ -30115,8 +30902,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -30182,8 +30969,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -30252,8 +31039,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -30267,8 +31054,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -30312,8 +31102,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -30327,8 +31117,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -30372,8 +31165,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -30387,8 +31180,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -30432,8 +31228,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -30447,8 +31243,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -30492,8 +31291,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -30507,8 +31306,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -30552,8 +31354,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -30567,8 +31369,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -30644,7 +31449,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -30697,7 +31506,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -30786,7 +31599,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -30839,7 +31656,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -30928,7 +31749,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -30981,7 +31806,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31070,7 +31899,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31123,7 +31956,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31213,50 +32050,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 30 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 30 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Custom Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Custom Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -31311,35 +32152,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 68 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            fill="black"
-                            focusable="true"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            tabIndex="0"
+                          <div
+                            className="iot--threshold-icon--wrapper"
                             title="pressure: 68 >= 10"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <path
-                              d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
-                            />
-                            <title>
-                              pressure: 68 &gt;= 10
-                            </title>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            <svg
+                              fill="black"
+                              focusable="true"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              tabIndex="0"
+                              title="pressure: 68 >= 10"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
+                              />
+                              <path
+                                d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
+                              />
+                              <path
+                                d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
+                              />
+                              <path
+                                d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
+                              />
+                              <path
+                                d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
+                              />
+                              <title>
+                                pressure: 68 &gt;= 10
+                              </title>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -31429,7 +32286,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31483,35 +32344,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            fill="black"
-                            focusable="true"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            tabIndex="0"
+                          <div
+                            className="iot--threshold-icon--wrapper"
                             title="pressure: 10 >= 10"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <path
-                              d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
-                            />
-                            <title>
-                              pressure: 10 &gt;= 10
-                            </title>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            <svg
+                              fill="black"
+                              focusable="true"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              tabIndex="0"
+                              title="pressure: 10 >= 10"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
+                              />
+                              <path
+                                d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
+                              />
+                              <path
+                                d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
+                              />
+                              <path
+                                d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
+                              />
+                              <path
+                                d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
+                              />
+                              <title>
+                                pressure: 10 &gt;= 10
+                              </title>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -31601,7 +32478,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31654,7 +32535,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31744,50 +32629,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 7 = 7"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 7 = 7"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
-                                  fill="#FC7B1E"
-                                  id="background-color"
-                                />
-                                <path
-                                  d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.7894601,14.2675131 C15.5195241,14.7230623 15.029513,15.0024208 14.5000526,15.0025132 L1.53339891,15.0021846 C0.996512233,15.0159597 0.493279942,14.7413061 0.202531324,14.2625132 C-0.0652585874,13.7984115 -0.0652585874,13.2266148 0.189272648,12.78623 L6.68470115,0.787539475 C6.94639352,0.302404679 7.45295465,2.66453526e-15 8.00391648,2.66453526e-15 C8.55487831,2.66453526e-15 9.06143944,0.302404679 9.3224242,0.78623001 L15.8183281,12.7858011 C16.0707419,13.2512161 16.0592142,13.8153414 15.7894601,14.2675131 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.941052,13.2599875 L8.44460575,1.26245909 C8.35737079,1.1007808 8.18850902,1 8.00484631,1 C7.82118359,1 7.65232182,1.1007808 7.56508686,1.26245909 L1.06864057,13.2599875 C0.979373004,13.4146562 0.979373004,13.6052158 1.06864057,13.7598845 C1.16167713,13.9128935 1.32942924,14.0044259 1.50840001,13.9998351 L14.5012926,13.9998351 C14.6777297,13.9998043 14.8410746,13.906704 14.9310575,13.7548855 C15.0215326,13.6032635 15.0253318,13.4151411 14.941052,13.2599875 Z"
+                                    fill="#FC7B1E"
+                                    id="background-color"
+                                  />
+                                  <path
+                                    d="M7.50084897,5.75 L8.50084897,5.75 L8.50084897,9.75 L7.50084897,9.75 L7.50084897,5.75 Z M8.00084897,12.5 C7.58663541,12.5 7.25084897,12.1642136 7.25084897,11.75 C7.25084897,11.3357864 7.58663541,11 8.00084897,11 C8.41506253,11 8.75084897,11.3357864 8.75084897,11.75 C8.75084897,12.1642136 8.41506253,12.5 8.00084897,12.5 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Moderate
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Moderate
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -31841,7 +32730,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31930,7 +32823,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -31983,7 +32880,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -32073,50 +32974,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 10 >= 10"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Custom Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Custom Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -32171,35 +33076,51 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="pressure: 10 >= 10"
+                        <span
+                          className=""
                         >
-                          <svg
-                            fill="black"
-                            focusable="true"
-                            height={16}
-                            preserveAspectRatio="xMidYMid meet"
-                            role="img"
-                            tabIndex="0"
+                          <div
+                            className="iot--threshold-icon--wrapper"
                             title="pressure: 10 >= 10"
-                            viewBox="0 0 32 32"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
                           >
-                            <path
-                              d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
-                            />
-                            <title>
-                              pressure: 10 &gt;= 10
-                            </title>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            <svg
+                              fill="black"
+                              focusable="true"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              tabIndex="0"
+                              title="pressure: 10 >= 10"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
+                              />
+                              <path
+                                d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
+                              />
+                              <path
+                                d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
+                              />
+                              <path
+                                d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
+                              />
+                              <path
+                                d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
+                              />
+                              <title>
+                                pressure: 10 &gt;= 10
+                              </title>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -32667,8 +33588,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <path
-                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
+                    <polygon
+                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -32734,8 +33655,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <path
-                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
+                        <polygon
+                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -32828,8 +33749,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -32843,8 +33764,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -32888,8 +33812,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -32903,8 +33827,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -32948,8 +33875,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -32963,8 +33890,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -33008,8 +33938,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
+                          <polygon
+                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
                           />
                         </svg>
                         <svg
@@ -33023,8 +33953,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <path
-                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
+                          <polygon
+                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
+                          />
+                          <polygon
+                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
                           />
                         </svg>
                       </button>
@@ -33101,52 +34034,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 2 > 0"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 2 > 0"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -33257,50 +34194,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 5 > 2"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 5 > 2"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -33411,52 +34352,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.2039201932 > 0"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1.2039201932 > 0"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -33567,52 +34512,56 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 1.10329291 > 0"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 1.10329291 > 0"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <circle
-                                  cx="8"
-                                  cy="8"
-                                  fill="#FDD13A"
-                                  id="background-color"
-                                  r="7"
-                                />
-                                <path
-                                  d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
-                                  fill="#FFFFFF"
-                                  id="symbol-color"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <circle
+                                    cx="8"
+                                    cy="8"
+                                    fill="#FDD13A"
+                                    id="background-color"
+                                    r="7"
+                                  />
+                                  <path
+                                    d="M7.22,4 L8.47,4 L8.47,8 L7.22,8 L7.22,4 Z M7.875,11.9 C7.39175084,11.9 7,11.5082492 7,11.025 C7,10.5417508 7.39175084,10.15 7.875,10.15 C8.35824916,10.15 8.75,10.5417508 8.75,11.025 C8.75,11.5082492 8.35824916,11.9 7.875,11.9 Z"
+                                    fill="#FFFFFF"
+                                    id="symbol-color"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Low
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Low
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -33723,50 +34672,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 30 > 2"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 30 > 2"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -33877,50 +34830,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 3 > 2"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 3 > 2"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -34031,50 +34988,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 5 > 2"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 5 > 2"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -34185,50 +35146,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 7 > 2"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 7 > 2"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td
@@ -34338,7 +35303,11 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
-                      />
+                      >
+                        <span
+                          className=""
+                        />
+                      </span>
                     </td>
                     <td
                       align="start"
@@ -34448,50 +35417,54 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                       <span
                         className="TableBodyRow__StyledNestedSpan-sc-103itxu-5 YBqdC"
                       >
-                        <div
-                          className="iot--threshold-icon--wrapper"
-                          title="count: 10 > 2"
+                        <span
+                          className=""
                         >
-                          <svg
-                            height="16px"
-                            version="1.1"
-                            viewBox="0 0 16 16"
-                            width="16px"
+                          <div
+                            className="iot--threshold-icon--wrapper"
+                            title="count: 10 > 2"
                           >
-                            <g
-                              fill="none"
-                              fillRule="evenodd"
-                              id="Artboard-Copy-2"
-                              stroke="none"
-                              strokeWidth="1"
+                            <svg
+                              height="16px"
+                              version="1.1"
+                              viewBox="0 0 16 16"
+                              width="16px"
                             >
                               <g
-                                id="Group"
+                                fill="none"
+                                fillRule="evenodd"
+                                id="Artboard-Copy-2"
+                                stroke="none"
+                                strokeWidth="1"
                               >
-                                <path
-                                  d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
-                                  fill="#FFFFFF"
-                                  id="outline-color"
-                                />
-                                <path
-                                  d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
-                                  fill="#DA1E28"
-                                  id="background-color"
-                                />
-                                <polygon
-                                  fill="#FFFFFF"
-                                  id="icon-color"
-                                  points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
-                                />
+                                <g
+                                  id="Group"
+                                >
+                                  <path
+                                    d="M15.483595,4.16821623 L11.828224,0.514898318 C11.4996389,0.186340499 11.0498759,0 10.5847164,0 L5.4141139,0 C4.94895439,0 4.49919139,0.186340499 4.17043702,0.51506755 L0.515728028,4.16947288 C0.186857661,4.49695966 1.58095759e-13,4.94738907 1.58095759e-13,5.41374714 L1.58095759e-13,10.5845032 C1.58095759e-13,11.0496811 0.18637442,11.4994512 0.515144768,11.8281943 L4.17032421,15.4842364 C4.50074437,15.813273 4.94971353,16 5.4141139,16 L10.5841331,16 C11.0519715,16 11.4969656,15.8151662 11.82781,15.4843492 L15.4864327,11.8277802 C15.8179763,11.4922167 16,11.0496451 16,10.5845032 L16,5.41374714 C16.00134,4.94645588 15.816286,4.49993244 15.483595,4.16821623 Z"
+                                    fill="#FFFFFF"
+                                    id="outline-color"
+                                  />
+                                  <path
+                                    d="M14.7771914,4.87602583 L11.1213159,1.22220371 C10.9801669,1.08106644 10.7847747,1 10.5847164,1 L5.4141139,1 C5.21405561,1 5.01866342,1.08106644 4.87751443,1.22220371 L1.22280543,4.87660904 C1.08107318,5.0177463 1,5.21312227 1,5.41374714 L1,10.5845032 C1,10.7845449 1.08107318,10.9799208 1.22222217,11.1210581 L4.87751443,14.7772131 C5.01924668,14.9183503 5.21463888,15 5.4141139,15 L10.5841331,15 C10.7865245,15 10.9772506,14.9206832 11.1207326,14.7772131 L14.7795244,11.1204749 C14.9218399,10.9764216 15,10.7862945 15,10.5845032 L15,5.41374714 C15.0005801,5.21020621 14.9212567,5.01949594 14.7771914,4.87602583 Z"
+                                    fill="#DA1E28"
+                                    id="background-color"
+                                  />
+                                  <polygon
+                                    fill="#FFFFFF"
+                                    id="icon-color"
+                                    points="10.3185714 11.001753 8 8.68318155 5.68142857 11.001753 5 10.3203244 7.31857143 8.00175297 5 5.68318155 5.68142857 5.00175297 8 7.3203244 10.3185714 5.00175297 11 5.68318155 8.68142857 8.00175297 11 10.3203244"
+                                  />
+                                </g>
                               </g>
-                            </g>
-                          </svg>
-                          <span
-                            className="iot--threshold-icon--text"
-                          >
-                            Critical
-                          </span>
-                        </div>
+                            </svg>
+                            <span
+                              className="iot--threshold-icon--text"
+                            >
+                              Critical
+                            </span>
+                          </div>
+                        </span>
                       </span>
                     </td>
                     <td

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -211,8 +211,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -278,8 +278,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -344,8 +344,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -359,11 +359,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -407,8 +404,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -422,11 +419,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -470,8 +464,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -485,11 +479,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -533,8 +524,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -548,11 +539,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -596,8 +584,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -611,11 +599,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -659,8 +644,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -674,11 +659,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -2627,8 +2609,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -2694,8 +2676,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -2760,8 +2742,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -2775,11 +2757,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -2823,8 +2802,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -2838,11 +2817,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -3796,8 +3772,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -3863,8 +3839,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -3929,8 +3905,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -3944,11 +3920,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -3992,8 +3965,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -4007,11 +3980,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -4055,8 +4025,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -4070,11 +4040,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -4118,8 +4085,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -4133,11 +4100,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -4181,8 +4145,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -4196,11 +4160,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -4244,8 +4205,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -4259,11 +4220,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -4307,8 +4265,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -4322,11 +4280,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -6476,8 +6431,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -6612,8 +6567,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -6627,11 +6582,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -6675,8 +6627,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -6690,11 +6642,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -6738,8 +6687,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -6753,11 +6702,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -7854,8 +7800,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -7994,8 +7940,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -8009,11 +7955,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -8057,8 +8000,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -8072,11 +8015,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -8120,8 +8060,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -8135,11 +8075,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -9545,8 +9482,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -9612,8 +9549,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -9702,8 +9639,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -9717,11 +9654,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -9765,8 +9699,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -9780,11 +9714,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -9828,8 +9759,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -9843,11 +9774,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -9877,19 +9805,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           xmlns="http://www.w3.org/2000/svg"
                         >
                           <path
-                            d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
-                          />
-                          <path
-                            d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
-                          />
-                          <path
-                            d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
-                          />
-                          <path
-                            d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
-                          />
-                          <path
-                            d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
+                            d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
                           />
                         </svg>
                         <p>
@@ -10143,8 +10059,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -10210,8 +10126,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -10276,8 +10192,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -10291,11 +10207,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -10339,8 +10252,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -10354,11 +10267,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -10402,8 +10312,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -10417,11 +10327,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -10465,8 +10372,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -10480,11 +10387,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -10528,8 +10432,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -10543,11 +10447,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -10591,8 +10492,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -10606,11 +10507,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -12759,8 +12657,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -12826,8 +12724,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -12916,8 +12814,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -12931,11 +12829,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -12979,8 +12874,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -12994,11 +12889,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -13042,8 +12934,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -13057,11 +12949,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -14165,8 +14054,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -14232,8 +14121,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -14298,8 +14187,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -14313,11 +14202,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -14361,8 +14247,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -14376,11 +14262,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -14424,8 +14307,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -14439,11 +14322,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -14487,8 +14367,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -14502,11 +14382,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -15810,8 +15687,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -15877,8 +15754,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -15967,8 +15844,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -15982,11 +15859,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -16030,8 +15904,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -16045,11 +15919,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -16093,8 +15964,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -16108,11 +15979,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -17216,8 +17084,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -17283,8 +17151,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -17373,8 +17241,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -17388,11 +17256,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -17436,8 +17301,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -17451,11 +17316,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -17499,8 +17361,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -17514,11 +17376,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -19206,8 +19065,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -19273,8 +19132,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -19367,8 +19226,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -19382,11 +19241,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -19430,8 +19286,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -19445,11 +19301,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -19493,8 +19346,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -19508,11 +19361,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -20926,8 +20776,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -20993,8 +20843,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -21087,8 +20937,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -21102,11 +20952,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -21150,8 +20997,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -21165,11 +21012,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -21213,8 +21057,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -21228,11 +21072,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -22646,8 +22487,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -22713,8 +22554,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -22807,8 +22648,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -22822,11 +22663,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -22870,8 +22708,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -22885,11 +22723,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -22933,8 +22768,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -22948,11 +22783,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -24366,8 +24198,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -24433,8 +24265,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -24523,8 +24355,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -24538,11 +24370,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -24586,8 +24415,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -24601,11 +24430,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -24649,8 +24475,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -24664,11 +24490,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -24793,14 +24616,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -24898,14 +24715,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25003,14 +24814,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25108,14 +24913,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25213,14 +25012,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25318,14 +25111,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25423,14 +25210,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25528,14 +25309,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25633,14 +25408,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -25738,14 +25507,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                             width={16}
                             xmlns="http://www.w3.org/2000/svg"
                           >
-                            <rect
-                              height="2"
-                              width="28"
-                              x="2"
-                              y="26"
-                            />
                             <path
-                              d="M25.4,9c0.8-0.8,0.8-2,0-2.8c0,0,0,0,0,0l-3.6-3.6c-0.8-0.8-2-0.8-2.8,0c0,0,0,0,0,0l-15,15V24h6.4L25.4,9z M20.4,4L24,7.6	l-3,3L17.4,7L20.4,4z M6,22v-3.6l10-10l3.6,3.6l-10,10H6z"
+                              d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
                             />
                           </svg>
                         </span>
@@ -26196,8 +25959,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -26263,8 +26026,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -26329,8 +26092,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -26344,11 +26107,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -26392,8 +26152,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -26407,11 +26167,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -26455,8 +26212,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -26470,11 +26227,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -26518,8 +26272,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -26533,11 +26287,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -26581,8 +26332,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -26596,11 +26347,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -26644,8 +26392,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -26659,11 +26407,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -28812,8 +28557,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -28879,8 +28624,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -28945,8 +28690,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -28960,11 +28705,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -29008,8 +28750,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -29023,11 +28765,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -29071,8 +28810,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -29086,11 +28825,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -29134,8 +28870,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -29149,11 +28885,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -30902,8 +30635,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -30969,8 +30702,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -31039,8 +30772,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -31054,11 +30787,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -31102,8 +30832,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -31117,11 +30847,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -31165,8 +30892,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -31180,11 +30907,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -31228,8 +30952,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -31243,11 +30967,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -31291,8 +31012,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -31306,11 +31027,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -31354,8 +31072,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -31369,11 +31087,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -32172,19 +31887,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
-                              />
-                              <path
-                                d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
-                              />
-                              <path
-                                d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
-                              />
-                              <path
-                                d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
-                              />
-                              <path
-                                d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
+                                d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
                               />
                               <title>
                                 pressure: 68 &gt;= 10
@@ -32364,19 +32067,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
-                              />
-                              <path
-                                d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
-                              />
-                              <path
-                                d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
-                              />
-                              <path
-                                d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
-                              />
-                              <path
-                                d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
+                                d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
                               />
                               <title>
                                 pressure: 10 &gt;= 10
@@ -33096,19 +32787,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M16,10a6,6,0,0,0-6,6v8a6,6,0,0,0,12,0V16A6,6,0,0,0,16,10Zm-4.25,7.87h8.5v4.25h-8.5ZM16,28.25A4.27,4.27,0,0,1,11.75,24v-.13h8.5V24A4.27,4.27,0,0,1,16,28.25Zm4.25-12.13h-8.5V16a4.25,4.25,0,0,1,8.5,0Z"
-                              />
-                              <path
-                                d="M30.66,19.21,24,13v9.1a4,4,0,0,0,8,0A3.83,3.83,0,0,0,30.66,19.21ZM28,24.35a2.25,2.25,0,0,1-2.25-2.25V17l3.72,3.47h0A2.05,2.05,0,0,1,30.2,22,2.25,2.25,0,0,1,28,24.35Z"
-                              />
-                              <path
-                                d="M0,22.1a4,4,0,0,0,8,0V13L1.34,19.21A3.88,3.88,0,0,0,0,22.1Zm2.48-1.56h0L6.25,17v5.1a2.25,2.25,0,0,1-4.5,0A2.05,2.05,0,0,1,2.48,20.54Z"
-                              />
-                              <path
-                                d="M15,5.5A3.5,3.5,0,1,0,11.5,9,3.5,3.5,0,0,0,15,5.5Zm-5.25,0A1.75,1.75,0,1,1,11.5,7.25,1.77,1.77,0,0,1,9.75,5.5Z"
-                              />
-                              <path
-                                d="M20.5,2A3.5,3.5,0,1,0,24,5.5,3.5,3.5,0,0,0,20.5,2Zm0,5.25A1.75,1.75,0,1,1,22.25,5.5,1.77,1.77,0,0,1,20.5,7.25Z"
+                                d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
                               />
                               <title>
                                 pressure: 10 &gt;= 10
@@ -33588,8 +33267,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <polygon
-                      points="26 15 24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15"
+                    <path
+                      d="M26 15L24.59 13.59 17 21.17 17 2 15 2 15 21.17 7.41 13.59 6 15 16 25 26 15z"
                     />
                     <path
                       d="M26,24v4H6V24H4v4H4a2,2,0,0,0,2,2H26a2,2,0,0,0,2-2h0V24Z"
@@ -33655,8 +33334,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                         <path
                           d="M21,30a8,8,0,1,1,8-8A8,8,0,0,1,21,30Zm0-14a6,6,0,1,0,6,6A6,6,0,0,0,21,16Z"
                         />
-                        <polygon
-                          points="22.59 25 20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25"
+                        <path
+                          d="M22.59 25L20 22.41 20 18 22 18 22 21.59 24 23.59 22.59 25z"
                         />
                         <path
                           d="M28,6a2,2,0,0,0-2-2H22V2H20V4H12V2H10V4H6A2,2,0,0,0,4,6V26a2,2,0,0,0,2,2h4V26H6V6h4V8h2V6h8V8h2V6h4v6h2Z"
@@ -33749,8 +33428,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -33764,11 +33443,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -33812,8 +33488,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -33827,11 +33503,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -33875,8 +33548,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -33890,11 +33563,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>
@@ -33938,8 +33608,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="16 4 6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4"
+                          <path
+                            d="M16 4L6 14 7.41 15.41 15 7.83 15 30 17 30 17 7.83 24.59 15.41 26 14 16 4z"
                           />
                         </svg>
                         <svg
@@ -33953,11 +33623,8 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                           width={20}
                           xmlns="http://www.w3.org/2000/svg"
                         >
-                          <polygon
-                            points="27.6,20.6 24,24.2 24,4 22,4 22,24.2 18.4,20.6 17,22 23,28 29,22"
-                          />
-                          <polygon
-                            points="9,4 3,10 4.4,11.4 8,7.8 8,28 10,28 10,7.8 13.6,11.4 15,10"
+                          <path
+                            d="M27.6 20.6L24 24.2 24 4 22 4 22 24.2 18.4 20.6 17 22 23 28 29 22zM9 4L3 10 4.4 11.4 8 7.8 8 28 10 28 10 7.8 13.6 11.4 15 10z"
                           />
                         </svg>
                       </button>


### PR DESCRIPTION
Closes #1262

**Summary**
The renderDataFunction is not included in the CellRenderer which means that apps that use renderDataFunction will miss out on CSS settings causing cell text wrapping and truncation to fail where it could have worked.

**Note**
Note sure if this should be considered breaking functionality since cells that are using renderDataFunction now could be wrapped with these classes  (when the wrapText prop is used) which might affect that cell rendering.

```
.#{$iot-prefix}--table__cell-text--truncate {
  @include text-overflow();
  display: block;
}

.#{$iot-prefix}--table__cell-text--no-wrap {
  white-space: nowrap;
}

```

**Change List (commits, features, bugs, etc)**
- Moved renderDataFunction into TableCellRenderer so that the cell from a renderDataFunction will be wrapped by the same CSS as a normal cell
- Added a unit test to catch the original issue

**Acceptance Test (how to verify the PR)**
- Check that the unit test looks correct and that it is passing

There is no story that shows this particular bug, but you can check the following:

1. Go to https://deploy-preview-1286--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--stateful-example-with-expansion-maxpages-and-column-resize
2. select 'auto' in the knob `wrapCellText``
3. the status column uses renderDataFunction so you can check by inspecting the DOM that the SVG is wrapped in a span with class `iot--table__cell-text--truncate`
4. Also check that this story still looks okay https://deploy-preview-1286--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-table--with-custom-cell-renderer
