### PR TITLE
fix(node): specify correct version in engines, require 12 for local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "carbon-addons-iot-react",
   "engines": {
-    "node": "12.x",
-    "yarn": "1.x"
+    "node": "10.x || 12.x"
   },
   "main": "lib/src/index.js",
   "module": "es/src/index.js",
@@ -43,7 +42,7 @@
     "test:watch": "yarn test:engines && cross-env NODE_ICU_DATA=node_modules/full-icu TZ=America/Chicago jest --testPathPattern='.*\\.test\\.js(x)?' --watch --verbose --coverage",
     "test:update": "yarn test:engines && cross-env NODE_ICU_DATA=node_modules/full-icu TZ=America/Chicago jest src/components/StorybookSnapshots.test.js src/utils/__tests__/publicAPI.test.js --updateSnapshot",
     "test:clear": "yarn test:engines && cross-env NODE_ICU_DATA=node_modules/full-icu TZ=America/Chicago jest --clearCache",
-    "test:engines": "check-node-version --package"
+    "test:engines": "check-node-version --node $(cat .nvmrc) --yarn 1.x"
   },
   "stylelint": {
     "extends": "stylelint-config-recommended-scss",


### PR DESCRIPTION
**Summary**

- Correct `engines` to allow node 10 or 12, ensure node 12 is used when developing locally

**Change List (commits, features, bugs, etc)**

- update package.json

**Acceptance Test (how to verify the PR)**

- pull down the branch, run the following:

| command | expected result |
| - | - |
| `nvm use 8 && yarn` | ❌ should show failure message |
| `nvm use 10 && yarn` | ✅ should pass |
| `nvm use 12 && yarn` | ✅ should pass |
| `nvm use 14 && yarn` | ❌ should show failure message |
| `nvm use 10 && yarn test:engines` | ❌ should show `check-node-version` failure message |
| `nvm use 12 && yarn test:engines` | ✅ should pass | 
| `nvm use 14 && yarn test:engines` | ❌ should show `check-node-version` failure message |

