### PR TITLE
fix(deps): updated use-resize-observer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "rollup-plugin-auto-external": "^2.0.0",
     "styled-components": "^4.1.3",
     "use-deep-compare-effect": "^1.2.0",
-    "use-resize-observer": "^5.0.0",
+    "use-resize-observer": "^6.1.0",
     "uuid": "^3.3.2",
     "warning": "^4.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19847,14 +19847,7 @@ use-deep-compare-effect@^1.2.0:
     "@babel/runtime" "^7.2.0"
     dequal "^1.0.0"
 
-use-resize-observer@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-5.0.0.tgz#2c1a1643bf0891ca094163c60ad0b08948540ec3"
-  integrity sha512-mQGibkHUeXW6iAog7wCv5UduAxWA8CTmhu54Z3s5IMPafvYhFJDRUzj36/9JrybFJ86HeIPZsV58ZhSghQJF/Q==
-  dependencies:
-    resize-observer-polyfill "^1.5.1"
-
-use-resize-observer@^6.0.0:
+use-resize-observer@^6.0.0, use-resize-observer@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-6.1.0.tgz#d4d267a940dbf9c326da6042f8a4bb8c89d29729"
   integrity sha512-SiPcWHiIQ1CnHmb6PxbYtygqiZXR0U9dNkkbpX9VYnlstUwF8+QqpUTrzh13pjPwcjMVGR+QIC+nvF5ujfFNng==


### PR DESCRIPTION
Closes #1250

**Summary**

- Updated use-resize-observer dependency

**Change List (commits, features, bugs, etc)**

- package.json and yarn.lock

**Acceptance Test (how to verify the PR)**

- yarn lint
