### PR TITLE
fix(table): row action gradient height should be dynamic

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -452,6 +452,7 @@ const Table = props => {
             [`${iotPrefix}--data-table--resize`]: options.hasResize,
             [`${iotPrefix}--data-table--fixed`]:
               options.hasResize && !options.useAutoTableLayoutForResize,
+            [`${iotPrefix}--data-table--row-actions`]: options.hasRowActions,
           })}
           {...others}
         >

--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -529,4 +529,16 @@ describe('Table', () => {
     expect(wrapper3.find(TableBodyRow).prop('options').truncateCellText).toBeFalsy();
     expect(wrapper3.find(TableHead).prop('options').truncateCellText).toBeFalsy();
   });
+
+  it('table should get row-actions HTML class only when rowActions are enabled', () => {
+    const wrapper = mount(
+      <Table columns={tableColumns} data={[tableData[0]]} options={{ hasRowActions: true }} />
+    );
+    expect(wrapper.exists(`table.${iotPrefix}--data-table--row-actions`)).toBeTruthy();
+
+    const wrapper2 = mount(
+      <Table columns={tableColumns} data={[tableData[0]]} options={{ hasRowActions: false }} />
+    );
+    expect(wrapper2.exists(`table.${iotPrefix}--data-table--row-actions`)).toBeFalsy();
+  });
 });

--- a/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -5,6 +5,7 @@
 }
 
 .#{$iot-prefix}--row-actions-container {
+  height: 100%;
   > * {
     margin-left: $spacing-04;
   }
@@ -18,6 +19,7 @@
 }
 
 .#{$iot-prefix}--row-actions-container__background {
+  height: 100%;
   align-items: center;
   display: flex;
   flex-shrink: 0;

--- a/src/components/Table/_table.scss
+++ b/src/components/Table/_table.scss
@@ -7,6 +7,10 @@ table.#{$prefix}--side-nav--data-table {
   white-space: nowrap;
 }
 
+.#{$iot-prefix}--data-table--row-actions {
+  height: 0;
+}
+
 .#{$iot-prefix}--data-table--fixed {
   table-layout: fixed;
 }


### PR DESCRIPTION
Closes #1085

**Summary**
Row action gradient container should fill the entire height of the table cells

The fix requires the table height to be 0. I've checked that all the stories and they seem to look normal.

**Change List (commits, features, bugs, etc)**
- Added css.
- Added unit test

**Acceptance Test (how to verify the PR)**
1. go to story watson-iot-table--stateful-example-with-expansion-maxpages-and-column-resize

2. Using chrome dev tools element inspector select the first row and force element state "hover"
![image](https://user-images.githubusercontent.com/5167091/84287245-f16d8f80-ab3f-11ea-80f5-b80f1171f66a.png)

3. Again with the element inspector hover over the `row-actions-container__background` and make sure it fills the table cell vertically
![image](https://user-images.githubusercontent.com/5167091/84288980-3a264800-ab42-11ea-8abb-b0b71c47414b.png)
