### PR TITLE
fix(image-hotspot): removed unused props

### DIFF
--- a/src/components/ImageCard/Hotspot.jsx
+++ b/src/components/ImageCard/Hotspot.jsx
@@ -126,7 +126,6 @@ const Hotspot = ({
         {...others}
         triggerText={iconToRender}
         showIcon={false}
-        clickToOpen
         triggerId={`hotspot-${x}-${y}`}
         tooltipId={`hotspot-${x}-${y}`}
       >

--- a/src/components/ImageCard/ImageHotspots.jsx
+++ b/src/components/ImageCard/ImageHotspots.jsx
@@ -383,13 +383,11 @@ const ImageHotspots = ({
             }
             key={`${hotspot.x}-${hotspot.y}`}
             style={hotspotsStyle}
-            offsetX={image.offsetX}
-            offsetY={image.offsetY}
             renderIconByName={renderIconByName}
           />
         );
       }),
-    [hotspots, hotspotsStyle, image.offsetX, image.offsetY, locale, renderIconByName]
+    [hotspots, hotspotsStyle, locale, renderIconByName]
   );
 
   if (imageLoaded) {


### PR DESCRIPTION
Closes #1154

**Summary**

- Removed unused props in ImageCard with hotspots causing errors

**Change List (commits, features, bugs, etc)**

- Removed `offsetX` and`offsetY` props being passed down to `Hotspot` in `ImageHotspot.jsx`
- Removed `clickToOpen` prop being passed down to `Tooltip` in `Hotspot.jsx`

**Acceptance Test (how to verify the PR)**

- Open Storybook
- Render the ImageCard with hotspots story
- Open console and see no more errors popping up
