### PR TITLE
fix(barchartcard): use label in simple, time-series

### DIFF
--- a/src/components/BarChartCard/barChartUtils.js
+++ b/src/components/BarChartCard/barChartUtils.js
@@ -167,7 +167,8 @@ export const formatChartData = (series, values, categoryDataSourceId, timeDataSo
           if (!isNil(value[series[0].dataSourceId])) {
             const dataDate = new Date(value[timeDataSourceId]);
             data.push({
-              group: series[0].dataSourceId, // bar this data belongs to
+              // Use the label if one exists
+              group: series[0].label ? series[0].label : series[0].dataSourceId, // bar this data belongs to
               value: value[series[0].dataSourceId], // there should only be one series here because its a simple bar
               date: dataDate, // timestamp
             });

--- a/src/components/BarChartCard/barChartUtils.test.js
+++ b/src/components/BarChartCard/barChartUtils.test.js
@@ -265,6 +265,7 @@ describe('barChartUtils', () => {
     const series = [
       {
         dataSourceId: 'particles',
+        label: 'Particles',
       },
     ];
     // check horizontal layout
@@ -279,22 +280,22 @@ describe('barChartUtils', () => {
     ).toEqual([
       {
         date: new Date('2020-02-09T16:23:45.000Z'),
-        group: 'particles',
+        group: 'Particles',
         value: 447,
       },
       {
         date: new Date('2020-02-10T16:23:45.000Z'),
-        group: 'particles',
+        group: 'Particles',
         value: 450,
       },
       {
         date: new Date('2020-02-11T16:23:45.000Z'),
-        group: 'particles',
+        group: 'Particles',
         value: 512,
       },
       {
         date: new Date('2020-02-12T16:23:45.000Z'),
-        group: 'particles',
+        group: 'Particles',
         value: 565,
       },
     ]);


### PR DESCRIPTION
Closes #1312 

**Summary**

- Dataset series labels weren't being displayed so this PR checks to see if there is a label and uses it if true

**Change List (commits, features, bugs, etc)**

- Added conditional check for the `series[i].label`
- Added label to existing test

**Acceptance Test (how to verify the PR)**

- Go to https://deploy-preview-1313--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-barchartcard--simple-bar-time-series of netlify preview and see that the label now says `Particles' instead of 'particles'