### PR TITLE
fix(rowactioncell): change action color

### DIFF
--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -218,9 +218,7 @@ class RowActionsCell extends React.Component {
                       key={`${tableId}-${id}-row-actions-button-${actionId}`}
                       data-testid={`${tableId}-${id}-row-actions-button-${actionId}`}
                       kind="ghost"
-                      className={classnames({
-                        [`${iotPrefix}--row-actions-cell-btn--icononly`]: !labelText,
-                      })}
+                      hasIconOnly={!labelText}
                       onClick={e => onClick(e, id, actionId, onApplyRowAction)}
                     >
                       {labelText}

--- a/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -8,14 +8,6 @@
   > * {
     margin-left: $spacing-04;
   }
-  .#{$iot-prefix}--row-actions-cell-btn--icononly {
-    margin-left: 0;
-    color: black; // black by default
-
-    .#{$prefix}--btn__icon {
-      margin-left: 0;
-    }
-  }
 }
 
 .#{$iot-prefix}--row-actions-container__background {

--- a/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -10,11 +10,16 @@
   }
   .#{$iot-prefix}--row-actions-cell-btn--icononly {
     margin-left: 0;
+    color: unset; // black by default
 
     .#{$prefix}--btn__icon {
       margin-left: 0;
     }
   }
+}
+
+.#{$iot-prefix}--row-actions-cell-btn--icononly:hover {
+  color: $interactive-01; // blue on hover
 }
 
 .#{$iot-prefix}--row-actions-container__background {

--- a/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
+++ b/src/components/Table/TableBody/RowActionsCell/_row-actions-cell.scss
@@ -10,16 +10,12 @@
   }
   .#{$iot-prefix}--row-actions-cell-btn--icononly {
     margin-left: 0;
-    color: unset; // black by default
+    color: black; // black by default
 
     .#{$prefix}--btn__icon {
       margin-left: 0;
     }
   }
-}
-
-.#{$iot-prefix}--row-actions-cell-btn--icononly:hover {
-  color: $interactive-01; // blue on hover
 }
 
 .#{$iot-prefix}--row-actions-container__background {

--- a/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -87,13 +87,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--row-actions-container__background"
                 >
                   <button
-                    className="iot--row-actions-cell-btn--icononly bx--btn bx--btn--ghost"
+                    className="bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                     data-testid="tableId-rowId-row-actions-button-add"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex={0}
                     type="button"
                   >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Add
+                    </span>
                     <svg
                       aria-hidden="true"
                       aria-label="Add"
@@ -232,13 +237,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--row-actions-container__background"
                 >
                   <button
-                    className="iot--row-actions-cell-btn--icononly bx--btn bx--btn--ghost"
+                    className="bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                     data-testid="tableId-rowId-row-actions-button-add"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex={0}
                     type="button"
                   >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Add
+                    </span>
                     <svg
                       aria-hidden="true"
                       aria-label="Add"
@@ -449,13 +459,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--row-actions-container__background"
                 >
                   <button
-                    className="iot--row-actions-cell-btn--icononly bx--btn bx--btn--ghost"
+                    className="bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                     data-testid="tableId-rowId-row-actions-button-add"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex={0}
                     type="button"
                   >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Add
+                    </span>
                     <svg
                       aria-hidden="true"
                       aria-label="Add"
@@ -591,13 +606,18 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   className="iot--row-actions-container__background"
                 >
                   <button
-                    className="iot--row-actions-cell-btn--icononly bx--btn bx--btn--ghost"
+                    className="bx--btn bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
                     data-testid="tableId-rowId-row-actions-button-add"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex={0}
                     type="button"
                   >
+                    <span
+                      className="bx--assistive-text"
+                    >
+                      Add
+                    </span>
                     <svg
                       aria-hidden="true"
                       aria-label="Add"


### PR DESCRIPTION
Closes #1314 

**Summary**

- Color was blue by default which did not adhere to the original design

**Change List (commits, features, bugs, etc)**

- Swap color to black by default and blue on hover

**Acceptance Test (how to verify the PR)**

- Check the row actions story to see that the colors are correct

![Screen Shot 2020-06-16 at 12 48 37 PM](https://user-images.githubusercontent.com/25177649/84809530-c7005400-afcf-11ea-9e9e-6033a1def090.png)


