### PR TITLE
fix(hierarchylist): preserve expanded state

### DIFF
--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -162,7 +162,7 @@ const HierarchyList = ({
       // Expand the parent elements of the defaultSelectedId
       if (defaultSelectedId) {
         const tempFilteredItems = searchForNestedItemIds(items, defaultSelectedId);
-        const tempExpandedIds = [];
+        const tempExpandedIds = [...expandedIds];
         // Expand the categories that have found results
         tempFilteredItems.forEach(categoryItem => {
           tempExpandedIds.push(categoryItem.id);
@@ -170,6 +170,7 @@ const HierarchyList = ({
         setExpandedIds(tempExpandedIds);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [defaultSelectedId, items]
   );
 


### PR DESCRIPTION
Closes #1319

**Summary**

Need to preserve the `expandedIds` state so that items don't collapse on update of `defaultSelectedId`.

**Change List (commits, features, bugs, etc)**

Keep the previous `expandedIds` when useEffect re-runs based on the `defaultSelectedId` dependancy

**Acceptance Test (how to verify the PR)**

Hard to verify in storybook.
In 'with default selectedId' story, paste in a new `defaultSelectedId` and see that the other items do not collapse.
