### PR TITLE
fix(hierarchylist): set the selected state if defaultSelectedId changes

### DIFF
--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -168,8 +168,13 @@ const HierarchyList = ({
           tempExpandedIds.push(categoryItem.id);
         });
         setExpandedIds(tempExpandedIds);
+        // If the defaultSelectedId prop is updated from the outside, we need to use it
+        if (selectedId !== defaultSelectedId) {
+          setSelectedId(defaultSelectedId);
+        }
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [defaultSelectedId, items]
   );
 

--- a/src/components/List/HierarchyList/HierarchyList.test.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import debounce from 'lodash/debounce';
 
@@ -243,7 +243,7 @@ describe('HierarchyList', () => {
   });
 
   it('parent items of defaultSelectedId should be expanded', () => {
-    const { getByTitle, queryByTitle } = render(
+    const { getByTitle, queryByTitle, rerender } = render(
       <HierarchyList
         items={items}
         title="Hierarchy List"
@@ -253,7 +253,13 @@ describe('HierarchyList', () => {
       />
     );
     // Nested item should be visible
-    expect(getByTitle('JD Davis')).toBeInTheDocument();
+    const selectedItem = getByTitle('JD Davis');
+    expect(selectedItem).toBeInTheDocument();
+
+    // Should be marked selected
+    expect(selectedItem?.parentElement?.parentElement?.parentElement?.className).toContain(
+      '__selected'
+    );
     // All other categories should be visible still
     expect(getByTitle('New York Mets')).toBeInTheDocument();
     // Yankees are unfortunately worthy too...
@@ -264,6 +270,24 @@ describe('HierarchyList', () => {
     expect(getByTitle('Washington Nationals')).toBeInTheDocument();
     // But no Yankees players should be visible
     expect(queryByTitle('Gary Sanchez')).not.toBeInTheDocument();
+
+    // Change the defaultSelectedId property
+    rerender(
+      <HierarchyList
+        items={items}
+        title="Hierarchy List"
+        pageSize="xl"
+        defaultSelectedId="New York Yankees_Gary Sanchez"
+        hasPagination={false}
+      />
+    );
+    // TODO: The previously selected players category should still be expanded needs fix #1320
+    // expect(screen.queryByTitle('JD Davis')).toBeInTheDocument();
+    const selectedYankee = screen.getByTitle('Gary Sanchez');
+    expect(selectedYankee).toBeInTheDocument();
+    expect(selectedYankee?.parentElement?.parentElement?.parentElement?.className).toContain(
+      '__selected'
+    );
   });
 
   it('clicking item should fire onSelect', () => {

--- a/src/components/List/HierarchyList/HierarchyList.test.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.test.jsx
@@ -281,8 +281,7 @@ describe('HierarchyList', () => {
         hasPagination={false}
       />
     );
-    // TODO: The previously selected players category should still be expanded needs fix #1320
-    // expect(screen.queryByTitle('JD Davis')).toBeInTheDocument();
+    expect(screen.queryByTitle('JD Davis')).toBeInTheDocument();
     const selectedYankee = screen.getByTitle('Gary Sanchez');
     expect(selectedYankee).toBeInTheDocument();
     expect(selectedYankee?.parentElement?.parentElement?.parentElement?.className).toContain(


### PR DESCRIPTION
Closes #

**Summary**

- If you switch the defaultSelectedId in the live preview knob here, you'll notice the selected state doesn't get updated

**Change List (commits, features, bugs, etc)**

- Small change to set the selectedId if the defaultSelectedId incoming prop changes

**Acceptance Test (how to verify the PR)**

- Verify that if you change the defaultSelectedId in the story, the visual selection state is updated
