### PR TITLE
add 'needs triage' label to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: "Bug report \U0001F41B"
 about: Create a report to help us improve
 title: '[ComponentName] bug_title'
-labels: 'type: bug :bug:'
+labels: 'type: bug :bug:, status: needs triage :mag:'
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
@@ -2,7 +2,7 @@
 name: "Feature request or enhancement \U0001F4A1"
 about: Suggest an idea for improvement
 title: '[ComponentName] request_title'
-labels: 'type: enhancement :bulb:'
+labels: 'type: enhancement :bulb:, status: needs triage :mag:'
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/new-component-proposal.md
+++ b/.github/ISSUE_TEMPLATE/new-component-proposal.md
@@ -2,7 +2,7 @@
 name: New component proposal ✨
 about: Nominate a new component to be added to the library
 title: '[Component Proposal] New_ComponentName'
-labels: 'type: enhancement :bulb:, type: discussion :speech_balloon:, type: contribution :gift:'
+labels: 'type: enhancement :bulb:, type: discussion :speech_balloon:, type: contribution :gift:, status: needs triage :mag:'
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question ❓
 about: Ask a question regarding usage or discussion about components
 title: '[ComponentName] question_title?'
-labels: 'type: question :grey_question:'
+labels: 'type: question :grey_question:, status: needs triage :mag:'
 assignees: ''
 ---
 


### PR DESCRIPTION
**Summary**

- This will help us filter issues that haven't been addressed, validated, estimated, etc.

**Change List (commits, features, bugs, etc)**

- add label to all 4 issue templates
