### PR TITLE
feat(classnames): updated classnames import for a consistent import name

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -76,23 +76,6 @@
     ],
     "no-prototype-builtins": 0, // not needed as we never mess with prototype
     "no-nested-ternary": 0,
-    "no-restricted-imports": ["warn", {
-      "paths": [{
-        "name": "classnames",
-        "importNames": ["classNames"],
-        "message": "Please use classnames from classnames instead."
-      },
-      {
-        "name": "classnames",
-        "importNames": ["cx"],
-        "message": "Please use classnames from classnames instead."
-      },
-      {
-        "name": "classnames",
-        "importNames": ["cn"],
-        "message": "Please use classnames from classnames instead."
-      }]
-    }],
     "react/jsx-one-expression-per-line": 0,
     "react/no-did-update-set-state": 0, //not needed after react 16: https://github.com/yannickcr/eslint-plugin-react/issues/1754
     "react/no-array-index-key": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -76,6 +76,23 @@
     ],
     "no-prototype-builtins": 0, // not needed as we never mess with prototype
     "no-nested-ternary": 0,
+    "no-restricted-imports": ["warn", {
+      "paths": [{
+        "name": "classnames",
+        "importNames": ["classNames"],
+        "message": "Please use classnames from classnames instead."
+      },
+      {
+        "name": "classnames",
+        "importNames": ["cx"],
+        "message": "Please use classnames from classnames instead."
+      },
+      {
+        "name": "classnames",
+        "importNames": ["cn"],
+        "message": "Please use classnames from classnames instead."
+      }]
+    }],
     "react/jsx-one-expression-per-line": 0,
     "react/no-did-update-set-state": 0, //not needed after react 16: https://github.com/yannickcr/eslint-plugin-react/issues/1754
     "react/no-array-index-key": 0,

--- a/src/components/AddCard/AddCard.jsx
+++ b/src/components/AddCard/AddCard.jsx
@@ -1,7 +1,7 @@
 import { ClickableTile } from 'carbon-components-react';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { g10 } from '@carbon/themes';
 import { Add20 } from '@carbon/icons-react';
 
@@ -20,7 +20,7 @@ const propTypes = {
  * Clickable card that shows "Add" button
  */
 const AddCard = ({ onClick, title, className }) => (
-  <ClickableTile className={classNames(`${iotPrefix}-add-card`, className)} handleClick={onClick}>
+  <ClickableTile className={classnames(`${iotPrefix}-add-card`, className)} handleClick={onClick}>
     <p className={`${iotPrefix}-addcard-title`}>{title}</p>
     <Add20 fill={g10.icon01} description={title} />
   </ClickableTile>

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button as CarbonButton, Loading } from 'carbon-components-react';
 import { ButtonKinds } from 'carbon-components-react/es/prop-types/types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 
@@ -58,7 +58,7 @@ const Button = props => {
       kind={kind === 'icon-selection' ? 'ghost' : kind}
       hasIconOnly={kind === 'icon-selection' ? true : hasIconOnly}
       onClick={onClick}
-      className={classNames(className, `${iotPrefix}--btn`, {
+      className={classnames(className, `${iotPrefix}--btn`, {
         [`${iotPrefix}--btn-icon-selection`]: kind === 'icon-selection',
         [`${iotPrefix}--btn-icon-selection--recommended`]:
           kind === 'icon-selection' && !disabled && recommended,

--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useEffect, useState } from 'react';
 import VisibilitySensor from 'react-visibility-sensor';
 import { Tooltip, SkeletonText } from 'carbon-components-react';
 import SizeMe from 'react-sizeme';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { settings } from '../../constants/Settings';
@@ -56,7 +56,7 @@ const CardWrapper = ({
       onTouchEnd={onTouchEnd}
       onTouchStart={onTouchStart}
       onScroll={onScroll}
-      className={classNames(className, `${iotPrefix}--card--wrapper`)}
+      className={classnames(className, `${iotPrefix}--card--wrapper`)}
       {...validOthers}
     >
       {children}
@@ -83,7 +83,7 @@ const CardContent = props => {
   return (
     <div
       style={{ [`--card-content-height`]: height }}
-      className={classNames(`${iotPrefix}--card--content`, {
+      className={classnames(`${iotPrefix}--card--content`, {
         [`${iotPrefix}--card--content--expanded`]: isExpanded,
       })}
     >
@@ -311,7 +311,7 @@ const Card = props => {
                         width: 'calc(100% - 50px)',
                       }
                 }
-                className={classNames(`${iotPrefix}--card`, className)}
+                className={classnames(`${iotPrefix}--card`, className)}
               >
                 {!hideHeader && (
                   <CardHeader>

--- a/src/components/Card/CardRangePicker.jsx
+++ b/src/components/Card/CardRangePicker.jsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { EventSchedule16 } from '@carbon/icons-react';
 import { ToolbarItem, OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import isNil from 'lodash/isNil';
 
 import { settings } from '../../constants/Settings';
@@ -70,7 +70,7 @@ const CardRangePicker = ({ i18n, timeRange: timeRangeProp, onCardAction, cardWid
         ) : null}
 
         <OverflowMenu
-          className={classNames(`${iotPrefix}--card--toolbar-date-range-action`)}
+          className={classnames(`${iotPrefix}--card--toolbar-date-range-action`)}
           flipped
           title={i18n.selectTimeRangeLabel}
           iconDescription={i18n.selectTimeRangeLabel}
@@ -81,7 +81,7 @@ const CardRangePicker = ({ i18n, timeRange: timeRangeProp, onCardAction, cardWid
             key="default"
             onClick={() => handleTimeRange('default')}
             itemText={i18n.defaultLabel}
-            className={classNames({
+            className={classnames({
               [`${iotPrefix}--card--overflow-menuitem-active`]:
                 timeRange === '' || isNil(timeRange),
             })}
@@ -95,7 +95,7 @@ const CardRangePicker = ({ i18n, timeRange: timeRangeProp, onCardAction, cardWid
                 hasDivider={index === 0}
                 onClick={() => handleTimeRange(i)}
                 itemText={timeBoxLabels[i]}
-                className={classNames({
+                className={classnames({
                   [`${iotPrefix}--card--overflow-menuitem-active`]: timeRange === i,
                 })}
               />
@@ -108,7 +108,7 @@ const CardRangePicker = ({ i18n, timeRange: timeRangeProp, onCardAction, cardWid
                 hasDivider={index === 0}
                 onClick={() => handleTimeRange(i)}
                 itemText={timeBoxLabels[i]}
-                className={classNames({
+                className={classnames({
                   [`${iotPrefix}--card--overflow-menuitem-active`]: timeRange === i,
                 })}
               />

--- a/src/components/Card/CardToolbar.jsx
+++ b/src/components/Card/CardToolbar.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import { Close16, Popup16 } from '@carbon/icons-react';
 import { OverflowMenu, OverflowMenuItem, Button } from 'carbon-components-react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 import { CARD_ACTIONS } from '../../constants/LayoutConstants';
@@ -16,7 +16,7 @@ const ToolbarSVGWrapper = props => {
   return (
     <Button
       kind="ghost"
-      className={classNames(
+      className={classnames(
         `${iotPrefix}--card--toolbar-action`,
         `${iotPrefix}--card--toolbar-svg-wrapper`,
         `${prefix}--btn--icon-only` // can't actually use the hasIconOnly prop because we don't want the tooltip
@@ -52,7 +52,7 @@ const CardToolbar = ({
   className,
 }) => {
   return isEditable ? (
-    <div className={classNames(className, `${iotPrefix}--card--toolbar`)}>
+    <div className={classnames(className, `${iotPrefix}--card--toolbar`)}>
       {(availableActions.edit || availableActions.clone || availableActions.delete) && (
         <OverflowMenu flipped title={i18n.overflowMenuDescription}>
           {availableActions.edit && (
@@ -85,7 +85,7 @@ const CardToolbar = ({
       )}
     </div>
   ) : (
-    <div className={classNames(className, `${iotPrefix}--card--toolbar`)}>
+    <div className={classnames(className, `${iotPrefix}--card--toolbar`)}>
       {availableActions.range ? (
         <CardRangePicker
           width={width}

--- a/src/components/ComposedModal/ComposedModal.jsx
+++ b/src/components/ComposedModal/ComposedModal.jsx
@@ -8,7 +8,7 @@ import {
 } from 'carbon-components-react';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import styled from 'styled-components';
 import { rem } from 'polished';
 import warning from 'warning';
@@ -229,7 +229,7 @@ class ComposedModal extends React.Component {
         {...props}
         open={open}
         onClose={this.doNotClose}
-        className={classNames(className, {
+        className={classnames(className, {
           'error-modal': type === 'warn',
           'big-modal': isLarge,
         })}

--- a/src/components/Header/HeaderAction/HeaderActionMenu.jsx
+++ b/src/components/Header/HeaderAction/HeaderActionMenu.jsx
@@ -1,6 +1,6 @@
 import { ChevronDown32 } from '@carbon/icons-react';
 import { settings } from 'carbon-components';
-import cx from 'classnames';
+import classnames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { HeaderMenuItem } from 'carbon-components-react/es/components/UIShell';
@@ -72,7 +72,7 @@ class HeaderActionMenu extends React.Component {
       'aria-labelledby': ariaLabelledBy,
     };
 
-    const className = cx(`${prefix}--header__submenu`, customClassName);
+    const className = classnames(`${prefix}--header__submenu`, customClassName);
 
     // Prevents the a element from navigating to it's href target
     const handleDefaultClick = event => {
@@ -94,7 +94,7 @@ class HeaderActionMenu extends React.Component {
         <a // eslint-disable-line jsx-a11y/role-supports-aria-props,jsx-a11y/anchor-is-valid
           aria-haspopup="menu" // eslint-disable-line jsx-a11y/aria-proptypes
           aria-expanded={isExpanded}
-          className={cx(`${prefix}--header__menu-item`, `${prefix}--header__menu-title`)}
+          className={classnames(`${prefix}--header__menu-item`, `${prefix}--header__menu-title`)}
           href=""
           onKeyDown={this.handleOnKeyDown}
           onClick={handleDefaultClick}

--- a/src/components/Header/HeaderAction/HeaderActionPanel.jsx
+++ b/src/components/Header/HeaderAction/HeaderActionPanel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { settings } from 'carbon-components';
-import cn from 'classnames';
+import classnames from 'classnames';
 import { HeaderGlobalAction, HeaderPanel } from 'carbon-components-react/es/components/UIShell';
 
 import { APP_SWITCHER } from '../Header';
@@ -53,10 +53,10 @@ const HeaderActionPanel = ({ item, index, onToggleExpansion, isExpanded, focusRe
         aria-label="Header Panel"
         className={
           item.label !== APP_SWITCHER
-            ? cn('action-btn__headerpanel', {
+            ? classnames('action-btn__headerpanel', {
                 'action-btn__headerpanel--closed': !isExpanded,
               })
-            : cn(`${carbonPrefix}--app-switcher`, {
+            : classnames(`${carbonPrefix}--app-switcher`, {
                 [item.childContent[0].className]: item.childContent[0].className,
               })
         }

--- a/src/components/IconSwitch/IconSwitch.jsx
+++ b/src/components/IconSwitch/IconSwitch.jsx
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { Button as CarbonButton } from 'carbon-components-react';
 
 import { settings } from '../../constants/Settings';
@@ -47,7 +47,7 @@ const IconSwitch = React.forwardRef((props, ref) => {
     }
   };
 
-  const classes = classNames(
+  const classes = classnames(
     className,
     `${iotPrefix}--icon-switch`,
     `${iotPrefix}--icon-switch--${size}`,

--- a/src/components/ListCard/ListCard.jsx
+++ b/src/components/ListCard/ListCard.jsx
@@ -8,7 +8,7 @@ import {
   Link,
 } from 'carbon-components-react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { CARD_CONTENT_PADDING } from '../../constants/LayoutConstants';
 import { CardPropTypes } from '../../constants/CardPropTypes';
@@ -41,7 +41,7 @@ const ListCard = ({
   return (
     <Card id={id} title={title} size={size} onScroll={handleScroll} {...others}>
       <div
-        className={classNames('list-card', className)}
+        className={classnames('list-card', className)}
         style={{
           paddingTop: 0,
           paddingRight: CARD_CONTENT_PADDING,

--- a/src/components/PageTitleBar/PageTitleBar.jsx
+++ b/src/components/PageTitleBar/PageTitleBar.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { Information20, Edit20 } from '@carbon/icons-react';
 import { Breadcrumb, BreadcrumbItem, Tooltip, SkeletonText, Tabs } from 'carbon-components-react';
 
@@ -78,7 +78,7 @@ const PageTitleBar = ({
   //
   const titleBarContent = content || tabs;
   return (
-    <div className={classNames(className, 'page-title-bar')}>
+    <div className={classnames(className, 'page-title-bar')}>
       {isLoading ? (
         <SkeletonText className="page-title-bar-loading" heading width="30%" />
       ) : (

--- a/src/components/PageWizard/PageWizard.jsx
+++ b/src/components/PageWizard/PageWizard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ProgressIndicator, ProgressStep } from 'carbon-components-react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 
@@ -117,7 +117,7 @@ const PageWizard = ({
 
   return (
     <div
-      className={classNames(
+      className={classnames(
         isProgressIndicatorVertical ? `${iotPrefix}--page-wizard` : null,
         className,
         hasStickyFooter ? `${iotPrefix}--page-wizard__sticky` : null
@@ -132,7 +132,7 @@ const PageWizard = ({
           }
         >
           <ProgressIndicator
-            className={classNames(className, `${iotPrefix}--progress-indicator`)}
+            className={classnames(className, `${iotPrefix}--progress-indicator`)}
             currentIndex={currentStepIdx}
             onChange={idx => setStep(steps[idx].id)}
             vertical={isProgressIndicatorVertical}

--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -4,7 +4,7 @@ import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import { Table as CarbonTable, TableContainer } from 'carbon-components-react';
 import isNil from 'lodash/isNil';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { defaultFunction } from '../../utils/componentUtilityFunctions';
 import { settings } from '../../constants/Settings';
@@ -374,7 +374,7 @@ const Table = props => {
   return (
     <TableContainer
       style={style}
-      className={classNames(className, `${iotPrefix}--table-container`)}
+      className={classnames(className, `${iotPrefix}--table-container`)}
     >
       {/* If there is no items being rendered in the toolbar, don't render the toolbar */
       options.hasFilter ||
@@ -448,7 +448,7 @@ const Table = props => {
       ) : null}
       <div className="addons-iot-table-container">
         <CarbonTable
-          className={classNames({
+          className={classnames({
             [`${iotPrefix}--data-table--resize`]: options.hasResize,
             [`${iotPrefix}--data-table--fixed`]:
               options.hasResize && !options.useAutoTableLayoutForResize,

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { DataTable, Checkbox } from 'carbon-components-react';
 import styled from 'styled-components';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { settings } from '../../../../constants/Settings';
 import RowActionsCell from '../RowActionsCell/RowActionsCell';
@@ -417,7 +417,7 @@ const TableBodyRow = ({
             data-offset={offset}
             offset={offset}
             align={align}
-            className={classNames(`data-table-${align}`, {
+            className={classnames(`data-table-${align}`, {
               [`${iotPrefix}--table__cell--truncate`]: truncateCellText,
             })}
             width={initialColumnWidth}

--- a/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
+++ b/src/components/Table/TableHead/ColumnHeaderSelect/ColumnHeaderSelect.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { DragSource, DropTarget } from 'react-dnd';
 import { Button } from 'carbon-components-react';
 import { Draggable16 } from '@carbon/icons-react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { settings } from '../../../../constants/Settings';
 
@@ -21,7 +21,7 @@ const ColumnHeaderSelect = ({
 }) => {
   return (
     <Button
-      className={classNames(
+      className={classnames(
         'column-header__btn',
         `${iotPrefix}--column-header`,
         'column-header__select',

--- a/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
+++ b/src/components/Table/TableHead/FilterHeaderRow/FilterHeaderRow.jsx
@@ -4,7 +4,7 @@ import { ComboBox, DataTable, FormItem, TextInput } from 'carbon-components-reac
 import { Close16 } from '@carbon/icons-react';
 import styled from 'styled-components';
 import memoize from 'lodash/memoize';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import debounce from 'lodash/debounce';
 
 import { COLORS } from '../../../../styles/styles';
@@ -310,7 +310,7 @@ class FilterHeaderRow extends Component {
                   {this.state[column.id] ? ( // eslint-disable-line react/destructuring-assignment
                     <div
                       role="button"
-                      className={classNames(`${prefix}--list-box__selection`, {
+                      className={classnames(`${prefix}--list-box__selection`, {
                         [`${iotPrefix}--clear-filters-button--disabled`]: isDisabled,
                       })}
                       tabIndex={isDisabled ? '-1' : '0'}

--- a/src/components/Table/TableHead/TableHeader.js
+++ b/src/components/Table/TableHead/TableHeader.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import cx from 'classnames';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { settings } from 'carbon-components';
@@ -75,7 +75,7 @@ const TableHeader = React.forwardRef(function TableHeader(
     );
   }
 
-  const className = cx(headerClassName, {
+  const className = classnames(headerClassName, {
     [`${prefix}--table-sort`]: true,
     [`${prefix}--table-sort--active`]: isSortHeader && sortDirection !== sortStates.NONE,
     [`${prefix}--table-sort--ascending`]: isSortHeader && sortDirection === sortStates.DESC,

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Column20, Filter20, Download20, Edit20 } from '@carbon/icons-react';
 import { DataTable, Button, Tooltip } from 'carbon-components-react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import deprecate from '../../../internal/deprecate';
 import {
@@ -144,7 +144,7 @@ const TableToolbar = ({
     rowEditBarButtons,
   },
 }) => (
-  <CarbonTableToolbar className={classNames(`${iotPrefix}--table-toolbar`, className)}>
+  <CarbonTableToolbar className={classnames(`${iotPrefix}--table-toolbar`, className)}>
     <TableBatchActions
       className={`${iotPrefix}--table-batch-actions`}
       onCancel={onCancelBatchAction}

--- a/src/components/Table/TableToolbar/TableToolbarSVGButton.jsx
+++ b/src/components/Table/TableToolbar/TableToolbarSVGButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { Button } from 'carbon-components-react';
 
 import { settings } from '../../../constants/Settings';
@@ -30,7 +30,7 @@ const TableToolbarSVGButton = ({ onClick, testId, className, description, isActi
   return (
     <Button
       {...rest}
-      className={classNames(
+      className={classnames(
         `${prefix}--btn--icon-only`,
         `${iotPrefix}--tooltip-svg-wrapper`,
         className,

--- a/src/components/TileCatalog/TileCatalog.jsx
+++ b/src/components/TileCatalog/TileCatalog.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { RadioTile, Tile, SkeletonText, DataTable } from 'carbon-components-react';
 import { Bee32 } from '@carbon/icons-react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import SimplePagination from '../SimplePagination/SimplePagination';
 import { settings } from '../../constants/Settings';
@@ -92,7 +92,7 @@ const TileCatalog = ({
   const totalTiles = pagination && pagination.totalItems ? pagination.totalItems : 10;
 
   return (
-    <div className={classNames(className, `${iotPrefix}--tile-catalog`)}>
+    <div className={classnames(className, `${iotPrefix}--tile-catalog`)}>
       <div className={`${iotPrefix}--tile-catalog--header`}>
         {search && search.placeHolderText ? (
           <TableToolbarSearch

--- a/src/components/TileCatalog/TileGroup.jsx
+++ b/src/components/TileCatalog/TileGroup.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tile } from 'carbon-components-react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { settings } from '../../constants/Settings';
 
@@ -17,7 +17,7 @@ const defaultProps = {
 
 /** this component just exists to make the last tile look good in a responsive flex container */
 const TileGroup = ({ tiles, className }) => (
-  <div className={classNames(className, `${iotPrefix}--tile-group`)}>
+  <div className={classnames(className, `${iotPrefix}--tile-group`)}>
     {tiles}
     <Tile className={`${iotPrefix}--greedy-tile`} />
   </div>

--- a/src/components/ValueCard/Attribute.jsx
+++ b/src/components/ValueCard/Attribute.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import isNil from 'lodash/isNil';
 import { CaretUp16, CaretDown16 } from '@carbon/icons-react';
 import withSize from 'react-sizeme';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
 import { settings } from '../../constants/Settings';
@@ -144,7 +144,7 @@ const Attribute = ({
   const renderThresholdIcon = allowedToWrap => {
     return (
       <div
-        className={classNames(`${bemBase}-threshold-icon-container`, {
+        className={classnames(`${bemBase}-threshold-icon-container`, {
           [`${bemBase}-threshold-icon-container--mini`]: isMini,
           [`${bemBase}-threshold-icon-container--wrappable`]: allowedToWrap,
         })}
@@ -172,7 +172,7 @@ const Attribute = ({
             isVertical={isVertical}
             isMini={isMini}
             label={label}
-            className={classNames({ [`${bemBase}--wrappable`]: allowWrap })}
+            className={classnames({ [`${bemBase}--wrappable`]: allowWrap })}
           >
             <ValueRenderer
               value={value}
@@ -214,7 +214,7 @@ const Attribute = ({
             ) : null}
             {matchingThreshold && matchingThreshold.icon ? (
               <div
-                className={classNames(`${bemBase}-icon-container`, {
+                className={classnames(`${bemBase}-icon-container`, {
                   [`${bemBase}-icon-container--wrappable`]: allowWrap,
                 })}
               >

--- a/src/components/ValueCard/UnitRenderer.jsx
+++ b/src/components/ValueCard/UnitRenderer.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { CARD_LAYOUTS } from '../../constants/LayoutConstants';
 import { settings } from '../../constants/Settings';
@@ -42,7 +42,7 @@ const UnitRenderer = ({
   const unitElement = (
     <span
       style={{ '--default-font-size': layout === CARD_LAYOUTS.HORIZONTAL ? '1.25rem' : '1.5rem' }}
-      className={classNames(bemBase, {
+      className={classnames(bemBase, {
         [`${bemBase}--wrappable`]: allowedToWrap,
         [`${bemBase}--not-wrappable`]: notAllowedToWrap,
         [`${bemBase}--wrappable-compact`]: wrapCompact,

--- a/src/components/ValueCard/ValueRenderer.jsx
+++ b/src/components/ValueCard/ValueRenderer.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import isNil from 'lodash/isNil';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 import { CARD_LAYOUTS, CARD_SIZES } from '../../constants/LayoutConstants';
 import {
@@ -131,7 +131,7 @@ const ValueRenderer = ({
       color={color}
       isVertical={isVertical}
       allowedToWrap={allowedToWrap}
-      className={classNames({
+      className={classnames({
         [`${iotPrefix}--value-card__attribute-value--wrappable`]: allowedToWrap,
         [`${iotPrefix}--value-card__attribute-value--wrappable-compact`]: wrapCompact,
       })}

--- a/src/components/WizardModal/WizardModal.jsx
+++ b/src/components/WizardModal/WizardModal.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import isNil from 'lodash/isNil';
 
 import ComposedModal from '../ComposedModal/ComposedModal';
@@ -155,7 +155,7 @@ class WizardModal extends Component {
     return (
       <ComposedModal
         {...other}
-        className={classNames(`${iotPrefix}--wizard-modal`, className)}
+        className={classnames(`${iotPrefix}--wizard-modal`, className)}
         footer={this.renderFooter()}
       >
         <ProgressIndicator


### PR DESCRIPTION
Closes #799

**Summary**

The classnames import used multiple names depending on the file (classnames, classNames, cx, cn), so the import names were updated so only one name is used (classnames).

**Change List (commits, features, bugs, etc)**

- Updated classnames import for a consistent import name
- Opened issue #1325 to track the progress for a potential ESLint rule that will maintain consistent naming for future imports.

**Acceptance Test (how to verify the PR)**

- In VSCode, do a project wide search for "classnames"
- This search should show that each time classnames is imported, it will be imported as "classnames"
<img width="643" alt="Screen Shot 2020-06-18 at 10 20 27 AM" src="https://user-images.githubusercontent.com/11526668/85039539-76af0080-b14d-11ea-83d4-73edca847352.png">

