### PR TITLE
feat(story): edited the title for the table sticky header story

### DIFF
--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -2006,7 +2006,7 @@ storiesOf('Watson IoT/Table', module)
     }
   )
   .add(
-    'with sticky header and cell tooltip calculation',
+    'with sticky header (experimental) and cell tooltip calculation',
     () => {
       const renderDataFunction = ({ value }) => (
         <div style={{ position: 'relative' }} data-floating-menu-container>

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -2061,7 +2061,7 @@ storiesOf('Watson IoT/Table', module)
     {
       centered: { disable: true },
       info: {
-        text: `To properly render a tooltip in a table with sticky headers you need to pass a menuOffset or menuOffsetFlip calculation to <Tooltip>`,
+        text: `StickyHeader is experimental. To properly render a tooltip in a table with sticky headers you need to pass a menuOffset or menuOffsetFlip calculation to <Tooltip>`,
       },
     }
   );


### PR DESCRIPTION
Closes #1242 

**Summary**

Made a note that the sticky header feature for the table is experimental.

**Change List (commits, features, bugs, etc)**

- Changed the title for the table sticky header story so it notes that the feature is experimental

**Acceptance Test (how to verify the PR)**

- When the storybook is launched (yarn start), scroll down to Table and view the stories within the component. The sticky header story should have (experimental) in the title to indicate.
<img width="175" alt="Screen Shot 2020-06-18 at 12 25 24 PM" src="https://user-images.githubusercontent.com/11526668/85052613-de217c00-b15e-11ea-9c92-8f52978153cc.png">

