### PR TITLE
Tablefilter fix

### DIFF
--- a/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
+++ b/src/components/Dashboard/__snapshots__/Dashboard.story.storyshot
@@ -1575,7 +1575,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           <tr>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -1585,7 +1585,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="alert"
                                 id="column-alert"
                                 onClick={[Function]}
@@ -1635,7 +1635,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -1645,7 +1645,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="hour"
                                 id="column-hour"
                                 onClick={[Function]}
@@ -1695,7 +1695,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -1705,7 +1705,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="pressure"
                                 id="column-pressure"
                                 onClick={[Function]}
@@ -3853,7 +3853,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           <tr>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -3863,7 +3863,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="alert"
                                 id="column-alert"
                                 onClick={[Function]}
@@ -3913,7 +3913,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -3923,7 +3923,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="hour"
                                 id="column-hour"
                                 onClick={[Function]}
@@ -3973,7 +3973,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -3983,7 +3983,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="pressure"
                                 id="column-pressure"
                                 onClick={[Function]}
@@ -6158,7 +6158,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           <tr>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -6168,7 +6168,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="alert"
                                 id="column-alert"
                                 onClick={[Function]}
@@ -6218,7 +6218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -6228,7 +6228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="hour"
                                 id="column-hour"
                                 onClick={[Function]}
@@ -6278,7 +6278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -6288,7 +6288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="pressure"
                                 id="column-pressure"
                                 onClick={[Function]}
@@ -7804,7 +7804,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           <tr>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -7814,7 +7814,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="timestamp"
                                 id="column-timestamp"
                                 onClick={[Function]}
@@ -7864,7 +7864,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -7874,7 +7874,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="Campus_EGL"
                                 id="column-Campus_EGL"
                                 onClick={[Function]}
@@ -7924,7 +7924,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -7934,7 +7934,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="peopleCount_EnterpriseBuilding_mean"
                                 id="column-peopleCount_EnterpriseBuilding_mean"
                                 onClick={[Function]}
@@ -7984,7 +7984,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -7994,7 +7994,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="headCount_EnterpriseBuilding_mean"
                                 id="column-headCount_EnterpriseBuilding_mean"
                                 onClick={[Function]}
@@ -8044,7 +8044,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -8054,7 +8054,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="capacity_EnterpriseBuilding_mean"
                                 id="column-capacity_EnterpriseBuilding_mean"
                                 onClick={[Function]}
@@ -10922,7 +10922,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           <tr>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -10932,7 +10932,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="alert"
                                 id="column-alert"
                                 onClick={[Function]}
@@ -10982,7 +10982,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -10992,7 +10992,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="hour"
                                 id="column-hour"
                                 onClick={[Function]}
@@ -11042,7 +11042,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -11052,7 +11052,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="pressure"
                                 id="column-pressure"
                                 onClick={[Function]}
@@ -25336,7 +25336,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                           <tr>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -25346,7 +25346,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="alert"
                                 id="column-alert"
                                 onClick={[Function]}
@@ -25396,7 +25396,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -25406,7 +25406,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="hour"
                                 id="column-hour"
                                 onClick={[Function]}
@@ -25456,7 +25456,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             </th>
                             <th
                               aria-sort="none"
-                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                              className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                               scope="col"
                               style={
                                 Object {
@@ -25466,7 +25466,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Dashb
                             >
                               <button
                                 align="start"
-                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                                className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                                 data-column="pressure"
                                 id="column-pressure"
                                 onClick={[Function]}

--- a/src/components/Table/TableHead/TableHead.jsx
+++ b/src/components/Table/TableHead/TableHead.jsx
@@ -121,7 +121,7 @@ const StyledCustomTableHeader = styled(TableHeader)`
       const { width } = props;
       return width !== undefined
         ? `
-       .bx--table-header-label { 
+       .bx--table-header-label {
           min-width: ${width};
           max-width: ${width};
           white-space: nowrap;
@@ -373,6 +373,7 @@ const TableHead = ({
       </TableRow>
       {filterBarActive && (
         <FilterHeaderRow
+          key={!hasFastFilter && JSON.stringify(filters)}
           columns={columns.map(column => ({
             ...column.filter,
             id: column.id,

--- a/src/components/TableCard/__snapshots__/TableCard.story.storyshot
+++ b/src/components/TableCard/__snapshots__/TableCard.story.storyshot
@@ -308,7 +308,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -318,7 +318,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -368,7 +368,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -378,7 +378,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="count"
                         id="column-count"
                         onClick={[Function]}
@@ -428,7 +428,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -438,7 +438,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -488,7 +488,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -498,7 +498,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-pressure"
                         id="column-iconColumn-pressure"
                         onClick={[Function]}
@@ -548,7 +548,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -558,7 +558,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -608,7 +608,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -618,7 +618,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="deviceId"
                         id="column-deviceId"
                         onClick={[Function]}
@@ -2707,7 +2707,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -2717,7 +2717,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -2767,7 +2767,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -2777,7 +2777,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="deviceId"
                         id="column-deviceId"
                         onClick={[Function]}
@@ -3871,7 +3871,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -3881,7 +3881,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -3931,7 +3931,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -3941,7 +3941,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="count"
                         id="column-count"
                         onClick={[Function]}
@@ -3991,7 +3991,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -4001,7 +4001,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -4051,7 +4051,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -4061,7 +4061,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-pressure"
                         id="column-iconColumn-pressure"
                         onClick={[Function]}
@@ -4111,7 +4111,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -4121,7 +4121,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -4171,7 +4171,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -4181,7 +4181,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="deviceId"
                         id="column-deviceId"
                         onClick={[Function]}
@@ -4231,7 +4231,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -4241,7 +4241,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="Link"
                         id="column-Link"
                         onClick={[Function]}
@@ -6533,7 +6533,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -6543,7 +6543,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -6593,7 +6593,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -6603,7 +6603,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -6653,7 +6653,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -6663,7 +6663,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -7906,7 +7906,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     />
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -7916,7 +7916,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -7966,7 +7966,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -7976,7 +7976,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -8026,7 +8026,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -8036,7 +8036,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -9610,7 +9610,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -9620,7 +9620,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -9670,7 +9670,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -9680,7 +9680,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -9730,7 +9730,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -9740,7 +9740,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -10163,7 +10163,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -10173,7 +10173,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -10223,7 +10223,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -10233,7 +10233,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-count"
                         id="column-iconColumn-count"
                         onClick={[Function]}
@@ -10283,7 +10283,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -10293,7 +10293,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="count"
                         id="column-count"
                         onClick={[Function]}
@@ -10343,7 +10343,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -10353,7 +10353,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -10403,7 +10403,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -10413,7 +10413,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-pressure"
                         id="column-iconColumn-pressure"
                         onClick={[Function]}
@@ -10463,7 +10463,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -10473,7 +10473,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -12790,7 +12790,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -12800,7 +12800,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -12850,7 +12850,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -12860,7 +12860,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -12910,7 +12910,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -12920,7 +12920,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -14164,7 +14164,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -14174,7 +14174,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -14224,7 +14224,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="descending"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -14234,7 +14234,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort bx--table-sort--active bx--table-sort--ascending"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort bx--table-sort--active bx--table-sort--ascending"
                         data-column="count"
                         id="column-count"
                         onClick={[Function]}
@@ -14284,7 +14284,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -14294,7 +14294,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -14344,7 +14344,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -14354,7 +14354,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -15826,7 +15826,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jlFEAc"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 gKXIZx"
                       scope="col"
                       style={
                         Object {
@@ -15836,7 +15836,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jlFEAc bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 gKXIZx bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -15886,7 +15886,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -15896,7 +15896,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -15946,7 +15946,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -15956,7 +15956,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -17228,7 +17228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -17238,7 +17238,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -17288,7 +17288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -17298,7 +17298,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -17348,7 +17348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -17358,7 +17358,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -17408,7 +17408,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       align="start"
-                      className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-0 foRRTU"
+                      className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-0 gliGEk"
                       data-column="actionColumn"
                       id="column-actionColumn"
                       scope="col"
@@ -19218,7 +19218,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     />
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -19228,7 +19228,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -19278,7 +19278,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -19288,7 +19288,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -19338,7 +19338,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -19348,7 +19348,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -20934,7 +20934,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     />
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -20944,7 +20944,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -20994,7 +20994,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -21004,7 +21004,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -21054,7 +21054,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -21064,7 +21064,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -22650,7 +22650,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     />
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -22660,7 +22660,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -22710,7 +22710,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -22720,7 +22720,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -22770,7 +22770,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -22780,7 +22780,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -24362,7 +24362,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -24372,7 +24372,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -24422,7 +24422,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -24432,7 +24432,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -24482,7 +24482,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -24492,7 +24492,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -24542,7 +24542,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       align="start"
-                      className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-0 foRRTU"
+                      className="table-header-label-start TableHead__StyledCustomTableHeader-sc-1fviaow-0 gliGEk"
                       data-column="actionColumn"
                       id="column-actionColumn"
                       scope="col"
@@ -26100,7 +26100,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -26110,7 +26110,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -26160,7 +26160,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -26170,7 +26170,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-count"
                         id="column-iconColumn-count"
                         onClick={[Function]}
@@ -26220,7 +26220,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -26230,7 +26230,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="count"
                         id="column-count"
                         onClick={[Function]}
@@ -26280,7 +26280,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -26290,7 +26290,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -26340,7 +26340,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -26350,7 +26350,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-pressure"
                         id="column-iconColumn-pressure"
                         onClick={[Function]}
@@ -26400,7 +26400,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -26410,7 +26410,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -28699,7 +28699,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                   <tr>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -28709,7 +28709,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -28759,7 +28759,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -28769,7 +28769,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -28819,7 +28819,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -28829,7 +28829,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-count"
                         id="column-iconColumn-count"
                         onClick={[Function]}
@@ -28879,7 +28879,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -28889,7 +28889,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-pressure"
                         id="column-iconColumn-pressure"
                         onClick={[Function]}
@@ -30782,7 +30782,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     />
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -30792,7 +30792,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -30842,7 +30842,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -30852,7 +30852,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-count"
                         id="column-iconColumn-count"
                         onClick={[Function]}
@@ -30902,7 +30902,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -30912,7 +30912,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="count"
                         id="column-count"
                         onClick={[Function]}
@@ -30962,7 +30962,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -30972,7 +30972,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -31022,7 +31022,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -31032,7 +31032,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-pressure"
                         id="column-iconColumn-pressure"
                         onClick={[Function]}
@@ -31082,7 +31082,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -31092,7 +31092,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}
@@ -33443,7 +33443,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     />
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -33453,7 +33453,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="alert"
                         id="column-alert"
                         onClick={[Function]}
@@ -33503,7 +33503,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -33513,7 +33513,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="iconColumn-count"
                         id="column-iconColumn-count"
                         onClick={[Function]}
@@ -33563,7 +33563,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -33573,7 +33573,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="hour"
                         id="column-hour"
                         onClick={[Function]}
@@ -33623,7 +33623,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     </th>
                     <th
                       aria-sort="none"
-                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol"
+                      className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE"
                       scope="col"
                       style={
                         Object {
@@ -33633,7 +33633,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
                     >
                       <button
                         align="start"
-                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 hxyol bx--table-sort"
+                        className="table-header-label-start table-header-sortable TableHead__StyledCustomTableHeader-sc-1fviaow-0 jdOvaE bx--table-sort"
                         data-column="pressure"
                         id="column-pressure"
                         onClick={[Function]}


### PR DESCRIPTION
Closes #1330 

**Summary**

Fixes the clear filter issue that was introduced 

**Change List (commits, features, bugs, etc)**

- add key conditionally to filterheaderrow

**Acceptance Test (how to verify the PR)**

- go to ?path=/story/watson-iot-table--stateful-example-with-expansion-maxpages-and-column-resize
- open knobs and change hasFilter from onKeyPress to onBlur
- press clear filter button
- see that all filters are cleared. 
