### PR TITLE
fix(simplelist): SimpleList items are now deselectable

### DIFF
--- a/src/components/List/SimpleList/SimpleList.jsx
+++ b/src/components/List/SimpleList/SimpleList.jsx
@@ -85,9 +85,11 @@ const SimpleList = ({
   const [selectedId, setSelectedId] = useState(null);
 
   const handleSelect = id => {
-    setSelectedId(selectedId === id ? null : id);
+    setSelectedId(selectedIds.indexOf(id) !== -1 ? null : id);
     setSelectedIds(
-      selectedId === id ? selectedIds.filter(item => item.id !== id) : [...selectedIds, id]
+      selectedIds.indexOf(id) !== -1
+        ? selectedIds.filter(item => item !== id)
+        : [...selectedIds, id]
     );
   };
 

--- a/src/components/List/SimpleList/SimpleList.test.jsx
+++ b/src/components/List/SimpleList/SimpleList.test.jsx
@@ -166,4 +166,20 @@ describe('SimpleList', () => {
     expect(getByTitle('Item 4')).toBeTruthy();
     expect(getByTitle('Item 5')).toBeTruthy();
   });
+
+  it('SimpleList items should be unselectable', () => {
+    const { getAllByRole } = render(<SimpleList title="Simple list" items={getListItems(1)} />);
+
+    fireEvent.click(getAllByRole('button')[0]);
+    expect(getAllByRole('button')[0]).toBeInTheDocument();
+    expect(getAllByRole('button')[0]).toBeVisible();
+    expect(
+      getAllByRole('button')[0].className.includes(`${iotPrefix}--list-item__selected`)
+    ).toEqual(true);
+
+    fireEvent.click(getAllByRole('button')[0]);
+    expect(
+      getAllByRole('button')[0].className.includes(`${iotPrefix}--list-item__selected`)
+    ).toEqual(false);
+  });
 });


### PR DESCRIPTION
Closes #1149 

**Summary**

- SimpleList items were not deselectable, but now can be

**Change List (commits, features, bugs, etc)**

- selectedItems.filter had a typo of item.id instead of just item
changed the setSelectedItems and setSelectedItem to check if the item is selected at all, not just the last one selected


**Acceptance Test (how to verify the PR)**

- Go to the SimpleList basic story, items should be selectable and deselectable
