### PR TITLE
fix(TimeSeriesCard): removed rounding and separator in formatter function

### DIFF
--- a/src/components/BarChartCard/BarChartCard.jsx
+++ b/src/components/BarChartCard/BarChartCard.jsx
@@ -10,7 +10,7 @@ import { BarChartCardPropTypes, CardPropTypes } from '../../constants/CardPropTy
 import { CARD_SIZES, BAR_CHART_TYPES, BAR_CHART_LAYOUTS } from '../../constants/LayoutConstants';
 import Card from '../Card/Card';
 import { settings } from '../../constants/Settings';
-import { valueFormatter, handleCardVariables } from '../../utils/cardUtilityFunctions';
+import { chartValueFormatter, handleCardVariables } from '../../utils/cardUtilityFunctions';
 import StatefulTable from '../Table/StatefulTable';
 import { csvDownloadHandler } from '../../utils/componentUtilityFunctions';
 
@@ -172,7 +172,8 @@ const BarChartCard = ({
               containerResizable: true,
               color: colors,
               tooltip: {
-                valueFormatter: tooltipValue => valueFormatter(tooltipValue, size, unit, locale),
+                valueFormatter: tooltipValue =>
+                  chartValueFormatter(tooltipValue, size, unit, locale),
                 customHTML: (...args) => handleTooltip(...args, timeDataSourceId, colors, locale),
               },
             }}

--- a/src/components/TimeSeriesCard/TimeSeriesCard.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.jsx
@@ -22,7 +22,7 @@ import { settings } from '../../constants/Settings';
 import {
   getUpdatedCardSize,
   handleCardVariables,
-  valueFormatter,
+  chartValueFormatter,
 } from '../../utils/cardUtilityFunctions';
 import deprecate from '../../internal/deprecate';
 
@@ -492,7 +492,7 @@ const TimeSeriesCard = ({
                     title: `${yLabel || ''} ${unit ? `(${unit})` : ''}`,
                     mapsTo: 'value',
                     ticks: {
-                      formatter: axisValue => valueFormatter(axisValue, newSize, null, locale),
+                      formatter: axisValue => chartValueFormatter(axisValue, newSize, null, locale),
                     },
                     ...(chartType !== TIME_SERIES_TYPES.BAR
                       ? { yMaxAdjuster: yMaxValue => yMaxValue * 1.3 }
@@ -506,7 +506,7 @@ const TimeSeriesCard = ({
                 containerResizable: true,
                 tooltip: {
                   valueFormatter: tooltipValue =>
-                    valueFormatter(tooltipValue, newSize, unit, locale),
+                    chartValueFormatter(tooltipValue, newSize, unit, locale),
                   customHTML: (...args) =>
                     handleTooltip(
                       ...args,

--- a/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
+++ b/src/components/TimeSeriesCard/TimeSeriesCard.story.jsx
@@ -372,11 +372,11 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
             ],
             xLabel: 'Time',
             yLabel: 'Temperature (˚F)',
-            includeZeroOnXaxis: true,
-            includeZeroOnYaxis: true,
+            includeZeroOnXaxis: false,
+            includeZeroOnYaxis: false,
             timeDataSourceId: 'timestamp',
           })}
-          values={getIntervalChartData('minute', 15, { min: 10, max: 100 }, 100)}
+          values={getIntervalChartData('minute', 15, { min: 4700000, max: 4800000 }, 100)}
           interval="minute"
           breakpoint="lg"
           size={size}
@@ -491,9 +491,9 @@ storiesOf('Watson IoT/TimeSeriesCard', module)
               },
             ],
             xLabel: 'Time',
-            yLabel: 'Temperature (˚F)',
-            includeZeroOnXaxis: true,
-            includeZeroOnYaxis: true,
+            yLabel: 'Temperature',
+            includeZeroOnXaxis: false,
+            includeZeroOnYaxis: false,
             timeDataSourceId: 'timestamp',
           })}
           values={getIntervalChartData('year', 10, { min: 10, max: 100 }, 100)}

--- a/src/utils/__tests__/cardUtilityFunctions.test.js
+++ b/src/utils/__tests__/cardUtilityFunctions.test.js
@@ -4,8 +4,9 @@ import {
   compareGrains,
   getUpdatedCardSize,
   formatNumberWithPrecision,
+  formatChartNumberWithPrecision,
   handleCardVariables,
-  valueFormatter,
+  chartValueFormatter,
 } from '../cardUtilityFunctions';
 import { CARD_SIZES } from '../../constants/LayoutConstants';
 
@@ -43,6 +44,12 @@ describe('cardUtilityFunctions', () => {
     expect(formatNumberWithPrecision(3.45, 2, 'en')).toEqual('3.45'); // decimal separator should be period
     expect(formatNumberWithPrecision(35000, 2, 'en')).toEqual('35.00K'); // K separator
     expect(formatNumberWithPrecision(35000, null, 'en')).toEqual('35K'); // K separator
+  });
+  it('formatChartNumberWithPrecision', () => {
+    expect(formatChartNumberWithPrecision(3.45, 1, 'fr')).toEqual('3,5'); // decimal separator should be comma
+    expect(formatChartNumberWithPrecision(3.45, 2, 'en')).toEqual('3.45'); // decimal separator should be period
+    expect(formatChartNumberWithPrecision(35000, 2, 'en')).toEqual('35,000.00');
+    expect(formatChartNumberWithPrecision(35000, null, 'en')).toEqual('35,000');
   });
   it('handleCardVariables updates value cards with variables', () => {
     const valueCardPropsWithVariables = {
@@ -676,19 +683,19 @@ describe('cardUtilityFunctions', () => {
       ...others,
     });
   });
-  it('valueFormatter', () => {
+  it('chartValueFormatter', () => {
     // Small should get 3 precision
-    expect(valueFormatter(0.23456, CARD_SIZES.LARGE, null)).toEqual('0.235');
+    expect(chartValueFormatter(0.23456, CARD_SIZES.LARGE, null)).toEqual('0.235');
     // default precision
-    expect(valueFormatter(1.23456, CARD_SIZES.LARGE, null)).toEqual('1.2');
+    expect(chartValueFormatter(1.23456, CARD_SIZES.LARGE, null)).toEqual('1.2');
     // With units
-    expect(valueFormatter(0.23456, CARD_SIZES.LARGE, 'writes per second')).toEqual(
+    expect(chartValueFormatter(0.23456, CARD_SIZES.LARGE, 'writes per second')).toEqual(
       '0.235 writes per second'
     );
 
     // Large numbers!
-    expect(valueFormatter(1500, CARD_SIZES.LARGE, null)).toEqual('2K');
+    expect(chartValueFormatter(1500, CARD_SIZES.LARGE, null)).toEqual('1,500');
     // nil
-    expect(valueFormatter(null, CARD_SIZES.LARGE, null)).toEqual('--');
+    expect(chartValueFormatter(null, CARD_SIZES.LARGE, null)).toEqual('--');
   });
 });

--- a/src/utils/cardUtilityFunctions.js
+++ b/src/utils/cardUtilityFunctions.js
@@ -130,8 +130,8 @@ export const getUpdatedCardSize = oldSize => {
  * @param {number} precision, how many decimal values to display configured at the attribute level
  * @param {string} locale, the local browser locale because locales use different decimal separators
  */
-export const formatNumberWithPrecision = (value, precision = 0, locale = 'en') =>
-  value > 1000000000000
+export const formatNumberWithPrecision = (value, precision = 0, locale = 'en') => {
+  return value > 1000000000000
     ? `${(value / 1000000000000).toLocaleString(
         locale,
         !isNil(precision)
@@ -180,6 +180,8 @@ export const formatNumberWithPrecision = (value, precision = 0, locale = 'en') =
             }
           : undefined
       );
+};
+
 /**
  * Find variables in a string that are identified by surrounding curly braces
  * @param {string} value - A string with variables, i.e. `{manufacturer} acceleration over the last {sensor} hours`
@@ -261,6 +263,24 @@ export const handleCardVariables = (title, content, values, card) => {
 };
 
 /**
+ * This function provides common value formatting across all chart card types
+ * @param {number} value, the value the card will display
+ * @param {number} precision, how many decimal values to display configured at the attribute level
+ * @param {string} locale, the local browser locale because locales use different decimal separators
+ */
+export const formatChartNumberWithPrecision = (value, precision = 0, locale = 'en') => {
+  return value.toLocaleString(
+    locale,
+    !isNil(precision)
+      ? {
+          minimumFractionDigits: precision,
+          maximumFractionDigits: precision,
+        }
+      : undefined
+  );
+};
+
+/**
  * Determines how many decimals to show for a value based on the value, the available size of the card
  * @param {string} size constant that describes the size of the Table card
  * @param {any} value will be checked to determine how many decimals to show
@@ -281,17 +301,17 @@ export const determinePrecision = (size, value, precision) => {
 };
 
 /**
- * Determines how to format our values for our lines
+ * Determines how to format our values for our lines and bars
  *
  * @param {any} value any value possible, but will only special format if a number
  * @param {string} size card size
  * @param {string} unit any optional units to show
  */
-export const valueFormatter = (value, size, unit, locale) => {
+export const chartValueFormatter = (value, size, unit, locale) => {
   const precision = determinePrecision(size, value, Math.abs(value) > 1 ? 1 : 3);
   let renderValue = value;
   if (typeof value === 'number') {
-    renderValue = formatNumberWithPrecision(value, precision, locale);
+    renderValue = formatChartNumberWithPrecision(value, precision, locale);
   } else if (isNil(value)) {
     renderValue = '--';
   }


### PR DESCRIPTION
Closes #1360 

**Summary**

- All values above 1000 were getting rounded down cause the y-axis to show the same values if the values were close enough together

**Change List (commits, features, bugs, etc)**

- Updated 1 story to have very high values where this bug appears
- Created a new function called `formatChartNumberWithPrecision` that would only localize and reduce the decimals rather than dividing and rounding down the number in chart cards
- Updated `valueFormatter` name to `chartValueFormatter` to ensure that its understood to be only for charts

**Acceptance Test (how to verify the PR)**

- Go to the following story and see that the values on the y-axis and the hovered datapoint tooltip shows the whole value value, instead of rounding it  https://deploy-preview-1361--carbon-addons-iot-react.netlify.app/?path=/story/watson-iot-timeseriescard--large-single-line-interval-hour-same-day