### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x.x   | :white_check_mark: |
+| 1.x.x   | :x:                |
+
+## Reporting a Vulnerability
+
+To report a vulnerability, please open an issue or email rdconner@us.ibm.com and taylorjones@us.ibm.com
+
+As this is a UI library, it's highly uncommon to see a security vulnerability directly within this codebase, but it is possible. 
+
+If a reported vulnerability is within the codebase, the issue will be added to the current sprint and someone will begin to investigate immediately. Some components/modules we export are a direct proxy of a module from the [Carbon Design System](https://github.com/carbon-design-system/carbon). If the vulnerability is there, a maintainer will contact a member of the Carbon team and we'll work with them to investigate. 
+
+If the vulnerability is within a dependency, we'll update the dependency to a patched version. We welcome pull requests and utilize dependabot to automate this for the codebase.


### PR DESCRIPTION
**Summary**

- It's recommended for us to have a documented security policy. This is fairly lightweight, I'm open to any contributions other maintainers feel are necessary here.

@joshblack does Carbon have a policy on file that we could reference?