### PR TITLE
Table filter numbers and booleans

### DIFF
--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -35,8 +35,8 @@ import { baseTableReducer } from './baseTableReducer';
  */
 export const defaultComparison = (value1, value2) =>
   !isNil(value1) && typeof value1 === 'number' // only if the column value filter is not null/undefined
-    ? value1 === value2 // type number do a direct comparison
-    : value1 && // type string do a lowercase includes comparison
+    ? value1 === (!isNil(Number(value2)) ? Number(value2) : value2) // for a number type, attempt to convert filter to number and direct compare
+    : value1 !== undefined && // type string do a lowercase includes comparison
       value1.toString &&
       caseInsensitiveSearch([value1.toString()], value2.toString());
 

--- a/src/components/Table/tableReducer.js
+++ b/src/components/Table/tableReducer.js
@@ -35,7 +35,7 @@ import { baseTableReducer } from './baseTableReducer';
  */
 export const defaultComparison = (value1, value2) =>
   !isNil(value1) && typeof value1 === 'number' // only if the column value filter is not null/undefined
-    ? value1 === (!isNil(Number(value2)) ? Number(value2) : value2) // for a number type, attempt to convert filter to number and direct compare
+    ? value1 === Number(value2) // for a number type, attempt to convert filter to number and direct compare
     : value1 !== undefined && // type string do a lowercase includes comparison
       value1.toString &&
       caseInsensitiveSearch([value1.toString()], value2.toString());


### PR DESCRIPTION
Closes #1189

**Summary**

Table filters were failing for numbers and booleans due to the comparison method used.

**Change List (commits, features, bugs, etc)**

Converts the user input filter to a number for direct comparison.
Allows false booleans to be compared.

**Acceptance Test (how to verify the PR)**

Go to the Table story: stateful-example-with-expansion-and-column-resize and confirm that all of the filter options work properly.
