### PR TITLE
fix(table): TableToolbarSearch rerenders when defaultValue is modified

### DIFF
--- a/src/components/Table/Table.test.jsx
+++ b/src/components/Table/Table.test.jsx
@@ -402,26 +402,17 @@ describe('Table', () => {
     expect(wrapper.find('.bx--search-input').prop('value')).toEqual('');
     expect(wrapper.find('.bx--search-input').html()).toContain(`aria-hidden="true"`);
 
-    const wrapper2 = mount(
-      <Table
-        columns={tableColumns}
-        data={tableData}
-        actions={mockActions}
-        options={{
-          hasSearch: true,
-        }}
-        view={{
-          toolbar: {
-            search: {
-              defaultValue: 'ferrari',
-            },
-          },
-        }}
-      />
-    );
+    wrapper.setProps({ view: { toolbar: { search: { defaultValue: 'ferrari' } } } });
+    wrapper.update();
 
-    expect(wrapper2.find('.bx--search-input').prop('value')).toEqual('ferrari');
-    expect(wrapper2.find('.bx--search-input').html()).toContain(`aria-hidden="false"`);
+    expect(wrapper.find('.bx--search-input').prop('value')).toEqual('ferrari');
+    expect(wrapper.find('.bx--search-input').html()).toContain(`aria-hidden="false"`);
+
+    wrapper.setProps({ view: { toolbar: { search: { defaultValue: '' } } } });
+    wrapper.update();
+
+    expect(wrapper.find('.bx--search-input').prop('value')).toEqual('');
+    expect(wrapper.find('.bx--search-input').html()).toContain(`aria-hidden="true"`);
   });
 
   it('cells should always wrap by default', () => {

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -187,7 +187,7 @@ const TableToolbar = ({
         {hasSearch ? (
           <TableToolbarSearch
             {...search}
-            key={hasSearch ? search.defaultValue || search.value : 'table-toolbar-search'}
+            key={search.defaultValue || search.value || 'table-toolbar-search'}
             defaultValue={search.defaultValue || search.value}
             className="table-toolbar-search"
             translateWithId={(...args) => tableTranslateWithId(i18n, ...args)}

--- a/src/components/Table/TableToolbar/TableToolbar.jsx
+++ b/src/components/Table/TableToolbar/TableToolbar.jsx
@@ -187,6 +187,7 @@ const TableToolbar = ({
         {hasSearch ? (
           <TableToolbarSearch
             {...search}
+            key={hasSearch ? search.defaultValue || search.value : 'table-toolbar-search'}
             defaultValue={search.defaultValue || search.value}
             className="table-toolbar-search"
             translateWithId={(...args) => tableTranslateWithId(i18n, ...args)}


### PR DESCRIPTION
Closes #1386

**Summary**

- Updates `TableToolbarSearch` to use `defaultValue` as a `key` so that updates to `defaultValue` cause a new instance of `TableToolbarSearch` to be created. This ensures that updates to `defaultValue` are reflected in the UI.

*Additional context*

In most cases in the Carbon codebase, `default*` variables, like `defaultValue` are intended to be single use and applied only once on initial render. In this specific case, updates to `defaultValue` intentionally do not trigger an update - it's not included in the useEffect dependency array. See [the thread here in the resolved conversation at this line](https://github.com/carbon-design-system/carbon/pull/5089/files#diff-e1d0d4ed749b59e29737a31a99c2686aR66) for more info.

**Change List (commits, features, bugs, etc)**

- place `key` on `TableToolbarSearch`
- restore original test from [#1238](https://github.com/IBM/carbon-addons-iot-react/pull/1238/files#diff-f47894e32d4dbf684d2ac3f89df148c9L411-R424) that caught this defect but was modified to pass (ironically by using the same approach - using a new component instance)

**Acceptance Test (how to verify the PR)**

- status checks should pass
