### PR TITLE
[Repo] 1382 test log cleanup

### DIFF
--- a/src/components/Dashboard/DashboardHeader.story.jsx
+++ b/src/components/Dashboard/DashboardHeader.story.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { text } from '@storybook/addon-knobs';
 import Pin from '@carbon/icons-react/lib/pin/20';
 import Edit from '@carbon/icons-react/lib/edit/20';
-import Delete from '@carbon/icons-react/lib/delete/20';
+import { TrashCan20 } from '@carbon/icons-react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { DatePicker, DatePickerInput } from 'carbon-components-react';
@@ -56,7 +56,7 @@ storiesOf('Watson IoT/Dashboard Header (Deprecated)', module)
           lastUpdated={text('lastUpdated', '03/31/2019 13:55')}
           actions={[
             { id: 'edit', labelText: 'Edit', icon: <Edit /> },
-            { id: 'delete', labelText: 'Delete', icon: Delete },
+            { id: 'delete', labelText: 'Delete', icon: TrashCan20 },
           ]}
           onDashboardAction={action('onDashboardAction')}
         />
@@ -88,7 +88,7 @@ storiesOf('Watson IoT/Dashboard Header (Deprecated)', module)
           }
           actions={[
             { id: 'edit', labelText: 'Edit', icon: <Edit /> },
-            { id: 'delete', labelText: 'Delete', icon: <Delete /> },
+            { id: 'delete', labelText: 'Delete', icon: <TrashCan20 /> },
             { id: 'pin', labelText: 'Pin', icon: <Pin /> },
           ]}
           onDashboardAction={action('onDashboardAction')}

--- a/src/components/DateTimePicker/DateTimePicker.story.jsx
+++ b/src/components/DateTimePicker/DateTimePicker.story.jsx
@@ -28,9 +28,9 @@ export const defaultRelativeValue = {
 export const defaultAbsoluteValue = {
   timeRangeKind: PICKER_KINDS.ABSOLUTE,
   timeRangeValue: {
-    startDate: '04/01/2020',
+    startDate: '2020-04-01',
     startTime: '12:34',
-    endDate: '04/06/2020',
+    endDate: '2020-04-06',
     endTime: '10:49',
   },
 };

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -6,7 +6,7 @@ import {
 } from 'carbon-components-react/es/components/UIShell';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { AppSwitcher20 } from '@carbon/icons-react';
+import { Switcher20 } from '@carbon/icons-react';
 
 import { settings } from '../../constants/Settings';
 
@@ -105,7 +105,7 @@ const Header = ({
           label: appSwitcherLabel,
           hasHeaderPanel: true,
           btnContent: (
-            <AppSwitcher20
+            <Switcher20
               fill="white"
               className={`${carbonPrefix}--header__menu-item ${carbonPrefix}--header__menu-title`}
             />

--- a/src/components/ImageCard/CardIcon.jsx
+++ b/src/components/ImageCard/CardIcon.jsx
@@ -16,6 +16,8 @@ const propTypes = {
 };
 
 /** This component calls out to our renderIconByName callback function with the icon name OR fails over to our legacy card icons from our legacy icon bundle */
+// We test the implementation and do not want to trigger this console in our test logs
+/* istanbul ignore next */
 const CardIcon = ({ icon, renderIconByName, title, color, width, height, className }) => {
   if (__DEV__ && !renderIconByName && !icons[icon]) {
     warning(

--- a/src/components/ImageCard/CardIcon.jsx
+++ b/src/components/ImageCard/CardIcon.jsx
@@ -16,7 +16,7 @@ const propTypes = {
 };
 
 /** This component calls out to our renderIconByName callback function with the icon name OR fails over to our legacy card icons from our legacy icon bundle */
-// We test the implementation and do not want to trigger this console in our test logs
+/* We test the implementation and do not want to trigger this console in our test logs */
 /* istanbul ignore next */
 const CardIcon = ({ icon, renderIconByName, title, color, width, height, className }) => {
   if (__DEV__ && !renderIconByName && !icons[icon]) {

--- a/src/components/ImageCard/CardIcon.test.jsx
+++ b/src/components/ImageCard/CardIcon.test.jsx
@@ -1,22 +1,22 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import CardIcon from './CardIcon';
 
 describe('CardIcon', () => {
-  const spy = {};
-  beforeAll(() => {
-    spy.console = jest.spyOn(console, 'error');
-    // globally this is false, but we need it true so the warning pops
-    global.__DEV__ = true;
-  });
-  afterAll(() => {
-    spy.console.mockRestore();
-    // globally this is false, but we need it true so the warning pops
-    global.__DEV__ = false;
-  });
   it('validate default', () => {
-    render(<CardIcon icon="bogus" title="title" color="#FFFFFF" />);
-    expect(spy.console).toHaveBeenCalled();
+    const { rerender } = render(<CardIcon icon="help" title="title" color="#FFFFFF" />);
+    // Help icon is the defaul used when Icon does not match list. Grabbing the path value
+    const defaultIcon = screen.getByRole('img').querySelector('[d]').attributes[0].nodeValue;
+    // Pass in bad icon name and check for default icon.
+    rerender(<CardIcon icon="bogus" title="title" color="#FFFFFF" />);
+    expect(screen.getByRole('img').querySelector('[d]').attributes[0].nodeValue).toEqual(
+      defaultIcon
+    );
+    // Pass in a correct icon value and see that the default is not used.
+    rerender(<CardIcon icon="warning" title="title" color="#FFFFFF" />);
+    expect(screen.getByRole('img').querySelector('[d]').attributes[0].nodeValue).not.toEqual(
+      defaultIcon
+    );
   });
 });

--- a/src/components/SideNav/SideNav.story.jsx
+++ b/src/components/SideNav/SideNav.story.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import AppSwitcher from '@carbon/icons-react/lib/app-switcher/24';
+import { Switcher24 } from '@carbon/icons-react';
 import Chip from '@carbon/icons-react/lib/chip/24';
 import Dashboard from '@carbon/icons-react/lib/dashboard/24';
 import Group from '@carbon/icons-react/lib/group/24';
@@ -23,7 +23,7 @@ const RouterComponent = ({ children, ...rest }) => <div {...rest}>{children}</di
 
 const links = [
   {
-    icon: AppSwitcher,
+    icon: Switcher24,
     isEnabled: true,
     metaData: {
       onClick: action('menu click'),

--- a/src/components/SideNav/SideNav.test.jsx
+++ b/src/components/SideNav/SideNav.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
-import { AppSwitcher24, Chip24, Group24 } from '@carbon/icons-react';
+import { Switcher24, Chip24, Group24 } from '@carbon/icons-react';
 
 import SideNav from './SideNav';
 
@@ -10,7 +10,7 @@ describe('SideNav', () => {
   const links = [
     {
       icon: () => (
-        <AppSwitcher24
+        <Switcher24
           fill="white"
           description="Icon"
           className="bx--header__menu-item bx--header__menu-title"
@@ -73,7 +73,7 @@ describe('SideNav', () => {
   const links2 = [
     {
       icon: () => (
-        <AppSwitcher24
+        <Switcher24
           fill="white"
           description="Icon"
           className="bx--header__menu-item bx--header__menu-title"
@@ -93,7 +93,7 @@ describe('SideNav', () => {
   const linksDisabled = [
     {
       icon: () => (
-        <AppSwitcher24
+        <Switcher24
           fill="white"
           description="Icon"
           className="bx--header__menu-item bx--header__menu-title"

--- a/src/components/Table/Table.story.jsx
+++ b/src/components/Table/Table.story.jsx
@@ -7,8 +7,7 @@ import styled from 'styled-components';
 import Arrow from '@carbon/icons-react/lib/arrow--right/16';
 import Add from '@carbon/icons-react/lib/add/16';
 import Edit from '@carbon/icons-react/lib/edit/16';
-import Delete from '@carbon/icons-react/lib/delete/16';
-import { Add20 } from '@carbon/icons-react';
+import { Add20, TrashCan16 } from '@carbon/icons-react';
 import { Tooltip, TextInput, Checkbox, ToastNotification, Button } from 'carbon-components-react';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -370,7 +369,7 @@ export const initialState = {
       },
       {
         id: 'delete',
-        renderIcon: Delete,
+        renderIcon: TrashCan16,
         labelText: 'Delete',
         isOverflow: true,
         iconDescription: 'Delete',
@@ -434,7 +433,7 @@ export const initialState = {
         {
           id: 'delete',
           labelText: 'Delete',
-          renderIcon: Delete,
+          renderIcon: TrashCan16,
           iconDescription: 'Delete',
         },
       ],
@@ -867,20 +866,20 @@ storiesOf('Watson IoT/Table', module)
       info: {
         text: `
 
-        This table has editable rows. It is wrapped in a component that handles the state of the table data and 
-        the active bar to serve as a simple example of how to use the 'hasRowEdit' and the 'hasSingleRowEdit' 
-        functionality with your own data store. 
-        
-        When the 'hasRowEdit' is true an edit icon will be shown in the 
+        This table has editable rows. It is wrapped in a component that handles the state of the table data and
+        the active bar to serve as a simple example of how to use the 'hasRowEdit' and the 'hasSingleRowEdit'
+        functionality with your own data store.
+
+        When the 'hasRowEdit' is true an edit icon will be shown in the
         table toolbar. Clicking the edit icon should enable row edit for all rows, but it requires the
         columns to have an 'editDataFunction' prop defined. For StatefulTable this is handled automatically, for normal tables it
         should be handled manually as shown in this story.
 
-        The 'hasSingleRowEdit' must be combined with a row action that has the "isEdit" property set to true. 
-        Clicking that row action shoulf turn that specific row editable, and it also requires the columns to have 
-        provided a 'editDataFunction'. For StatefulTable the row action state is automatically updated with 
+        The 'hasSingleRowEdit' must be combined with a row action that has the "isEdit" property set to true.
+        Clicking that row action shoulf turn that specific row editable, and it also requires the columns to have
+        provided a 'editDataFunction'. For StatefulTable the row action state is automatically updated with
         isEditMode:true but for normal tables it should be handled manually as shown in this story.
-    
+
 
         ~~~js
 
@@ -1039,7 +1038,7 @@ storiesOf('Watson IoT/Table', module)
             {
               id: 'delete',
               labelText: 'Delete',
-              renderIcon: Delete,
+              renderIcon: TrashCan16,
               iconDescription: 'Delete Item',
             },
           ],
@@ -1153,7 +1152,7 @@ storiesOf('Watson IoT/Table', module)
             },
             {
               id: 'delete',
-              renderIcon: Delete,
+              renderIcon: TrashCan16,
               iconDescription: 'Delete',
               labelText: 'Delete',
               isOverflow: true,

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -230,7 +230,7 @@ class RowActionsCell extends React.Component {
                     data-testid={`${tableId}-${id}-row-actions-cell-overflow`}
                     flipped={ltr}
                     ariaLabel={overflowMenuAria}
-                    // onClick={event => event.stopPropagation()}
+                    onClick={event => event.stopPropagation()}
                     isRowExpanded={isRowExpanded}
                     iconDescription={overflowMenuAria}
                     onOpen={this.handleOpen}

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.jsx
@@ -186,6 +186,7 @@ class RowActionsCell extends React.Component {
           className={`${iotPrefix}--row-actions-container`}
         >
           <div
+            data-testid="row-action-container-background"
             className={classnames(`${iotPrefix}--row-actions-container__background`, {
               [`${iotPrefix}--row-actions-container__background--overflow-menu-open`]: isOpen,
             })}
@@ -229,7 +230,7 @@ class RowActionsCell extends React.Component {
                     data-testid={`${tableId}-${id}-row-actions-cell-overflow`}
                     flipped={ltr}
                     ariaLabel={overflowMenuAria}
-                    onClick={event => event.stopPropagation()}
+                    // onClick={event => event.stopPropagation()}
                     isRowExpanded={isRowExpanded}
                     iconDescription={overflowMenuAria}
                     onOpen={this.handleOpen}

--- a/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
+++ b/src/components/Table/TableBody/RowActionsCell/RowActionsCell.test.jsx
@@ -1,5 +1,7 @@
-import { mount } from 'enzyme';
 import React from 'react';
+import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Add32, Edit16 } from '@carbon/icons-react';
 
 import { settings } from '../../../../constants/Settings';
@@ -18,58 +20,75 @@ describe('RowActionsCell', () => {
   beforeEach(() => {
     mockApplyRowAction.mockClear();
   });
+
   it('click handler', () => {
+    const tableRow = document.createElement('tr');
     const actions = [{ id: 'addAction', renderIcon: Add32, iconDescription: 'See more' }];
-    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
-    const button = wrapper.find('.bx--btn');
+    render(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+      container: document.body.appendChild(tableRow),
+    });
+
+    const btn = screen.queryByRole('button');
     // one button should render
-    expect(button).toHaveLength(1);
-    button.at(0).simulate('click');
+    expect(btn).toBeTruthy();
+    userEvent.click(btn);
     expect(mockApplyRowAction).toHaveBeenCalledTimes(1);
   });
+
   it('custom SVG in button', () => {
+    const tableRow = document.createElement('tr');
     const actions = [
       { id: 'addAction', renderIcon: () => <svg title="my svg" />, iconDescription: 'See more' },
     ];
-    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
-    const button = wrapper.find('.bx--btn');
+    render(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+      container: document.body.appendChild(tableRow),
+    });
+    const btn = screen.queryByRole('button');
     // one button should render
-    expect(button).toHaveLength(1);
-    button.at(0).simulate('click');
+    expect(btn).toBeTruthy();
+    userEvent.click(btn);
     expect(mockApplyRowAction).toHaveBeenCalledTimes(1);
   });
 
   it('overflow menu trigger has ID', () => {
+    const tableRow = document.createElement('tr');
     const actions = [
       { id: 'add', renderIcon: Add32, iconDescription: 'See more' },
       { id: 'edit', renderIcon: Edit16, isOverflow: true, labelText: 'Edit' },
     ];
-    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
-    const button = wrapper.find('OverflowMenu #tableId-rowId-row-actions-cell-overflow');
+    render(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+      container: document.body.appendChild(tableRow),
+    });
+    const btns = screen.queryAllByRole('button');
     // Only one id should be present
-    expect(button).toHaveLength(1);
+    expect(btns[0].id).not.toEqual('tableId-rowId-row-actions-cell-overflow');
+    expect(btns[1].id).toEqual('tableId-rowId-row-actions-cell-overflow');
   });
 
   it('actions are wrapped in special gradient background container', () => {
+    const tableRow = document.createElement('tr');
     const action = {
       id: 'addAction',
       renderIcon: Add32,
       iconDescription: 'See more',
       labelText: 'Drill in to find out more',
     };
-    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={[action]} />);
-    const container = wrapper.find(
-      `.${iotPrefix}--row-actions-container .${iotPrefix}--row-actions-container__background`
-    );
-    const button = container.find('button');
+    render(<RowActionsCell {...commonRowActionsProps} actions={[action]} />, {
+      container: document.body.appendChild(tableRow),
+    });
 
-    expect(container).toHaveLength(1);
-    expect(button.text()).toEqual(action.labelText);
+    //  Container background div is present
+    expect(screen.queryByTestId('row-action-container-background')).toBeTruthy();
+    // Action text matches the action.labelText prop value
+    expect(screen.queryByText(action.labelText)).toBeTruthy();
   });
 
   it('action container background knows when overflow menu is open (in order to stay visible)', () => {
+    const tableRow = document.createElement('tr');
     const actions = [{ id: 'edit', renderIcon: Edit16, isOverflow: true, labelText: 'Edit' }];
-    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
+    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+      attachTo: tableRow,
+    });
 
     let container = wrapper.find(
       `.${iotPrefix}--row-actions-container .${iotPrefix}--row-actions-container__background--overflow-menu-open`
@@ -94,12 +113,15 @@ describe('RowActionsCell', () => {
   });
 
   it('autoselects the first enabled alternative when the overflow menu is opened', () => {
+    const tableRow = document.createElement('tr');
     const actions = [
       { disabled: true, id: 'add', isOverflow: true, labelText: 'Add' },
       { disabled: false, id: 'edit', renderIcon: Edit16, isOverflow: true, labelText: 'Edit' },
     ];
 
-    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />);
+    const wrapper = mount(<RowActionsCell {...commonRowActionsProps} actions={actions} />, {
+      attachTo: tableRow,
+    });
     const container = wrapper.find(
       `.${iotPrefix}--row-actions-container .${iotPrefix}--row-actions-container__background--overflow-menu-open`
     );

--- a/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
+++ b/src/components/Table/TableBody/TableBodyRow/TableBodyRow.story.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { actions } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 import { DataTable } from 'carbon-components-react';
-import { Add32, Edit16, Stop16, Delete16 } from '@carbon/icons-react';
+import { Add32, Edit16, Stop16, TrashCan16 } from '@carbon/icons-react';
 
 import TableBodyRow from './TableBodyRow';
 
@@ -66,7 +66,7 @@ storiesOf('Watson IoT/TableBodyRow', module)
         { id: 'test3', renderIcon: Stop16, isOverflow: true, labelText: 'Test 3' },
         {
           id: 'delete',
-          renderIcon: Delete16,
+          renderIcon: TrashCan16,
           isOverflow: true,
           labelText: 'Delete',
           isDelete: true,

--- a/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
+++ b/src/components/Table/TableBody/TableBodyRow/__snapshots__/TableBodyRow.story.storyshot
@@ -85,6 +85,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <div
                   className="iot--row-actions-container__background"
+                  data-testid="row-action-container-background"
                 >
                   <button
                     className="bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-end"
@@ -235,6 +236,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <div
                   className="iot--row-actions-container__background"
+                  data-testid="row-action-container-background"
                 >
                   <button
                     className="bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-end"
@@ -457,6 +459,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <div
                   className="iot--row-actions-container__background"
+                  data-testid="row-action-container-background"
                 >
                   <button
                     className="bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-end"
@@ -604,6 +607,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <div
                   className="iot--row-actions-container__background"
+                  data-testid="row-action-container-background"
                 >
                   <button
                     className="bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y bx--tooltip--left bx--tooltip--align-end"
@@ -797,6 +801,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <div
                   className="iot--row-actions-container__background"
+                  data-testid="row-action-container-background"
                 >
                   <div
                     className="bx--tooltip__label"
@@ -954,6 +959,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
               >
                 <div
                   className="iot--row-actions-container__background"
+                  data-testid="row-action-container-background"
                 >
                   <div
                     aria-atomic="true"

--- a/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
+++ b/src/components/Table/TableCellRenderer/TableCellRenderer.test.jsx
@@ -156,10 +156,18 @@ describe('TableCellRenderer', () => {
   });
 
   it('locale formats numbers', () => {
-    const wrapper = mount(<TableCellRenderer locale="fr">{35.6}</TableCellRenderer>);
+    const wrapper = mount(
+      <TableCellRenderer locale="fr" truncateCellText>
+        {35.6}
+      </TableCellRenderer>
+    );
     expect(wrapper.text()).toContain('35,6'); // french locale should have commas for decimals
 
-    const wrapper2 = mount(<TableCellRenderer locale="en">{35.1234567}</TableCellRenderer>);
+    const wrapper2 = mount(
+      <TableCellRenderer locale="en" truncateCellText>
+        {35.1234567}
+      </TableCellRenderer>
+    );
     expect(wrapper2.text()).toContain('35.1234567'); // no limit on the count of decimals
   });
 });


### PR DESCRIPTION
related to #1382 

**Summary**

PR to fix several test log issues. 

**Change List (commits, features, bugs, etc)**

- Swapped out a couple icon names that were deprecated from Carbon for their new versions.
- Changed date format for our default Absolute date in DateTimePicker. 
- Changed test for ImageCard to test for implementation instead of looking for the console warning. Then added ignore to test since we will never trigger that if statement in our testing suite
- Added `truncateCellText` to TableCellRenderer

**Acceptance Test (how to verify the PR)**

- Go to each test file and run them. You should not see any console statements or deprecation warnings. 
