### PR TITLE
fix(tests): defer loading acessibility-checker package

### DIFF
--- a/config/jest/setupTest.js
+++ b/config/jest/setupTest.js
@@ -1,7 +1,15 @@
 import 'jest-styled-components';
-import aChecker from 'accessibility-checker';
+
+let aChecker;
 
 async function toBeAccessible(node, label) {
+  // We defer initialization of AAT as it seems to have a race condition if
+  // we are running a test suite in node instead of jsdom. As a result, we only
+  // initialize it if this matcher is called
+  if (!aChecker) {
+    aChecker = require('accessibility-checker');
+  }
+
   let results = await aChecker.getCompliance(node, label);
   if (aChecker.assertCompliance(results.report) === 0) {
     return {
@@ -14,7 +22,21 @@ async function toBeAccessible(node, label) {
     };
   }
 }
+console.log(`hiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
+i
+i
+i
+i
+i
 
+I
+i
+i
+i
+i
+i
+i`);
+console.log(toBeAccessible);
 expect.extend({ toBeAccessible });
 
 beforeEach(() => {

--- a/config/jest/setupTest.js
+++ b/config/jest/setupTest.js
@@ -22,21 +22,7 @@ async function toBeAccessible(node, label) {
     };
   }
 }
-console.log(`hiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
-i
-i
-i
-i
-i
 
-I
-i
-i
-i
-i
-i
-i`);
-console.log(toBeAccessible);
 expect.extend({ toBeAccessible });
 
 beforeEach(() => {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@testing-library/jest-dom": "^5.10.0",
     "@testing-library/react": "^10.2.1",
     "@testing-library/user-event": "^11.4.2",
-    "accessibility-checker": "^3.0.5",
+    "accessibility-checker": "^3.0.6",
     "autoprefixer": "^9.4.4",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4407,10 +4407,10 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-accessibility-checker@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/accessibility-checker/-/accessibility-checker-3.0.5.tgz#ec1053b85c4969da300194bf3e3494f1ca30645c"
-  integrity sha512-bt1FviTs5eJX/AgXR5sqLg+CuyPMm3aESh54Zp7yT2O/8CI8fbIN5fxjJ2GUTLBkjm1cY+rndKcriNZDxQwbCQ==
+accessibility-checker@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/accessibility-checker/-/accessibility-checker-3.0.6.tgz#07b85f4cc0bb8ed43e26037f3c407143f769c113"
+  integrity sha512-i12/FS8q0Kc0zNatC/ux8cg42zmeRHclLitEHiLhaF0icO4II6eVUMCMZOCBVLLgb/vW7Ltt2Qxa4fTPNhm6nA==
   dependencies:
     chromedriver "^83.0.0"
     deep-diff "^0.3.4"


### PR DESCRIPTION
Tests are failing in master.

**Summary**

- Defer the loading of the accessibility-checker package due to a race condition causing tests to fail randomly due to network errors. 
  - Carbon https://github.com/carbon-design-system/carbon/blob/master/tasks/jest/matchers/toHaveNoDAPViolations.js#L10
  - ibm-security https://github.com/carbon-design-system/ibm-security/pull/581

**Change List (commits, features, bugs, etc)**

- update dep to latest version
- modify jest test setup file

**Acceptance Test (how to verify the PR)**

- status checks should pass

I've opened a bug on the `accessibility-checker` package https://github.com/IBMa/equal-access/issues/143