### PR TITLE
fix(proptypes): relax proptypes errors on pagewizard

### DIFF
--- a/src/components/List/ListItem/ListItem.jsx
+++ b/src/components/List/ListItem/ListItem.jsx
@@ -43,7 +43,7 @@ const ListItemWrapperProps = {
   isSelectable: PropTypes.bool.isRequired,
   onSelect: PropTypes.func.isRequired,
   selected: PropTypes.bool.isRequired,
-  children: React.Children.isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 const ListItemPropTypes = {

--- a/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
+++ b/src/components/PageWizard/PageWizardStep/PageWizardStep.jsx
@@ -24,7 +24,7 @@ const PageWizardStepPropTypes = {
   /** Optional sticky footer */
   hasStickyFooter: PropTypes.bool,
   /** Callback function to close the wizard */
-  onClose: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
   /** Determines if Cancel or Previous button is rendered */
   hasPrev: PropTypes.bool,
   /** Determines if Next or Submit button is rendered */
@@ -38,7 +38,7 @@ const PageWizardStepPropTypes = {
   /** Renders a loading icon in the Next button */
   sendingData: PropTypes.bool,
   /** Callback function when Submit button is clicked */
-  onSubmit: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func,
   /** Content to render before footer buttons (on left side, in LTR) */
   beforeFooterContent: PropTypes.node,
 };
@@ -63,6 +63,8 @@ const PageWizardStepDefaultProps = {
   onNext: null,
   onBack: null,
   beforeFooterContent: null,
+  onSubmit: null,
+  onClose: null,
 };
 
 const PageWizardStep = ({

--- a/src/components/PageWizard/StatefulPageWizard.jsx
+++ b/src/components/PageWizard/StatefulPageWizard.jsx
@@ -28,7 +28,7 @@ const StatefulPageWizardPropTypes = {
     close: PropTypes.string,
   }),
   /** function to go to step when click ProgressIndicator step. */
-  setStep: PropTypes.func.isRequired,
+  setStep: PropTypes.func,
   /** next button disabled */
   nextDisabled: PropTypes.bool,
   /** show progress indicator on finish button */
@@ -63,6 +63,7 @@ const defaultProps = {
   onNext: null,
   onBack: null,
   beforeFooterContent: null,
+  setStep: null,
 };
 
 const StatefulPageWizard = ({

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -12764,7 +12764,9 @@ Map {
       "nextDisabled": false,
       "onBack": null,
       "onClearError": null,
+      "onClose": null,
       "onNext": null,
+      "onSubmit": null,
       "onValidate": [Function],
       "sendingData": false,
     },
@@ -12824,14 +12826,12 @@ Map {
         "type": "func",
       },
       "onClose": Object {
-        "isRequired": true,
         "type": "func",
       },
       "onNext": Object {
         "type": "func",
       },
       "onSubmit": Object {
-        "isRequired": true,
         "type": "func",
       },
       "onValidate": Object {
@@ -12961,6 +12961,7 @@ Map {
       "onBack": null,
       "onNext": null,
       "sendingData": false,
+      "setStep": null,
     },
     "propTypes": Object {
       "beforeFooterContent": Object {
@@ -13043,7 +13044,6 @@ Map {
         "type": "bool",
       },
       "setStep": Object {
-        "isRequired": true,
         "type": "func",
       },
     },


### PR DESCRIPTION
Closes #1227 

**Summary**

- Relax the required proptypes for pagewizardstep as they shouldn't be required

**Change List (commits, features, bugs, etc)**

- fix(ListItemWrapper): invalid proptype for children
- fix(PageWizard): remove the required proptypes for the functions as single step page wizards don't need them

**Acceptance Test (how to verify the PR)**

- Only propTypes changes, no functional changes
