### PR TITLE
fix(experimental): enabled snapshots for all experimental components

### DIFF
--- a/.storybook/__snapshots__/Welcome.story.storyshot
+++ b/.storybook/__snapshots__/Welcome.story.storyshot
@@ -59,7 +59,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
           onAnimationEnd={[Function]}
         >
           <button
-            aria-controls="accordion-item-3"
+            aria-controls="accordion-item-10"
             aria-expanded={false}
             className="bx--accordion__heading"
             onClick={[Function]}
@@ -89,7 +89,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots 0/Getting Starte
           </button>
           <div
             className="bx--accordion__content"
-            id="accordion-item-3"
+            id="accordion-item-10"
           >
             <p>
               The following table shows a comparison of exports from carbon-components-react and this library. These are primarily used for snapshot purposes to track and ensure that as the exports change upstream in Carbon we continue to provide parity with their package.

--- a/src/components/Accordion/__snapshots__/AccordionItemDefer.story.storyshot
+++ b/src/components/Accordion/__snapshots__/AccordionItemDefer.story.storyshot
@@ -28,7 +28,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Accor
           onAnimationEnd={[Function]}
         >
           <button
-            aria-controls="accordion-item-4"
+            aria-controls="accordion-item-11"
             aria-expanded={false}
             className="bx--accordion__heading"
             onClick={[Function]}
@@ -58,7 +58,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Accor
           </button>
           <div
             className="bx--accordion__content"
-            id="accordion-item-4"
+            id="accordion-item-11"
           >
             <p>
               This content is always rendered to the DOM, no matter if the accordion item has been open or closed.
@@ -72,7 +72,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Accor
           onAnimationEnd={[Function]}
         >
           <button
-            aria-controls="accordion-item-5"
+            aria-controls="accordion-item-12"
             aria-expanded={false}
             className="bx--accordion__heading"
             onClick={[Function]}
@@ -102,7 +102,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Accor
           </button>
           <div
             className="bx--accordion__content"
-            id="accordion-item-5"
+            id="accordion-item-12"
           />
         </li>
       </ul>

--- a/src/components/ComboBox/__snapshots__/ComboBox.story.storyshot
+++ b/src/components/ComboBox/__snapshots__/ComboBox.story.storyshot
@@ -1,0 +1,968 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ComboBox Default 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "padding": "1rem",
+          "width": 300,
+        }
+      }
+    >
+      <div
+        className="iot--combobox"
+        data-testid="combo-wrapper"
+        onKeyDown={[Function]}
+      >
+        <div
+          className="bx--list-box__wrapper"
+        >
+          <div
+            aria-label="Choose an item"
+            className="bx--combo-box iot--combobox-input bx--list-box"
+            id="combobox-a11y-1"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            <div
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              aria-labelledby="combobox-label-1"
+              aria-owns={null}
+              className="bx--list-box__field"
+              data-toggle={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={-1}
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls={null}
+                aria-disabled={false}
+                aria-expanded={false}
+                aria-labelledby="combobox-a11y-1"
+                aria-owns={null}
+                autoComplete="off"
+                className="bx--text-input bx--text-input--empty"
+                data-testid="combo-box"
+                disabled={false}
+                id="carbon-combobox-example"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                placeholder="Filter..."
+                role="combobox"
+                tabIndex="0"
+                title=""
+                value=""
+              />
+              
+              <div
+                className="bx--list-box__menu-icon"
+              >
+                <svg
+                  aria-label="Open menu"
+                  focusable="false"
+                  height={16}
+                  name="chevron--down"
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                  <title>
+                    Open menu
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              aria-label="Choose an item"
+              className="bx--list-box__menu"
+              id="carbon-combobox-example__menu"
+              role="listbox"
+            >
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-0-item-0"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 1"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 1
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-0-item-1"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 2"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 2
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-0-item-2"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 3"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 3
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-0-item-3"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 4"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 4
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-0-item-4"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="An example option that is really long to show what should be done to handle long text"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  An example option that is really long to show what should be done to handle long text
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <ul
+          className="iot--combobox-tags"
+          data-testid="combo-tags"
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ComboBox Mult-value tags 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "padding": "1rem",
+          "width": 300,
+        }
+      }
+    >
+      <div
+        className="iot--combobox"
+        data-testid="combo-wrapper"
+        onKeyDown={[Function]}
+      >
+        <div
+          className="bx--list-box__wrapper"
+        >
+          <div
+            aria-label="Choose an item"
+            className="bx--combo-box iot--combobox-input bx--list-box"
+            id="combobox-a11y-2"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            <div
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              aria-labelledby="combobox-label-2"
+              aria-owns={null}
+              className="bx--list-box__field"
+              data-toggle={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={-1}
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls={null}
+                aria-disabled={false}
+                aria-expanded={false}
+                aria-labelledby="combobox-a11y-2"
+                aria-owns={null}
+                autoComplete="off"
+                className="bx--text-input bx--text-input--empty"
+                data-testid="combo-box"
+                disabled={false}
+                id="carbon-combobox-example"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                placeholder="Filter..."
+                role="combobox"
+                tabIndex="0"
+                title=""
+                value=""
+              />
+              
+              <div
+                className="bx--list-box__menu-icon"
+              >
+                <svg
+                  aria-label="Open menu"
+                  focusable="false"
+                  height={16}
+                  name="chevron--down"
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                  <title>
+                    Open menu
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              aria-label="Choose an item"
+              className="bx--list-box__menu"
+              id="carbon-combobox-example__menu"
+              role="listbox"
+            >
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-1-item-0"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 1"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 1
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-1-item-1"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 2"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 2
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-1-item-2"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 3"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 3
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-1-item-3"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 4"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  Option 4
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-1-item-4"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="An example option that is really long to show what should be done to handle long text"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  An example option that is really long to show what should be done to handle long text
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <ul
+          className="iot--combobox-tags"
+          data-testid="combo-tags"
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ComboBox application-level control for selection 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      className="iot--combobox"
+      data-testid="combo-wrapper"
+      onKeyDown={[Function]}
+    >
+      <div
+        className="bx--list-box__wrapper"
+      >
+        <div
+          aria-label="Choose an item"
+          className="bx--combo-box iot--combobox-input bx--list-box"
+          id="combobox-a11y-4"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          <div
+            aria-controls={null}
+            aria-expanded={false}
+            aria-haspopup={true}
+            aria-label="open menu"
+            aria-labelledby="combobox-label-4"
+            aria-owns={null}
+            className="bx--list-box__field"
+            data-toggle={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex={-1}
+            type="button"
+          >
+            <input
+              aria-activedescendant={null}
+              aria-autocomplete="list"
+              aria-controls={null}
+              aria-disabled={false}
+              aria-expanded={false}
+              aria-labelledby="combobox-a11y-4"
+              aria-owns={null}
+              autoComplete="off"
+              className="bx--text-input"
+              data-testid="combo-box"
+              disabled={false}
+              id="carbon-combobox-example"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Filter..."
+              role="combobox"
+              tabIndex="0"
+              title="Option 1"
+              value="Option 1"
+            />
+            <div
+              aria-label="Clear Selection"
+              className="bx--list-box__selection"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={0}
+              title="Clear selected item"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                />
+              </svg>
+            </div>
+            <div
+              className="bx--list-box__menu-icon"
+            >
+              <svg
+                aria-label="Open menu"
+                focusable="false"
+                height={16}
+                name="chevron--down"
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+                <title>
+                  Open menu
+                </title>
+              </svg>
+            </div>
+          </div>
+          <div
+            aria-label="Choose an item"
+            className="bx--list-box__menu"
+            id="carbon-combobox-example__menu"
+            role="listbox"
+          >
+            <div
+              className="bx--list-box__menu-item bx--list-box__menu-item--active bx--list-box__menu-item--highlighted"
+              data-text="-Create"
+              id="downshift-3-item-0"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+              title="Option 1"
+            >
+              <div
+                className="bx--list-box__menu-item__option"
+              >
+                Option 1
+                <svg
+                  aria-hidden={true}
+                  className="bx--list-box__menu-item__selected-icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13 21.2L5.4 13.6 4 15 13 24 28 9 26.6 7.5 13 21.2z"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              className="bx--list-box__menu-item"
+              data-text="-Create"
+              id="downshift-3-item-1"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+              title="Option 2"
+            >
+              <div
+                className="bx--list-box__menu-item__option"
+              >
+                Option 2
+              </div>
+            </div>
+            <div
+              className="bx--list-box__menu-item"
+              data-text="-Create"
+              id="downshift-3-item-2"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+              title="Option 3"
+            >
+              <div
+                className="bx--list-box__menu-item__option"
+              >
+                Option 3
+              </div>
+            </div>
+            <div
+              className="bx--list-box__menu-item"
+              data-text="-Create"
+              id="downshift-3-item-3"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+              title="Option 4"
+            >
+              <div
+                className="bx--list-box__menu-item__option"
+              >
+                Option 4
+              </div>
+            </div>
+            <div
+              className="bx--list-box__menu-item"
+              data-text="-Create"
+              id="downshift-3-item-4"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
+              title="An example option that is really long to show what should be done to handle long text"
+            >
+              <div
+                className="bx--list-box__menu-item__option"
+              >
+                An example option that is really long to show what should be done to handle long text
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <ul
+        className="iot--combobox-tags"
+        data-testid="combo-tags"
+      />
+    </div>
+    <button
+      className="iot--btn bx--btn bx--btn--primary"
+      disabled={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "marginTop": "1rem",
+        }
+      }
+      tabIndex={0}
+      type="button"
+    >
+      Add new item
+    </button>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ComboBox items as components 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "padding": "1rem",
+          "width": 300,
+        }
+      }
+    >
+      <div
+        className="iot--combobox"
+        data-testid="combo-wrapper"
+        onKeyDown={[Function]}
+      >
+        <div
+          className="bx--list-box__wrapper"
+        >
+          <div
+            aria-label="Choose an item"
+            className="bx--combo-box iot--combobox-input bx--list-box"
+            id="combobox-a11y-3"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+          >
+            <div
+              aria-controls={null}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="open menu"
+              aria-labelledby="combobox-label-3"
+              aria-owns={null}
+              className="bx--list-box__field"
+              data-toggle={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={-1}
+              type="button"
+            >
+              <input
+                aria-activedescendant={null}
+                aria-autocomplete="list"
+                aria-controls={null}
+                aria-disabled={false}
+                aria-expanded={false}
+                aria-labelledby="combobox-a11y-3"
+                aria-owns={null}
+                autoComplete="off"
+                className="bx--text-input bx--text-input--empty"
+                data-testid="combo-box"
+                disabled={false}
+                id="carbon-combobox-example"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                placeholder="Filter..."
+                role="combobox"
+                tabIndex="0"
+                title=""
+                value=""
+              />
+              
+              <div
+                className="bx--list-box__menu-icon"
+              >
+                <svg
+                  aria-label="Open menu"
+                  focusable="false"
+                  height={16}
+                  name="chevron--down"
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                  <title>
+                    Open menu
+                  </title>
+                </svg>
+              </div>
+            </div>
+            <div
+              aria-label="Choose an item"
+              className="bx--list-box__menu"
+              id="carbon-combobox-example__menu"
+              role="listbox"
+            >
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-2-item-0"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 1"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  <div>
+                    <span>
+                      Option
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "blue",
+                        }
+                      }
+                    >
+                       
+                      1
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-2-item-1"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 2"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  <div>
+                    <span>
+                      Option
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "blue",
+                        }
+                      }
+                    >
+                       
+                      2
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-2-item-2"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 3"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  <div>
+                    <span>
+                      Option
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "blue",
+                        }
+                      }
+                    >
+                       
+                      3
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-2-item-3"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="Option 4"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  <div>
+                    <span>
+                      Option
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "blue",
+                        }
+                      }
+                    >
+                       
+                      4
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="bx--list-box__menu-item"
+                data-text="-Create"
+                id="downshift-2-item-4"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
+                title="An example option that is really long to show what should be done to handle long text"
+              >
+                <div
+                  className="bx--list-box__menu-item__option"
+                >
+                  <div>
+                    <span>
+                      An
+                    </span>
+                    <span
+                      style={
+                        Object {
+                          "color": "blue",
+                        }
+                      }
+                    >
+                       
+                      example option that is really long to show what should be done to handle long text
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <ul
+          className="iot--combobox-tags"
+          data-testid="combo-tags"
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
+++ b/src/components/DateTimePicker/__snapshots__/DateTimePicker.story.storyshot
@@ -1,0 +1,1543 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/DateTime Picker Default 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--date-time-picker__wrapper"
+        id="iot--date-time-picker__wrapper"
+      >
+        <div
+          className="iot--date-time-picker__box"
+        >
+          <div
+            className="iot--date-time-picker__field"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="bx--tooltip--definition bx--tooltip--a11y"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <button
+                aria-describedby="definition-tooltip-2"
+                className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+                onFocus={[Function]}
+              >
+                Last 30 minutes
+              </button>
+              <div
+                className="bx--assistive-text"
+                id="definition-tooltip-2"
+                role="tooltip"
+              >
+                2018-10-28 07:04 to Now
+              </div>
+            </div>
+            <svg
+              aria-label="Calendar"
+              className="iot--date-time-picker__icon"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+              />
+            </svg>
+          </div>
+          <div
+            className="iot--date-time-picker__menu"
+            role="listbox"
+          >
+            <div
+              className="iot--date-time-picker__menu-scroll"
+            >
+              <ol
+                className="bx--list--ordered"
+              >
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--current"
+                >
+                  2018-10-28 07:04 to Now
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--custom"
+                  onClick={[Function]}
+                >
+                  Custom Range
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset iot--date-time-picker__listitem--preset-selected"
+                  onClick={[Function]}
+                >
+                  Last 30 minutes
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 1 hour
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 6 hours
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 12 hours
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 24 hours
+                </li>
+              </ol>
+            </div>
+            <div
+              className="iot--date-time-picker__menu-btn-set"
+            >
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-cancel bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-apply bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/DateTime Picker Selected absolute 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--date-time-picker__wrapper"
+        id="iot--date-time-picker__wrapper"
+      >
+        <div
+          className="iot--date-time-picker__box"
+        >
+          <div
+            className="iot--date-time-picker__field"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <span
+              title="2018-10-28 12:34 to 2018-10-28 12:34"
+            >
+              2018-10-28 12:34 to 2018-10-28 12:34
+            </span>
+            <svg
+              aria-label="Calendar"
+              className="iot--date-time-picker__icon"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+              />
+            </svg>
+          </div>
+          <div
+            className="iot--date-time-picker__menu"
+            role="listbox"
+          >
+            <div
+              className="iot--date-time-picker__menu-scroll"
+            >
+              <div>
+                <fieldset
+                  className="bx--fieldset iot--date-time-picker__menu-formgroup"
+                >
+                  <legend
+                    className="bx--label iot--date-time-picker__menu-formgroup"
+                  >
+                    Custom range
+                  </legend>
+                  <div
+                    className="bx--form-item"
+                  >
+                    <div
+                      className="bx--radio-button-group bx--radio-button-group--label-right"
+                    >
+                      <div
+                        className="bx--radio-button-wrapper"
+                      >
+                        <input
+                          checked={false}
+                          className="bx--radio-button"
+                          id="relative"
+                          name="radiogroup"
+                          onChange={[Function]}
+                          type="radio"
+                          value="RELATIVE"
+                        />
+                        <label
+                          className="bx--radio-button__label"
+                          htmlFor="relative"
+                        >
+                          <span
+                            className="bx--radio-button__appearance"
+                          />
+                          <span
+                            className=""
+                          >
+                            Relative
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="bx--radio-button-wrapper"
+                      >
+                        <input
+                          checked={true}
+                          className="bx--radio-button"
+                          id="absolute"
+                          name="radiogroup"
+                          onChange={[Function]}
+                          type="radio"
+                          value="ABSOLUTE"
+                        />
+                        <label
+                          className="bx--radio-button__label"
+                          htmlFor="absolute"
+                        >
+                          <span
+                            className="bx--radio-button__appearance"
+                          />
+                          <span
+                            className=""
+                          >
+                            Absolute
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div>
+                  <div
+                    className="iot--date-time-picker__datepicker"
+                  >
+                    <div
+                      className="bx--form-item"
+                    >
+                      <div
+                        className="bx--date-picker bx--date-picker--range bx--date-picker--nolabel"
+                        onClose={[Function]}
+                      >
+                        <div
+                          className="bx--date-picker-container bx--date-picker--nolabel"
+                        >
+                          <div
+                            className="bx--date-picker-input__wrapper"
+                          >
+                            <input
+                              className="bx--date-picker__input"
+                              disabled={false}
+                              id="date-picker-input-start"
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              pattern="\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}"
+                              type="text"
+                              value="2020-04-01"
+                            />
+                            <svg
+                              aria-hidden={true}
+                              className="bx--date-picker__icon"
+                              focusable="false"
+                              height={16}
+                              onClick={[Function]}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          className="bx--date-picker-container bx--date-picker--nolabel"
+                        >
+                          <div
+                            className="bx--date-picker-input__wrapper"
+                          >
+                            <input
+                              className="bx--date-picker__input"
+                              disabled={false}
+                              id="date-picker-input-end"
+                              onChange={[Function]}
+                              onClick={[Function]}
+                              pattern="\\\\d{1,2}\\\\/\\\\d{1,2}\\\\/\\\\d{4}"
+                              type="text"
+                              value="2020-04-06"
+                            />
+                            <svg
+                              aria-hidden={true}
+                              className="bx--date-picker__icon"
+                              focusable="false"
+                              height={16}
+                              onClick={[Function]}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <fieldset
+                    className="bx--fieldset iot--date-time-picker__menu-formgroup"
+                  >
+                    <legend
+                      className="bx--label iot--date-time-picker__menu-formgroup"
+                    >
+                      
+                    </legend>
+                    <div
+                      className="iot--date-time-picker__fields-wrapper"
+                    >
+                      <div
+                        className="iot--time-picker__wrapper iot--time-picker__wrapper--with-spinner"
+                      >
+                        <div
+                          className="bx--form-item"
+                        >
+                          <label
+                            className="bx--label"
+                            htmlFor="start-time"
+                          >
+                            Start time
+                          </label>
+                          <div
+                            className="bx--time-picker"
+                          >
+                            <div
+                              className="bx--time-picker__input"
+                            >
+                              <input
+                                autoComplete="off"
+                                className="bx--time-picker__input-field bx--text-input"
+                                disabled={false}
+                                id="start-time"
+                                maxLength={5}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                pattern="(1[012]|[1-9]):[0-5][0-9](\\\\s)?"
+                                placeholder="hh:mm"
+                                type="text"
+                                value="12:34"
+                              />
+                            </div>
+                            <div
+                              className="iot--time-picker__controls"
+                            >
+                              <button
+                                aria-atomic="true"
+                                aria-label="Increment hours"
+                                aria-live="polite"
+                                className="iot--time-picker__controls--btn up-icon"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                title="Increment hours"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="up-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M0 4L4 0 8 4z"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                aria-atomic="true"
+                                aria-label="Decrement hours"
+                                aria-live="polite"
+                                className="iot--time-picker__controls--btn down-icon"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                title="Decrement hours"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="down-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M8 0L4 4 0 0z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--time-picker__wrapper iot--time-picker__wrapper--with-spinner"
+                      >
+                        <div
+                          className="bx--form-item"
+                        >
+                          <label
+                            className="bx--label"
+                            htmlFor="end-time"
+                          >
+                            End time
+                          </label>
+                          <div
+                            className="bx--time-picker"
+                          >
+                            <div
+                              className="bx--time-picker__input"
+                            >
+                              <input
+                                autoComplete="off"
+                                className="bx--time-picker__input-field bx--text-input"
+                                disabled={false}
+                                id="end-time"
+                                maxLength={5}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                pattern="(1[012]|[1-9]):[0-5][0-9](\\\\s)?"
+                                placeholder="hh:mm"
+                                type="text"
+                                value="10:49"
+                              />
+                            </div>
+                            <div
+                              className="iot--time-picker__controls"
+                            >
+                              <button
+                                aria-atomic="true"
+                                aria-label="Increment hours"
+                                aria-live="polite"
+                                className="iot--time-picker__controls--btn up-icon"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                title="Increment hours"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="up-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M0 4L4 0 8 4z"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                aria-atomic="true"
+                                aria-label="Decrement hours"
+                                aria-live="polite"
+                                className="iot--time-picker__controls--btn down-icon"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                title="Decrement hours"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="down-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M8 0L4 4 0 0z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--date-time-picker__menu-btn-set"
+            >
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-back bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Back
+              </button>
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-apply bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/DateTime Picker Selected preset 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--date-time-picker__wrapper"
+        id="iot--date-time-picker__wrapper"
+      >
+        <div
+          className="iot--date-time-picker__box"
+        >
+          <div
+            className="iot--date-time-picker__field"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="bx--tooltip--definition bx--tooltip--a11y"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <button
+                aria-describedby="definition-tooltip-4"
+                className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+                onFocus={[Function]}
+              >
+                Last 12 hours
+              </button>
+              <div
+                className="bx--assistive-text"
+                id="definition-tooltip-4"
+                role="tooltip"
+              >
+                2018-10-27 19:34 to Now
+              </div>
+            </div>
+            <svg
+              aria-label="Calendar"
+              className="iot--date-time-picker__icon"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+              />
+            </svg>
+          </div>
+          <div
+            className="iot--date-time-picker__menu"
+            role="listbox"
+          >
+            <div
+              className="iot--date-time-picker__menu-scroll"
+            >
+              <ol
+                className="bx--list--ordered"
+              >
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--current"
+                >
+                  2018-10-27 19:34 to Now
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--custom"
+                  onClick={[Function]}
+                >
+                  Custom Range
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 30 minutes
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 1 hour
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 6 hours
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset iot--date-time-picker__listitem--preset-selected"
+                  onClick={[Function]}
+                >
+                  Last 12 hours
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 24 hours
+                </li>
+              </ol>
+            </div>
+            <div
+              className="iot--date-time-picker__menu-btn-set"
+            >
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-cancel bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-apply bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/DateTime Picker Selected relative 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--date-time-picker__wrapper"
+        id="iot--date-time-picker__wrapper"
+      >
+        <div
+          className="iot--date-time-picker__box"
+        >
+          <div
+            className="iot--date-time-picker__field"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <span
+              title="2018-10-28 12:34 to 2018-10-28 12:34"
+            >
+              2018-10-28 12:34 to 2018-10-28 12:34
+            </span>
+            <svg
+              aria-label="Calendar"
+              className="iot--date-time-picker__icon"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+              />
+            </svg>
+          </div>
+          <div
+            className="iot--date-time-picker__menu"
+            role="listbox"
+          >
+            <div
+              className="iot--date-time-picker__menu-scroll"
+            >
+              <div>
+                <fieldset
+                  className="bx--fieldset iot--date-time-picker__menu-formgroup"
+                >
+                  <legend
+                    className="bx--label iot--date-time-picker__menu-formgroup"
+                  >
+                    Custom range
+                  </legend>
+                  <div
+                    className="bx--form-item"
+                  >
+                    <div
+                      className="bx--radio-button-group bx--radio-button-group--label-right"
+                    >
+                      <div
+                        className="bx--radio-button-wrapper"
+                      >
+                        <input
+                          checked={true}
+                          className="bx--radio-button"
+                          id="relative"
+                          name="radiogroup"
+                          onChange={[Function]}
+                          type="radio"
+                          value="RELATIVE"
+                        />
+                        <label
+                          className="bx--radio-button__label"
+                          htmlFor="relative"
+                        >
+                          <span
+                            className="bx--radio-button__appearance"
+                          />
+                          <span
+                            className=""
+                          >
+                            Relative
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="bx--radio-button-wrapper"
+                      >
+                        <input
+                          checked={false}
+                          className="bx--radio-button"
+                          id="absolute"
+                          name="radiogroup"
+                          onChange={[Function]}
+                          type="radio"
+                          value="ABSOLUTE"
+                        />
+                        <label
+                          className="bx--radio-button__label"
+                          htmlFor="absolute"
+                        >
+                          <span
+                            className="bx--radio-button__appearance"
+                          />
+                          <span
+                            className=""
+                          >
+                            Absolute
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+                <div>
+                  <fieldset
+                    className="bx--fieldset iot--date-time-picker__menu-formgroup"
+                  >
+                    <legend
+                      className="bx--label iot--date-time-picker__menu-formgroup"
+                    >
+                      Last
+                    </legend>
+                    <div
+                      className="iot--date-time-picker__fields-wrapper"
+                    >
+                      <div
+                        className="bx--form-item"
+                      >
+                        <div
+                          className="bx--number bx--number--helpertext"
+                        >
+                          <div
+                            className="bx--number__input-wrapper"
+                          >
+                            <input
+                              aria-describedby={null}
+                              aria-label="Numeric input field with increment and decrement buttons"
+                              disabled={false}
+                              id="last-number"
+                              min={0}
+                              onChange={[Function]}
+                              pattern="[0-9]*"
+                              step={1}
+                              type="number"
+                              value={20}
+                            />
+                            <div
+                              className="bx--number__controls"
+                            >
+                              <button
+                                aria-atomic="true"
+                                aria-label="Increment number"
+                                aria-live="polite"
+                                className="bx--number__control-btn up-icon"
+                                disabled={false}
+                                onClick={[Function]}
+                                title="Increment number"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="up-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M0 4L4 0 8 4z"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                aria-atomic="true"
+                                aria-label="Decrement number"
+                                aria-live="polite"
+                                className="bx--number__control-btn down-icon"
+                                disabled={false}
+                                onClick={[Function]}
+                                title="Decrement number"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="down-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M8 0L4 4 0 0z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="bx--form-item"
+                      >
+                        <div
+                          className="bx--select"
+                        >
+                          <label
+                            className="bx--label bx--visually-hidden"
+                            htmlFor="last-interval"
+                          >
+                            Select
+                          </label>
+                          <div
+                            className="bx--select-input__wrapper"
+                            data-invalid={null}
+                          >
+                            <select
+                              className="bx--select-input"
+                              defaultValue="MINUTES"
+                              id="last-interval"
+                              onChange={[Function]}
+                            >
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="MINUTES"
+                              >
+                                minutes
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="HOURS"
+                              >
+                                hours
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="DAYS"
+                              >
+                                days
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="WEEKS"
+                              >
+                                weeks
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="MONTHS"
+                              >
+                                months
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="YEARS"
+                              >
+                                years
+                              </option>
+                            </select>
+                            <svg
+                              aria-hidden={true}
+                              className="bx--select__arrow"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </fieldset>
+                  <fieldset
+                    className="bx--fieldset iot--date-time-picker__menu-formgroup"
+                  >
+                    <legend
+                      className="bx--label iot--date-time-picker__menu-formgroup"
+                    >
+                      Relative to
+                    </legend>
+                    <div
+                      className="iot--date-time-picker__fields-wrapper"
+                    >
+                      <div
+                        className="bx--form-item"
+                      >
+                        <div
+                          className="bx--select"
+                        >
+                          <label
+                            className="bx--label bx--visually-hidden"
+                            htmlFor="relative-to-when"
+                          >
+                            Select
+                          </label>
+                          <div
+                            className="bx--select-input__wrapper"
+                            data-invalid={null}
+                          >
+                            <select
+                              className="bx--select-input"
+                              defaultValue="TODAY"
+                              id="relative-to-when"
+                              onChange={[Function]}
+                            >
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="TODAY"
+                              >
+                                Today
+                              </option>
+                              <option
+                                className="bx--select-option"
+                                disabled={false}
+                                hidden={false}
+                                value="YESTERDAY"
+                              >
+                                Yesterday
+                              </option>
+                            </select>
+                            <svg
+                              aria-hidden={true}
+                              className="bx--select__arrow"
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="iot--time-picker__wrapper iot--time-picker__wrapper--with-spinner"
+                      >
+                        <div
+                          className="bx--form-item"
+                        >
+                          <div
+                            className="bx--time-picker"
+                          >
+                            <div
+                              className="bx--time-picker__input"
+                            >
+                              <input
+                                autoComplete="off"
+                                className="bx--time-picker__input-field bx--text-input"
+                                disabled={false}
+                                id="relative-to-time"
+                                maxLength={5}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                pattern="(1[012]|[1-9]):[0-5][0-9](\\\\s)?"
+                                placeholder="hh:mm"
+                                type="text"
+                                value="13:30"
+                              />
+                            </div>
+                            <div
+                              className="iot--time-picker__controls"
+                            >
+                              <button
+                                aria-atomic="true"
+                                aria-label="Increment hours"
+                                aria-live="polite"
+                                className="iot--time-picker__controls--btn up-icon"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                title="Increment hours"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="up-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M0 4L4 0 8 4z"
+                                  />
+                                </svg>
+                              </button>
+                              <button
+                                aria-atomic="true"
+                                aria-label="Decrement hours"
+                                aria-live="polite"
+                                className="iot--time-picker__controls--btn down-icon"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                title="Decrement hours"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="down-icon"
+                                  focusable="false"
+                                  height={4}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  viewBox="0 0 8 4"
+                                  width={8}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M8 0L4 4 0 0z"
+                                  />
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--date-time-picker__menu-btn-set"
+            >
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-back bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Back
+              </button>
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-apply bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/DateTime Picker Without a relative option 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--date-time-picker__wrapper"
+        id="iot--date-time-picker__wrapper"
+      >
+        <div
+          className="iot--date-time-picker__box"
+        >
+          <div
+            className="iot--date-time-picker__field"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="bx--tooltip--definition bx--tooltip--a11y"
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+            >
+              <button
+                aria-describedby="definition-tooltip-6"
+                className="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+                onFocus={[Function]}
+              >
+                Last 12 hours
+              </button>
+              <div
+                className="bx--assistive-text"
+                id="definition-tooltip-6"
+                role="tooltip"
+              >
+                2018-10-27 19:34 to Now
+              </div>
+            </div>
+            <svg
+              aria-label="Calendar"
+              className="iot--date-time-picker__icon"
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M26,4h-4V2h-2v2h-8V2h-2v2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20c1.1,0,2-0.9,2-2V6C28,4.9,27.1,4,26,4z M26,26H6V12h20	V26z M26,10H6V6h4v2h2V6h8v2h2V6h4V10z"
+              />
+            </svg>
+          </div>
+          <div
+            className="iot--date-time-picker__menu"
+            role="listbox"
+          >
+            <div
+              className="iot--date-time-picker__menu-scroll"
+            >
+              <ol
+                className="bx--list--ordered"
+              >
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--current"
+                >
+                  2018-10-27 19:34 to Now
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--custom"
+                  onClick={[Function]}
+                >
+                  Custom Range
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 30 minutes
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 1 hour
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 6 hours
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset iot--date-time-picker__listitem--preset-selected"
+                  onClick={[Function]}
+                >
+                  Last 12 hours
+                </li>
+                <li
+                  className="bx--list__item iot--date-time-picker__listitem iot--date-time-picker__listitem--preset"
+                  onClick={[Function]}
+                >
+                  Last 24 hours
+                </li>
+              </ol>
+            </div>
+            <div
+              className="iot--date-time-picker__menu-btn-set"
+            >
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-cancel bx--btn bx--btn--secondary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className="iot--date-time-picker__menu-btn iot--date-time-picker__menu-btn-apply bx--btn bx--btn--primary"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/GaugeCard/__snapshots__/GaugeCard.story.storyshot
+++ b/src/components/GaugeCard/__snapshots__/GaugeCard.story.storyshot
@@ -1,0 +1,375 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/GaugeCard basic 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 60,
+          "width": "232px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--gauge-card iot--card--wrapper"
+        data-testid="Card"
+        id="GaugeCard"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "144px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Health"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Health
+            </div>
+            <div
+              className="bx--tooltip__label"
+              id="card-tooltip-trigger-GaugeCard"
+            >
+              
+              <div
+                aria-describedby={null}
+                className="bx--tooltip__trigger"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-hidden={true}
+                  description={null}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                  />
+                  <path
+                    d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "96px",
+            }
+          }
+        >
+          <div
+            className="iot--gauge-container"
+            style={
+              Object {
+                "paddingBottom": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <svg
+              aria-labelledby="gauge-label"
+              className="iot--gauge"
+              percent="0"
+              style={
+                Object {
+                  "--gauge-bg": "#e0e0e0",
+                  "--gauge-colors": "#42be65",
+                  "--gauge-max-value": 100,
+                  "--gauge-size": "80px",
+                  "--gauge-trend-color": "",
+                  "--gauge-value": 81,
+                  "--stroke-dash": 183.21768355735674,
+                  "--stroke-dash-array": 226.1946710584651,
+                }
+              }
+            >
+              <circle
+                className="iot--gauge-bg"
+                cx={40}
+                cy={40}
+                r={36}
+              />
+              <circle
+                className="iot--gauge-fg"
+                cx={40}
+                cy={40}
+                r={36}
+              />
+              <text
+                className="iot--gauge-value iot--gauge-value__centered iot--gauge-value-lg"
+                id="gauge-label"
+                textAnchor="middle"
+                x={40}
+                y="33"
+              >
+                <tspan>
+                  81
+                </tspan>
+                <tspan>
+                  %
+                </tspan>
+              </text>
+            </svg>
+            <div
+              className="iot--gauge-trend iot--gauge-trend__up"
+            >
+              <p
+                style={
+                  Object {
+                    "--gauge-trend-color": "",
+                  }
+                }
+              >
+                12%
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/GaugeCard with data state no-data 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 60,
+          "width": "252px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--gauge-card iot--card--wrapper"
+        data-testid="Card"
+        id="GaugeCard"
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "144px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Health"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Health
+            </div>
+            <div
+              className="bx--tooltip__label"
+              id="card-tooltip-trigger-GaugeCard"
+            >
+              
+              <div
+                aria-describedby={null}
+                className="bx--tooltip__trigger"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                role="button"
+                tabIndex={0}
+              >
+                <svg
+                  aria-hidden={true}
+                  description={null}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role={null}
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8.5 11L8.5 6.5 6.5 6.5 6.5 7.5 7.5 7.5 7.5 11 6 11 6 12 10 12 10 11zM8 3.5c-.4 0-.8.3-.8.8S7.6 5 8 5c.4 0 .8-.3.8-.8S8.4 3.5 8 3.5z"
+                  />
+                  <path
+                    d="M8,15c-3.9,0-7-3.1-7-7s3.1-7,7-7s7,3.1,7,7S11.9,15,8,15z M8,2C4.7,2,2,4.7,2,8s2.7,6,6,6s6-2.7,6-6S11.3,2,8,2z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "96px",
+            }
+          }
+        >
+          <div
+            className="iot--gauge-container"
+            style={Object {}}
+          >
+            <div
+              className="iot--data-state-container"
+              style={
+                Object {
+                  "--container-padding": "16px",
+                }
+              }
+            >
+              <p
+                className="iot--data-state-dashes"
+              >
+                --
+              </p>
+              <div
+                className="iot--data-state-grid"
+              >
+                <div
+                  aria-describedby={null}
+                  aria-labelledby="iot--data-state-grid__icon-GaugeCard"
+                  className="bx--tooltip__label"
+                  id="iot--data-state-grid__icon-GaugeCard"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  role="button"
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="iot--data-state-default-warning-icon"
+                    focusable="false"
+                    height={24}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                    width={24}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12,1C5.9,1,1,5.9,1,12s4.9,11,11,11s11-4.9,11-11C23,5.9,18.1,1,12,1z M11.1,6h1.8v8h-1.8V6z M12,19.2	c-0.7,0-1.2-0.6-1.2-1.2s0.6-1.2,1.2-1.2s1.2,0.6,1.2,1.2S12.7,19.2,12,19.2z"
+                    />
+                    <path
+                      d="M13.2,18c0,0.7-0.6,1.2-1.2,1.2s-1.2-0.6-1.2-1.2s0.6-1.2,1.2-1.2S13.2,17.3,13.2,18z M12.9,6	h-1.8v8h1.8V6z"
+                      data-icon-path="inner-path"
+                      fill="none"
+                      opacity="0"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "height": "150vh",
+          }
+        }
+      />
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/List/HierarchyList/HierarchyList.jsx
+++ b/src/components/List/HierarchyList/HierarchyList.jsx
@@ -149,9 +149,8 @@ const HierarchyList = ({
 
   const selectedItemRef = useCallback(
     node => {
-      if (node) {
-        node.parentNode.scrollIntoView();
-      }
+      // eslint-disable-next-line no-unused-expressions
+      node?.parentNode?.scrollIntoView();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [defaultSelectedId]

--- a/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
+++ b/src/components/List/HierarchyList/__snapshots__/HierarchyList.story.storyshot
@@ -1,0 +1,1179 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/HierarchyList Stateful list with nested searching 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": 400,
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list iot--list__full-height"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              MLB Expanded List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="iot--list-header--search-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="iot--list-header--search"
+                id="iot--list-header--search-search"
+              >
+                Enter a value
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="iot--list-header--search"
+                onChange={[Function]}
+                placeholder="Enter a value"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content__full-height iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Chicago White Sox"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Yankees"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Houston Astros"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Atlanta Braves"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Mets"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={2}
+            >
+              Page 1
+            </span>
+            <div
+              className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
+              role="button"
+              tabIndex={-1}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret-disabled"
+                description="Prev page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M20 24L10 16 20 8z"
+                />
+              </svg>
+            </div>
+            <div
+              className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret"
+                description="Next page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8L22 16 12 24z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/HierarchyList With defaultSelectedId 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": 400,
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              MLB Expanded List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="iot--list-header--search-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="iot--list-header--search"
+                id="iot--list-header--search-search"
+              >
+                Enter a value
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="iot--list-header--search"
+                onChange={[Function]}
+                placeholder="Enter a value"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Chicago White Sox"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Yankees"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Houston Astros"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Atlanta Braves"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Mets"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Jeff McNeil"
+                  >
+                    Jeff McNeil
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Amed Rosario"
+                  >
+                    Amed Rosario
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto"
+                  >
+                    Michael ConfortoMichael ConfortoMichael ConfortoMichael Conforto
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable iot--list-item__selected"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content iot--list-item--content__selected"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Pete Alonso"
+                  >
+                    Pete Alonso
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Wilson Ramos"
+                  >
+                    Wilson Ramos
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="JD Davis"
+                  >
+                    JD Davis
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brandon Nimmo"
+                  >
+                    Brandon Nimmo
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Jacob Degrom"
+                  >
+                    Jacob Degrom
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Washington Nationals"
+                  >
+                    Washington Nationals
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/List/List.story.jsx
+++ b/src/components/List/List.story.jsx
@@ -363,6 +363,7 @@ storiesOf('Watson IoT Experimental/List', module)
               <Checkbox
                 id={`${team}-checkbox`}
                 name={team}
+                labelText={`${team}`}
                 onClick={e => handleCheckboxChange(e, nestedItems, team)}
                 checked={selectedIds.some(id => team === id)}
                 indeterminate={
@@ -383,6 +384,7 @@ storiesOf('Watson IoT Experimental/List', module)
                 <Checkbox
                   id={`${team}-${player}-checkbox`}
                   name={player}
+                  labelText={`${player}`}
                   onClick={e => {
                     handleCheckboxChange(e, nestedItems, `${team}-${player}`);
                   }}
@@ -402,6 +404,7 @@ storiesOf('Watson IoT Experimental/List', module)
               <Checkbox
                 id={`${team}-checkbox`}
                 name={team}
+                labelText={`${team}`}
                 onClick={e => handleCheckboxChange(e, nestedItems, team)}
                 checked={selectedIds.some(id => team === id)}
                 indeterminate={
@@ -422,6 +425,7 @@ storiesOf('Watson IoT Experimental/List', module)
                 <Checkbox
                   id={`${team}-${player}-checkbox`}
                   name={player}
+                  labelText={`${player}`}
                   onClick={e => {
                     handleCheckboxChange(e, nestedItems, `${team}-${player}`);
                   }}

--- a/src/components/List/ListHeader/ListHeader.jsx
+++ b/src/components/List/ListHeader/ListHeader.jsx
@@ -45,6 +45,7 @@ const ListHeader = ({ title, buttons, search, i18n, isLoading }) => {
       {search && !isLoading ? (
         <div className={`${iotPrefix}--list-header--search`}>
           <Search
+            id={`${iotPrefix}--list-header--search`}
             placeHolderText={i18n.searchPlaceHolderText}
             onChange={search.onChange}
             size="sm"

--- a/src/components/List/ListItem/__snapshots__/ListItem.story.storyshot
+++ b/src/components/List/ListItem/__snapshots__/ListItem.story.storyshot
@@ -1,0 +1,1032 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem basic w/ knobs 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="List Item"
+              >
+                List Item
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem testing isLargeRow overflow 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item iot--list-item__large"
+      >
+        <div
+          className="iot--list-item--content iot--list-item--content__large"
+        >
+          <div
+            className="iot--list-item--content--values iot--list-item--content--values__large"
+          >
+            <div
+              className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="List Item this could be a reaaaaaaaaaaally really long value"
+              >
+                List Item this could be a reaaaaaaaaaaally really long value
+              </div>
+            </div>
+            <div
+              className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+              title="With isLargeRow, the secondary value serves primarily as a description field for the list item.  If the content is too wide for the list item, it will be visible in a tooltip."
+            >
+              With isLargeRow, the secondary value serves primarily as a description field for the list item.  If the content is too wide for the list item, it will be visible in a tooltip.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem testing secondaryValue overflow 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item iot--list-item__large"
+      >
+        <div
+          className="iot--list-item--content iot--list-item--content__large"
+        >
+          <div
+            className="iot--list-item--content--values iot--list-item--content--values__large"
+          >
+            <div
+              className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="List Item this could be a really long value that can't quite fit"
+              >
+                List Item this could be a really long value that can't quite fit
+              </div>
+            </div>
+            <div
+              className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+              title="Secondary Value could also be a really, extraordinarily long value"
+            >
+              Secondary Value could also be a really, extraordinarily long value
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with OverflowMenu row actions 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--expand-icon"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            aria-label="Close"
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+            />
+          </svg>
+        </div>
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                title="List Item"
+              >
+                List Item
+              </div>
+              <div
+                className="iot--list-item--content--row-actions"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-label="Menu"
+                  className="bx--overflow-menu"
+                  onClick={[Function]}
+                  onClose={[Function]}
+                  onKeyDown={[Function]}
+                  open={false}
+                  tabIndex={0}
+                >
+                  <svg
+                    aria-label="open and close list of options"
+                    className="bx--overflow-menu__icon"
+                    focusable="false"
+                    height={16}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      cx="16"
+                      cy="8"
+                      r="2"
+                    />
+                    <circle
+                      cx="16"
+                      cy="16"
+                      r="2"
+                    />
+                    <circle
+                      cx="16"
+                      cy="24"
+                      r="2"
+                    />
+                    <title>
+                      open and close list of options
+                    </title>
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with icon 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--icon iot--list-item--content--icon__left"
+          >
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+              />
+            </svg>
+          </div>
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="List Item"
+              >
+                List Item
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with isCategory 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--expand-icon"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            aria-label="Close"
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+            />
+          </svg>
+        </div>
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value iot--list-item--category"
+                title="List Item"
+              >
+                List Item
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with isExpandable 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--expand-icon"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <svg
+            aria-label="Close"
+            focusable="false"
+            height={16}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            viewBox="0 0 16 16"
+            width={16}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+            />
+          </svg>
+        </div>
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="Expandable List Item"
+              >
+                Expandable List Item
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with isLargeRow 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item iot--list-item__large"
+      >
+        <div
+          className="iot--list-item--content iot--list-item--content__large"
+        >
+          <div
+            className="iot--list-item--content--values iot--list-item--content--values__large"
+          >
+            <div
+              className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="List Item"
+              >
+                List Item
+              </div>
+            </div>
+            <div
+              className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+              title="With isLargeRow, the secondary value serves primarily as a description field for the list item"
+            >
+              With isLargeRow, the secondary value serves primarily as a description field for the list item
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with isSelectable 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item iot--list-item__selectable"
+        onClick={[Function]}
+        onKeyPress={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="Selectable List Item"
+              >
+                Selectable List Item
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with secondaryValue 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="List Item"
+              >
+                List Item
+              </div>
+              <div
+                className="iot--list-item--content--values--value"
+                title="Secondary Value"
+              >
+                Secondary Value
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with single row action 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                title="List Item"
+              >
+                List Item
+              </div>
+              <div
+                className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                title="Secondary Value"
+              >
+                Secondary Value
+              </div>
+              <div
+                className="iot--list-item--content--row-actions"
+              >
+                <button
+                  className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "color": "black",
+                    }
+                  }
+                  tabIndex={0}
+                  type="button"
+                >
+                  <span
+                    className="bx--assistive-text"
+                  >
+                    Edit
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    aria-label="Edit"
+                    className="bx--btn__icon"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    role="img"
+                    viewBox="0 0 32 32"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListItem with value 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list-item"
+      >
+        <div
+          className="iot--list-item--content"
+        >
+          <div
+            className="iot--list-item--content--values"
+          >
+            <div
+              className="iot--list-item--content--values--main"
+            >
+              <div
+                className="iot--list-item--content--values--value"
+                title="List Item"
+              >
+                List Item
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/List/SimpleList/SimpleList.story.jsx
+++ b/src/components/List/SimpleList/SimpleList.story.jsx
@@ -21,13 +21,13 @@ const getListItems = num =>
 const listItemsWithEmptyRow = getListItems(5).concat({ id: '6', content: { value: '' } });
 
 const rowActions = [
-  <Edit16 onClick={action('edit')} />,
-  <Add16 onClick={action('add')} />,
-  <Close16 onClick={action('close')} />,
+  <Edit16 onClick={action('edit')} key="simple-list-action-edit" />,
+  <Add16 onClick={action('add')} key="simple-list-action-add" />,
+  <Close16 onClick={action('close')} key="simple-list-action-close" />,
 ];
 
 const rowActionsOverFlowMenu = [
-  <OverflowMenu flipped>
+  <OverflowMenu flipped key="simple-list-overflow-menu">
     <OverflowMenuItem itemText="Edit" primaryFocus />
     <OverflowMenuItem itemText="Add" />
     <OverflowMenuItem itemText="Delete" />
@@ -108,7 +108,7 @@ const buttonsToRender = [
 
 storiesOf('Watson IoT Experimental/SimpleList', module)
   .add(
-    'basic',
+    'basic - SimpleList',
     withReadme(SimpleListREADME, () => (
       <div style={{ width: 500 }}>
         <SimpleList

--- a/src/components/List/SimpleList/__snapshots__/SimpleList.story.storyshot
+++ b/src/components/List/SimpleList/__snapshots__/SimpleList.story.storyshot
@@ -1,0 +1,5874 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList basic - SimpleList 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_0s43nqslvanm-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_0s43nqslvanm"
+                id="search__input__id_0s43nqslvanm-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_0s43nqslvanm"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 6"
+                  >
+                    Item 6
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 7"
+                  >
+                    Item 7
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 8"
+                  >
+                    Item 8
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 9"
+                  >
+                    Item 9
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 10"
+                  >
+                    Item 10
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 11"
+                  >
+                    Item 11
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 12"
+                  >
+                    Item 12
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 13"
+                  >
+                    Item 13
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 14"
+                  >
+                    Item 14
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 15"
+                  >
+                    Item 15
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 16"
+                  >
+                    Item 16
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 17"
+                  >
+                    Item 17
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 18"
+                  >
+                    Item 18
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 19"
+                  >
+                    Item 19
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 20"
+                  >
+                    Item 20
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 21"
+                  >
+                    Item 21
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 22"
+                  >
+                    Item 22
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 23"
+                  >
+                    Item 23
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 24"
+                  >
+                    Item 24
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 25"
+                  >
+                    Item 25
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 26"
+                  >
+                    Item 26
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 27"
+                  >
+                    Item 27
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 28"
+                  >
+                    Item 28
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 29"
+                  >
+                    Item 29
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 30"
+                  >
+                    Item 30
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={2}
+            >
+              Page 1
+            </span>
+            <div
+              className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
+              role="button"
+              tabIndex={-1}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret-disabled"
+                description="Prev page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M20 24L10 16 20 8z"
+                />
+              </svg>
+            </div>
+            <div
+              className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret"
+                description="Next page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8L22 16 12 24z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList large row list with multiple actions 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 600,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_qihpms9zma-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_qihpms9zma"
+                id="search__input__id_qihpms9zma-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_qihpms9zma"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 100"
+                >
+                  This is a description or some secondary bit of data for Item 100
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 101"
+                >
+                  This is a description or some secondary bit of data for Item 101
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 102"
+                >
+                  This is a description or some secondary bit of data for Item 102
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 103"
+                >
+                  This is a description or some secondary bit of data for Item 103
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 104"
+                >
+                  This is a description or some secondary bit of data for Item 104
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList large row list with overflow menu 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 600,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_pcylgispyg-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_pcylgispyg"
+                id="search__input__id_pcylgispyg-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_pcylgispyg"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 100"
+                >
+                  This is a description or some secondary bit of data for Item 100
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 101"
+                >
+                  This is a description or some secondary bit of data for Item 101
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 102"
+                >
+                  This is a description or some secondary bit of data for Item 102
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 103"
+                >
+                  This is a description or some secondary bit of data for Item 103
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large iot--list-item--content--values--value__with-actions"
+                  title="This is a description or some secondary bit of data for Item 104"
+                >
+                  This is a description or some secondary bit of data for Item 104
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList list with empty row 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 500,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_0a7nx41zerzi-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_0a7nx41zerzi"
+                id="search__input__id_0a7nx41zerzi-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_0a7nx41zerzi"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title=""
+                  >
+                    
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList list with large row 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 600,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_djmiuh9ay2-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_djmiuh9ay2"
+                id="search__input__id_djmiuh9ay2-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_djmiuh9ay2"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="This is a description or some secondary bit of data for Item 100"
+                >
+                  This is a description or some secondary bit of data for Item 100
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="This is a description or some secondary bit of data for Item 101"
+                >
+                  This is a description or some secondary bit of data for Item 101
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="This is a description or some secondary bit of data for Item 102"
+                >
+                  This is a description or some secondary bit of data for Item 102
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="This is a description or some secondary bit of data for Item 103"
+                >
+                  This is a description or some secondary bit of data for Item 103
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="This is a description or some secondary bit of data for Item 104"
+                >
+                  This is a description or some secondary bit of data for Item 104
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={4}
+            >
+              Page 1
+            </span>
+            <div
+              className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
+              role="button"
+              tabIndex={-1}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret-disabled"
+                description="Prev page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M20 24L10 16 20 8z"
+                />
+              </svg>
+            </div>
+            <div
+              className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret"
+                description="Next page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8L22 16 12 24z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList list with multiple actions 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 600,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_dqcm0bmigx-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_dqcm0bmigx"
+                id="search__input__id_dqcm0bmigx-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_dqcm0bmigx"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      onClick={[Function]}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList list with overflow grow 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 500,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_t1u3ajh220i-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_t1u3ajh220i"
+                id="search__input__id_t1u3ajh220i-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_t1u3ajh220i"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 6"
+                  >
+                    Item 6
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 7"
+                  >
+                    Item 7
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 8"
+                  >
+                    Item 8
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 9"
+                  >
+                    Item 9
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 10"
+                  >
+                    Item 10
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 11"
+                  >
+                    Item 11
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 12"
+                  >
+                    Item 12
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 13"
+                  >
+                    Item 13
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 14"
+                  >
+                    Item 14
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 15"
+                  >
+                    Item 15
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 16"
+                  >
+                    Item 16
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 17"
+                  >
+                    Item 17
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 18"
+                  >
+                    Item 18
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 19"
+                  >
+                    Item 19
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 20"
+                  >
+                    Item 20
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList list with overflow menu 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 600,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_rf2e6bgfjyb-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_rf2e6bgfjyb"
+                id="search__input__id_rf2e6bgfjyb-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_rf2e6bgfjyb"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList list with pageSize 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 500,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_7x1t98368r7-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_7x1t98368r7"
+                id="search__input__id_7x1t98368r7-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_7x1t98368r7"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 4"
+                  >
+                    Item 4
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 5"
+                  >
+                    Item 5
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={4}
+            >
+              Page 1
+            </span>
+            <div
+              className="bx--pagination__button bx--pagination__button--backward iot-addons-simple-pagination-button-disabled"
+              role="button"
+              tabIndex={-1}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret-disabled"
+                description="Prev page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M20 24L10 16 20 8z"
+                />
+              </svg>
+            </div>
+            <div
+              className="bx--pagination__button bx--pagination__button--forward iot-addons-simple-pagination-button"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-hidden={true}
+                className="iot-simple-pagination-caret"
+                description="Next page"
+                dir="ltr"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8L22 16 12 24z"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList tall list (isFullHeight = false) 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 500,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_0sc8g19efu8a-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_0sc8g19efu8a"
+                id="search__input__id_0sc8g19efu8a-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_0sc8g19efu8a"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/SimpleList tall list (isFullHeight = true) 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "#fee",
+          "height": 500,
+          "padding": 10,
+          "width": 500,
+        }
+      }
+    >
+      <div
+        className="iot--list iot--list__full-height"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Simple List
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                />
+              </svg>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--secondary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Close
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Close"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="iot--list-header--search"
+          >
+            <div
+              aria-labelledby="search__input__id_3nh27as5q8j-search"
+              className="bx--search bx--search--sm"
+              role="search"
+            >
+              <svg
+                aria-hidden={true}
+                className="bx--search-magnifier"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                />
+              </svg>
+              <label
+                className="bx--label"
+                htmlFor="search__input__id_3nh27as5q8j"
+                id="search__input__id_3nh27as5q8j-search"
+              >
+                Enter a search
+              </label>
+              <input
+                autoComplete="off"
+                className="bx--search-input"
+                id="search__input__id_3nh27as5q8j"
+                onChange={[Function]}
+                placeholder="Enter a search"
+                role="searchbox"
+                type="text"
+                value=""
+              />
+              <button
+                aria-label="Clear search input"
+                className="bx--search-close bx--search-close--hidden"
+                onClick={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content__full-height iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 1"
+                  >
+                    Item 1
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 2"
+                  >
+                    Item 2
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Item 3"
+                  >
+                    Item 3
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--page"
+        >
+          <div
+            className="iot-simple-pagination-container"
+          >
+            <span
+              className="iot-simple-pagination-page-label"
+              maxpage={1}
+            >
+              Page 1
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/List/__snapshots__/List.story.storyshot
+++ b/src/components/List/__snapshots__/List.story.storyshot
@@ -1,0 +1,5862 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List basic (single column) 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with categories, fixed height 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": 600,
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Major League Baseball
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Chicago White Sox"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Yankees"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="1B"
+                  >
+                    1B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="C"
+                  >
+                    C
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DH"
+                  >
+                    DH
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="SS"
+                  >
+                    SS
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="LF"
+                  >
+                    LF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="3B"
+                  >
+                    3B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Houston Astros"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Atlanta Braves"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Ronald Acuna Jr."
+                  >
+                    Ronald Acuna Jr.
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="CF"
+                  >
+                    CF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Dansby Swanson"
+                  >
+                    Dansby Swanson
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="SS"
+                  >
+                    SS
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Freddie Freeman"
+                  >
+                    Freddie Freeman
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="1B"
+                  >
+                    1B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Josh Donaldson"
+                  >
+                    Josh Donaldson
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="3B"
+                  >
+                    3B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Nick Markakis"
+                  >
+                    Nick Markakis
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Austin Riley"
+                  >
+                    Austin Riley
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="LF"
+                  >
+                    LF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brian McCann"
+                  >
+                    Brian McCann
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="C"
+                  >
+                    C
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Ozzie Albies"
+                  >
+                    Ozzie Albies
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Kevin Gausman"
+                  >
+                    Kevin Gausman
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="P"
+                  >
+                    P
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Mets"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Washington Nationals"
+                  >
+                    Washington Nationals
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with checkbox multi-selection 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Sports Teams
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <div
+                  className="bx--form-item bx--checkbox-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--checkbox"
+                    id="Chicago White Sox-checkbox"
+                    name="Chicago White Sox"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="bx--checkbox-label"
+                    htmlFor="Chicago White Sox-checkbox"
+                    title={null}
+                  >
+                    <span
+                      className="bx--checkbox-label-text"
+                    >
+                      Chicago White Sox
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Chicago White Sox"
+                  >
+                    Chicago White Sox
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <div
+                  className="bx--form-item bx--checkbox-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--checkbox"
+                    id="New York Yankees-checkbox"
+                    name="New York Yankees"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="bx--checkbox-label"
+                    htmlFor="New York Yankees-checkbox"
+                    title={null}
+                  >
+                    <span
+                      className="bx--checkbox-label-text"
+                    >
+                      New York Yankees
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Yankees"
+                  >
+                    New York Yankees
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <div
+                  className="bx--form-item bx--checkbox-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--checkbox"
+                    id="Houston Astros-checkbox"
+                    name="Houston Astros"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="bx--checkbox-label"
+                    htmlFor="Houston Astros-checkbox"
+                    title={null}
+                  >
+                    <span
+                      className="bx--checkbox-label-text"
+                    >
+                      Houston Astros
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Houston Astros"
+                  >
+                    Houston Astros
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <div
+                  className="bx--form-item bx--checkbox-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--checkbox"
+                    id="Atlanta Braves-checkbox"
+                    name="Atlanta Braves"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="bx--checkbox-label"
+                    htmlFor="Atlanta Braves-checkbox"
+                    title={null}
+                  >
+                    <span
+                      className="bx--checkbox-label-text"
+                    >
+                      Atlanta Braves
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Atlanta Braves"
+                  >
+                    Atlanta Braves
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <div
+                  className="bx--form-item bx--checkbox-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--checkbox"
+                    id="New York Mets-checkbox"
+                    name="New York Mets"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="bx--checkbox-label"
+                    htmlFor="New York Mets-checkbox"
+                    title={null}
+                  >
+                    <span
+                      className="bx--checkbox-label-text"
+                    >
+                      New York Mets
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="New York Mets"
+                  >
+                    New York Mets
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__selectable"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <div
+                  className="bx--form-item bx--checkbox-wrapper"
+                >
+                  <input
+                    checked={false}
+                    className="bx--checkbox"
+                    id="Washington Nationals-checkbox"
+                    name="Washington Nationals"
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="bx--checkbox-label"
+                    htmlFor="Washington Nationals-checkbox"
+                    title={null}
+                  >
+                    <span
+                      className="bx--checkbox-label-text"
+                    >
+                      Washington Nationals
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--category"
+                    title="Washington Nationals"
+                  >
+                    Washington Nationals
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with hierarchy 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              Sports Teams
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            >
+              <button
+                className="iot--btn bx--btn bx--btn--sm bx--btn--primary bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="bx--assistive-text"
+                >
+                  Add
+                </span>
+                <svg
+                  aria-hidden="true"
+                  aria-label="Add"
+                  className="bx--btn__icon"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M17 15L17 8 15 8 15 15 8 15 8 17 15 17 15 24 17 24 17 17 24 17 24 15z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="MLB"
+                  >
+                    MLB
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="American League"
+                  >
+                    American League
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Chicago White Sox"
+                  >
+                    Chicago White Sox
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="New York Yankees"
+                  >
+                    New York Yankees
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="1B"
+                  >
+                    1B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="C"
+                  >
+                    C
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DH"
+                  >
+                    DH
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="SS"
+                  >
+                    SS
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="LF"
+                  >
+                    LF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="3B"
+                  >
+                    3B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "90px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Houston Astros"
+                  >
+                    Houston Astros
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "30px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Expand"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 5L13 10 12.3 10.7 8 6.4 3.7 10.7 3 10z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="National League"
+                  >
+                    National League
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Atlanta Braves"
+                  >
+                    Atlanta Braves
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="New York Mets"
+                  >
+                    New York Mets
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--nesting-offset"
+              style={
+                Object {
+                  "width": "60px",
+                }
+              }
+            >
+               
+            </div>
+            <div
+              className="iot--list-item--expand-icon"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={0}
+            >
+              <svg
+                aria-label="Close"
+                focusable="false"
+                height={16}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                viewBox="0 0 16 16"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                />
+              </svg>
+            </div>
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Washington Nationals"
+                  >
+                    Washington Nationals
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with isLargeRow and icon 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="2B"
+                >
+                  2B
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="1B"
+                >
+                  1B
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="C"
+                >
+                  C
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="DH"
+                >
+                  DH
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="SS"
+                >
+                  SS
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="RF"
+                >
+                  RF
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="LF"
+                >
+                  LF
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="3B"
+                >
+                  3B
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="RF"
+                >
+                  RF
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item iot--list-item__large"
+          >
+            <div
+              className="iot--list-item--content iot--list-item--content__large"
+            >
+              <div
+                className="iot--list-item--content--icon iot--list-item--content--icon__left"
+              >
+                <svg
+                  aria-hidden={true}
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8,3.3l1.4,2.8l0.2,0.5l0.5,0.1l3.1,0.4L11,9.2l-0.4,0.4l0.1,0.5l0.5,3.1l-2.8-1.4L8,11.5l-0.5,0.2l-2.8,1.4l0.5-3.1	l0.1-0.5L5,9.2L2.8,7l3.1-0.4l0.5-0.1L6.6,6L8,3.3 M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7	L8,1z"
+                  />
+                </svg>
+              </div>
+              <div
+                className="iot--list-item--content--values iot--list-item--content--values__large"
+              >
+                <div
+                  className="iot--list-item--content--values--main iot--list-item--content--values--main__large"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                </div>
+                <div
+                  className="iot--list-item--content--values--value iot--list-item--content--values--value__large"
+                  title="2B"
+                >
+                  2B
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with row actions (multiple) 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="1B"
+                  >
+                    1B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="C"
+                  >
+                    C
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="DH"
+                  >
+                    DH
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="SS"
+                  >
+                    SS
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="LF"
+                  >
+                    LF
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="3B"
+                  >
+                    3B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      aria-label="Menu"
+                      className="bx--overflow-menu"
+                      onClick={[Function]}
+                      onClose={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      tabIndex={0}
+                    >
+                      <svg
+                        aria-label="open and close list of options"
+                        className="bx--overflow-menu__icon"
+                        focusable="false"
+                        height={16}
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="16"
+                          cy="8"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="16"
+                          r="2"
+                        />
+                        <circle
+                          cx="16"
+                          cy="24"
+                          r="2"
+                        />
+                        <title>
+                          open and close list of options
+                        </title>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with row actions (single) 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="1B"
+                  >
+                    1B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="C"
+                  >
+                    C
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="DH"
+                  >
+                    DH
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="SS"
+                  >
+                    SS
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="LF"
+                  >
+                    LF
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="3B"
+                  >
+                    3B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value iot--list-item--content--values--value__with-actions"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                  <div
+                    className="iot--list-item--content--row-actions"
+                  >
+                    <button
+                      className="iot--btn bx--btn bx--btn--sm bx--btn--ghost bx--btn--icon-only bx--tooltip__trigger bx--tooltip--a11y"
+                      disabled={false}
+                      onClick={[Function]}
+                      style={
+                        Object {
+                          "color": "black",
+                        }
+                      }
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="bx--assistive-text"
+                      >
+                        Edit
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        aria-label="Edit"
+                        className="bx--btn__icon"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M2 26H30V28H2zM25.4 9c.8-.8.8-2 0-2.8 0 0 0 0 0 0l-3.6-3.6c-.8-.8-2-.8-2.8 0 0 0 0 0 0 0l-15 15V24h6.4L25.4 9zM20.4 4L24 7.6l-3 3L17.4 7 20.4 4zM6 22v-3.6l10-10 3.6 3.6-10 10H6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/List with secondaryValue 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": 400,
+        }
+      }
+    >
+      <div
+        className="iot--list"
+      >
+        <div
+          className="iot--list-header-container"
+        >
+          <div
+            className="iot--list-header"
+          >
+            <div
+              className="iot--list-header--title"
+            >
+              NY Yankees
+            </div>
+            <div
+              className="iot--list-header--btn-container"
+            />
+          </div>
+        </div>
+        <div
+          className="iot--list--content"
+        >
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DJ LeMahieu"
+                  >
+                    DJ LeMahieu
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Luke Voit"
+                  >
+                    Luke Voit
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="1B"
+                  >
+                    1B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gary Sanchez"
+                  >
+                    Gary Sanchez
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="C"
+                  >
+                    C
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Kendrys Morales"
+                  >
+                    Kendrys Morales
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="DH"
+                  >
+                    DH
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gleyber Torres"
+                  >
+                    Gleyber Torres
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="SS"
+                  >
+                    SS
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Clint Frazier"
+                  >
+                    Clint Frazier
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Brett Gardner"
+                  >
+                    Brett Gardner
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="LF"
+                  >
+                    LF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Gio Urshela"
+                  >
+                    Gio Urshela
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="3B"
+                  >
+                    3B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Cameron Maybin"
+                  >
+                    Cameron Maybin
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="RF"
+                  >
+                    RF
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="iot--list-item"
+          >
+            <div
+              className="iot--list-item--content"
+            >
+              <div
+                className="iot--list-item--content--values"
+              >
+                <div
+                  className="iot--list-item--content--values--main"
+                >
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="Robinson Cano"
+                  >
+                    Robinson Cano
+                  </div>
+                  <div
+                    className="iot--list-item--content--values--value"
+                    title="2B"
+                  >
+                    2B
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/ListCard/__snapshots__/ListCard.story.storyshot
+++ b/src/components/ListCard/__snapshots__/ListCard.story.storyshot
@@ -1,0 +1,659 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListCard basic 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "252px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="ListCard"
+        onScroll={[Function]}
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "304px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="Simple List with Icon"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              Simple List with Icon
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "256px",
+            }
+          }
+        >
+          <div
+            className="list-card"
+            style={
+              Object {
+                "paddingBottom": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <section
+              aria-label="Structured list section"
+              className="bx--structured-list"
+            >
+              <div
+                className="bx--structured-list-tbody"
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://internetofthings.ibmcloud.com/"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        Row content 1
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://internetofthings.ibmcloud.com/"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        Row content 2
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      Row content 3
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://internetofthings.ibmcloud.com/"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        Row content 4
+                      </a>
+                    </div>
+                    <div
+                      className="list-card--item--extra-content"
+                    >
+                      <svg
+                        height="10"
+                        width="30"
+                      >
+                        <circle
+                          cx="5"
+                          cy="5"
+                          fill="red"
+                          r="3"
+                          stroke="none"
+                          strokeWidth="1"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      Row content 5
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      Row content 6
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      Row content 7
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      Row content 8
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListCard with extra content 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="ListCard"
+        onScroll={[Function]}
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "304px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="List with extra content"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              List with extra content
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "256px",
+            }
+          }
+        >
+          <div
+            className="list-card"
+            style={
+              Object {
+                "paddingBottom": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <section
+              aria-label="Structured list section"
+              className="bx--structured-list"
+            >
+              <div
+                className="bx--structured-list-tbody"
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://www.ibm.com/support/knowledgecenter/SSQP8H/iot/guides/micro-explore.html"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        Explore entity metrics in the data lake
+                      </a>
+                    </div>
+                    <div
+                      className="list-card--item--extra-content"
+                    >
+                      <span>
+                        View your device data in the entity view of the main Watson IoT Platform dashboard. If your plan includes Watson IoT Platform Analytics, the data is stored in the data lake for later retrieval and processing.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://www.ibm.com/support/knowledgecenter/SSQP8H/iot/guides/micro-calculate.html"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        Perform simple calculations on your entity metrics
+                      </a>
+                    </div>
+                    <div
+                      className="list-card--item--extra-content"
+                    >
+                      <span>
+                        Process your entity metrics by running simple or complex calculations to create calculated metrics.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://www.ibm.com/support/knowledgecenter/SSQP8H/iot/guides/micro-monitor.html"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        View entity metrics in a monitoring dashboard
+                      </a>
+                    </div>
+                    <div
+                      className="list-card--item--extra-content"
+                    >
+                      <span>
+                        Visualize your entity metrics in monitoring dashboards to get an overview of your data.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/ListCard with extra long content 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+          "width": "520px",
+        }
+      }
+    >
+      <div
+        className="iot--card iot--card--wrapper"
+        data-testid="Card"
+        id="ListCard"
+        onScroll={[Function]}
+        role="presentation"
+        style={
+          Object {
+            "--card-default-height": "304px",
+          }
+        }
+      >
+        <div
+          className="iot--card--header"
+        >
+          <span
+            className="iot--card--title"
+            title="List with extra long content"
+          >
+            <div
+              className="iot--card--title--text"
+            >
+              List with extra long content
+            </div>
+          </span>
+        </div>
+        <div
+          className="iot--card--content"
+          style={
+            Object {
+              "--card-content-height": "256px",
+            }
+          }
+        >
+          <div
+            className="list-card"
+            style={
+              Object {
+                "paddingBottom": 0,
+                "paddingLeft": 16,
+                "paddingRight": 16,
+                "paddingTop": 0,
+              }
+            }
+          >
+            <section
+              aria-label="Structured list section"
+              className="bx--structured-list"
+            >
+              <div
+                className="bx--structured-list-tbody"
+                onKeyDown={[Function]}
+              >
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://www.ibm.com/support/knowledgecenter/SSQP8H/iot/guides/micro-explore.html"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        Explore entity metrics in the data lake
+                      </a>
+                    </div>
+                    <div
+                      className="list-card--item--extra-content"
+                    >
+                      <span>
+                        Lorem ipsum, dolor sit amet consectetur adipisicing elit. Aliquid cumque in quam qui ut vero facilis autem. Laudantium enim accusantium facere nemo aspernatur repudiandae at, incidunt adipisci consequuntur ut, non, sint delectus labore id quaerat debitis quia veritatis autem aliquid voluptates? Quam perspiciatis aperiam perferendis incidunt rerum magni ratione iusto porro natus cumque omnis velit dolores, ipsa veniam! Maiores libero quam nam fugiat, voluptatum fuga ex architecto, enim similique quod, voluptates qui voluptas blanditiis tempora dolor assumenda quos numquam temporibus.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://www.ibm.com/support/knowledgecenter/SSQP8H/iot/guides/micro-calculate.html"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        Perform simple calculations on your entity metrics
+                      </a>
+                    </div>
+                    <div
+                      className="list-card--item--extra-content"
+                    >
+                      <span>
+                        Lorem ipsum dolor sit amet consectetur adipisicing elit. Delectus id nulla porro temporibus excepturi cupiditate rem voluptatibus aspernatur minima quasi autem labore, quaerat facilis perferendis quas iste quae, voluptatem, possimus dicta fugit. Voluptatem similique odio necessitatibus delectus non itaque fugiat, saepe consectetur impedit, harum cupiditate velit repellendus assumenda, vel quasi eveniet at vero voluptate asperiores maxime quas. Error, nemo, nobis recusandae totam quod provident pariatur ipsum exercitationem nihil, doloremque consequuntur. Possimus assumenda odit nesciunt veritatis, maxime quae. Hic unde quasi quas recusandae obcaecati repellendus officia aperiam sunt, aut, minus quod vero provident, velit blanditiis necessitatibus laudantium nihil tempore nostrum impedit porro enim. Enim ipsam quasi iure perferendis repellat saepe vero, voluptate tenetur consequatur necessitatibus excepturi accusamus asperiores nam hic sapiente!
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="bx--structured-list-row"
+                >
+                  <div
+                    className="list-card--item bx--structured-list-td"
+                  >
+                    <div
+                      className="list-card--item--value"
+                    >
+                      <a
+                        className="bx--link"
+                        href="https://www.ibm.com/support/knowledgecenter/SSQP8H/iot/guides/micro-monitor.html"
+                        style={
+                          Object {
+                            "display": "inherit",
+                          }
+                        }
+                        target="_blank"
+                      >
+                        View entity metrics in a monitoring dashboard
+                      </a>
+                    </div>
+                    <div
+                      className="list-card--item--extra-content"
+                    >
+                      <span>
+                        Visualize your entity metrics in monitoring dashboards to get an overview of your data.
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
+++ b/src/components/Table/TableViewDropdown/__snapshots__/TableViewDropdown.story.storyshot
@@ -47,7 +47,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           >
             <span
               className="bx--list-box__label"
-              htmlFor="downshift-6-input"
+              htmlFor="downshift-10-input"
               id="dropdown-field-label-iot--view-dropdown"
               title={
                 <TableViewDropdownItem
@@ -145,7 +145,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
           >
             <div
               className="bx--list-box__menu-item bx--list-box__menu-item--active bx--list-box__menu-item--highlighted"
-              id="downshift-6-item-0"
+              id="downshift-10-item-0"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -234,7 +234,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-6-item-1"
+              id="downshift-10-item-1"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -281,7 +281,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-6-item-2"
+              id="downshift-10-item-2"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -328,7 +328,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-6-item-3"
+              id="downshift-10-item-3"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -375,7 +375,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-6-item-4"
+              id="downshift-10-item-4"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -423,7 +423,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-6-item-5"
+              id="downshift-10-item-5"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}
@@ -471,7 +471,7 @@ exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT/Table
             </div>
             <div
               className="bx--list-box__menu-item"
-              id="downshift-6-item-6"
+              id="downshift-10-item-6"
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseMove={[Function]}

--- a/src/components/TileCatalogNew/TileCatalogNew.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.jsx
@@ -20,7 +20,7 @@ const propTypes = {
   /** Number of rows to be rendered per page */
   numRows: PropTypes.number,
   /** A collection of tiles to to rendered  */
-  tiles: PropTypes.arrayOf(PropTypes.node).isRequired,
+  tiles: PropTypes.arrayOf(PropTypes.node),
   /** Set to true if a search is needed */
   hasSearch: PropTypes.bool,
   /** Call back function of search */
@@ -66,6 +66,7 @@ const defaultProps = {
     searchPlaceHolderText: 'Enter a value',
     error: 'An error has occurred. Please make sure your catalog has content.',
   },
+  tiles: null,
 };
 
 const TileCatalogNew = ({

--- a/src/components/TileCatalogNew/TileCatalogNew.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.jsx
@@ -66,7 +66,7 @@ const defaultProps = {
     searchPlaceHolderText: 'Enter a value',
     error: 'An error has occurred. Please make sure your catalog has content.',
   },
-  tiles: null,
+  tiles: [],
 };
 
 const TileCatalogNew = ({
@@ -118,9 +118,7 @@ const TileCatalogNew = ({
   // only render pagination if there is no minTileWidth and there are more tiles than can fit in
   // the bounds of our specified number of rows and columns
   const hasPagination =
-    tiles && !minTileWidth && !isLoading
-      ? Math.ceil(tiles.length / (numRows * numColumns)) > 1
-      : null;
+    !minTileWidth && !isLoading ? Math.ceil(tiles.length / (numRows * numColumns)) > 1 : null;
 
   return (
     <div className={className}>
@@ -162,7 +160,7 @@ const TileCatalogNew = ({
               ) : null}
             </div>
           </div>
-          {tiles && tiles.length && !error ? (
+          {tiles.length > 0 && !error ? (
             <div className={`${iotPrefix}--tile-catalog--tile-canvas--content`}>{renderGrid()}</div>
           ) : (
             <Tile className={`${iotPrefix}--tile-catalog--empty-tile`}>
@@ -174,7 +172,7 @@ const TileCatalogNew = ({
           )}
 
           <div className={`${iotPrefix}--tile-catalog--tile-canvas--bottom`}>
-            {tiles && hasPagination ? (
+            {hasPagination ? (
               <TilePagination
                 page={currentPage}
                 numPages={Math.ceil(tiles.length / (numRows * numColumns))}

--- a/src/components/TileCatalogNew/TileCatalogNew.story.jsx
+++ b/src/components/TileCatalogNew/TileCatalogNew.story.jsx
@@ -18,7 +18,13 @@ const getTiles = num => {
   Array(num)
     .fill(0)
     .map((i, idx) => {
-      tiles[idx] = <SampleTile title={`${idx + 1}`} description="This is a sample product tile" />;
+      tiles[idx] = (
+        <SampleTile
+          key={`${idx}-sample-tile`}
+          title={`${idx + 1}`}
+          description="This is a sample product tile"
+        />
+      );
       return tiles[idx];
     });
   return tiles;
@@ -31,10 +37,7 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
       <div style={{ width: '60rem' }}>
         <TileCatalogNew
           title="Product name"
-          tiles={getTiles(
-            numOfTiles,
-            <SampleTile title="Sample product tile" description="This is a sample product tile" />
-          )}
+          tiles={getTiles(numOfTiles)}
           numColumns={number('numColumns', 2)}
           numRows={number('numRows', 2)}
           hasSearch={boolean('hasSearch', true)}
@@ -49,10 +52,7 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
       <div>
         <TileCatalogNew
           title="Product name"
-          tiles={getTiles(
-            numOfTiles,
-            <SampleTile title="Sample product tile" description="This is a sample product tile" />
-          )}
+          tiles={getTiles(numOfTiles)}
           minTileWidth={text('minTileWidth', '15rem')}
           hasSearch={boolean('hasSearch', true)}
           hasSort={boolean('hasSort', true)}
@@ -66,10 +66,7 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
       <div style={{ width: '60rem' }}>
         <TileCatalogNew
           title="Product name"
-          tiles={getTiles(
-            numOfTiles,
-            <SampleTile title="Sample product tile" description="This is a sample product tile" />
-          )}
+          tiles={getTiles(numOfTiles)}
           numColumns={number('numColumns', 2)}
           numRows={number('numRows', 2)}
           hasSearch={boolean('hasSearch', true)}
@@ -99,10 +96,7 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
       <div style={{ width: '60rem' }}>
         <TileCatalogNew
           title="Product name"
-          tiles={getTiles(
-            numOfTiles,
-            <SampleTile title="Sample product tile" description="This is a sample product tile" />
-          )}
+          tiles={getTiles(numOfTiles)}
           numColumns={number('numColumns', 4)}
           numRows={number('numRows', 2)}
           hasSearch={boolean('hasSearch', true)}
@@ -127,10 +121,7 @@ storiesOf('Watson IoT Experimental/TileCatalogNew', module)
     <div style={{ width: '60rem' }}>
       <TileCatalogNew
         title="Product name"
-        tiles={getTiles(
-          8,
-          <SampleTile title="Sample product tile" description="This is a sample product tile" />
-        )}
+        tiles={getTiles(8)}
         numColumns={number('numColumns', 4)}
         numRows={number('numRows', 2)}
         hasSort={boolean('hasSort', true)}

--- a/src/components/TileCatalogNew/TilePagination/TilePagination.jsx
+++ b/src/components/TileCatalogNew/TilePagination/TilePagination.jsx
@@ -28,67 +28,7 @@ const defaultProps = {
 
 const TilePagination = ({ page, numPages, onChange, i18n }) => {
   const [selectedValue, setSelectedValue] = useState();
-  const prevButton = (
-    <button
-      type="button"
-      onClick={() => page > 1 && onChange(page - 1)}
-      className={classnames(
-        `${prefix}--pagination-nav__page`,
-        `${prefix}--pagination-nav__page--direction`,
-        {
-          [`${prefix}--pagination-nav__page--disabled`]: page === 1,
-        }
-      )}
-      aria-disabled="true"
-    >
-      <span className={`${prefix}--pagination-nav__accessibility-label`}>
-        {i18n.ariaLabelPreviousPage}
-      </span>
-      <svg
-        focusable="false"
-        preserveAspectRatio="xMidYMid meet"
-        style={{ willChange: 'transform' }}
-        xmlns="http://www.w3.org/2000/svg"
-        className={`${prefix}--pagination-nav__icon`}
-        width="5"
-        height="8"
-        viewBox="0 0 5 8"
-        aria-hidden="true"
-      >
-        <path d="M5 8L0 4 5 0z" />
-      </svg>
-    </button>
-  );
-  const nextButton = (
-    <button
-      type="button"
-      onClick={() => page < numPages && onChange(page + 1)}
-      className={classnames(
-        `${prefix}--pagination-nav__page`,
-        `${prefix}--pagination-nav__page--direction`,
-        {
-          [`${prefix}--pagination-nav__page--disabled`]: page === numPages,
-        }
-      )}
-    >
-      <span className={`${prefix}--pagination-nav__accessibility-label`}>
-        {i18n.ariaLabelNextPage}
-      </span>
-      <svg
-        focusable="false"
-        preserveAspectRatio="xMidYMid meet"
-        style={{ willChange: 'transform' }}
-        xmlns="http://www.w3.org/2000/svg"
-        className={`${prefix}--pagination-nav__icon`}
-        width="5"
-        height="8"
-        viewBox="0 0 5 8"
-        aria-hidden="true"
-      >
-        <path d="M0 0L5 4 0 8z" />
-      </svg>
-    </button>
-  );
+
   const getPageButton = pageNumber => (
     <button
       type="button"
@@ -104,6 +44,7 @@ const TilePagination = ({ page, numPages, onChange, i18n }) => {
       {pageNumber}
     </button>
   );
+
   const getPageSelect = (pageNumber, accumulator) => (
     <li className={`${prefix}--pagination-nav__list-item`}>
       <div className={`${prefix}--pagination-nav__select`}>
@@ -201,7 +142,37 @@ const TilePagination = ({ page, numPages, onChange, i18n }) => {
   return (
     <nav className={`${prefix}--pagination-nav`} aria-label={i18n.ariaLabelPagination}>
       <ul className={`${prefix}--pagination-nav__list`}>
-        <li className={`${prefix}--pagination-nav__list-item`}>{prevButton}</li>
+        <li className={`${prefix}--pagination-nav__list-item`}>
+          <button
+            type="button"
+            onClick={() => page > 1 && onChange(page - 1)}
+            className={classnames(
+              `${prefix}--pagination-nav__page`,
+              `${prefix}--pagination-nav__page--direction`,
+              {
+                [`${prefix}--pagination-nav__page--disabled`]: page === 1,
+              }
+            )}
+            aria-disabled="true"
+          >
+            <span className={`${prefix}--pagination-nav__accessibility-label`}>
+              {i18n.ariaLabelPreviousPage}
+            </span>
+            <svg
+              focusable="false"
+              preserveAspectRatio="xMidYMid meet"
+              style={{ willChange: 'transform' }}
+              xmlns="http://www.w3.org/2000/svg"
+              className={`${prefix}--pagination-nav__icon`}
+              width="5"
+              height="8"
+              viewBox="0 0 5 8"
+              aria-hidden="true"
+            >
+              <path d="M5 8L0 4 5 0z" />
+            </svg>
+          </button>
+        </li>
         <li className={`${prefix}--pagination-nav__list-item`}>{getPageButton(1)}</li>
 
         {showFrontOverFlowMenu ? getFrontOverFlowMenu() : null}
@@ -213,7 +184,36 @@ const TilePagination = ({ page, numPages, onChange, i18n }) => {
         {numPages > 1 ? (
           <li className={`${prefix}--pagination-nav__list-item`}>{getPageButton(numPages)}</li>
         ) : null}
-        <li className={`${prefix}--pagination-nav__list-item`}>{nextButton}</li>
+        <li className={`${prefix}--pagination-nav__list-item`}>
+          <button
+            type="button"
+            onClick={() => page < numPages && onChange(page + 1)}
+            className={classnames(
+              `${prefix}--pagination-nav__page`,
+              `${prefix}--pagination-nav__page--direction`,
+              {
+                [`${prefix}--pagination-nav__page--disabled`]: page === numPages,
+              }
+            )}
+          >
+            <span className={`${prefix}--pagination-nav__accessibility-label`}>
+              {i18n.ariaLabelNextPage}
+            </span>
+            <svg
+              focusable="false"
+              preserveAspectRatio="xMidYMid meet"
+              style={{ willChange: 'transform' }}
+              xmlns="http://www.w3.org/2000/svg"
+              className={`${prefix}--pagination-nav__icon`}
+              width="5"
+              height="8"
+              viewBox="0 0 5 8"
+              aria-hidden="true"
+            >
+              <path d="M0 0L5 4 0 8z" />
+            </svg>
+          </button>
+        </li>
       </ul>
     </nav>
   );

--- a/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
+++ b/src/components/TileCatalogNew/__snapshots__/TileCatalogNew.story.storyshot
@@ -1,0 +1,2829 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew Base with col / row specified 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "60rem",
+        }
+      }
+    >
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                tabIndex="0"
+              >
+                <div
+                  aria-labelledby="32-search"
+                  className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="32"
+                    id="32-search"
+                  >
+                    Filter table
+                  </label>
+                  <input
+                    aria-hidden={true}
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="32"
+                    onChange={[Function]}
+                    placeholder="Enter a value"
+                    role="searchbox"
+                    tabIndex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--tile-catalog--tile-canvas--header--select"
+                    >
+                      
+                    </label>
+                    <div
+                      className="bx--select-input__wrapper"
+                      data-invalid={null}
+                    >
+                      <select
+                        className="bx--select-input"
+                        defaultValue=""
+                        id="iot--tile-catalog--tile-canvas--header--select"
+                        onChange={[Function]}
+                      />
+                      <svg
+                        aria-hidden={true}
+                        className="bx--select__arrow"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--content"
+            >
+              <div
+                className="iot--tile-catalog--grid-container"
+                style={
+                  Object {
+                    "--columns": "repeat(2, 1fr)",
+                  }
+                }
+              >
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      1
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      2
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      3
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      4
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            >
+              <nav
+                aria-label="pagination"
+                className="bx--pagination-nav"
+              >
+                <ul
+                  className="bx--pagination-nav__list"
+                >
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-disabled="true"
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Previous page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 8L0 4 5 0z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={true}
+                      className="bx--pagination-nav__page bx--pagination-nav__page--active bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      1
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      2
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Next page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0L5 4 0 8z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew Dynamic resize with tile width specification 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                tabIndex="0"
+              >
+                <div
+                  aria-labelledby="33-search"
+                  className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="33"
+                    id="33-search"
+                  >
+                    Filter table
+                  </label>
+                  <input
+                    aria-hidden={true}
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="33"
+                    onChange={[Function]}
+                    placeholder="Enter a value"
+                    role="searchbox"
+                    tabIndex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--tile-catalog--tile-canvas--header--select"
+                    >
+                      
+                    </label>
+                    <div
+                      className="bx--select-input__wrapper"
+                      data-invalid={null}
+                    >
+                      <select
+                        className="bx--select-input"
+                        defaultValue=""
+                        id="iot--tile-catalog--tile-canvas--header--select"
+                        onChange={[Function]}
+                      />
+                      <svg
+                        aria-hidden={true}
+                        className="bx--select__arrow"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--content"
+            >
+              <div
+                className="iot--tile-catalog--grid-container"
+                style={
+                  Object {
+                    "--columns": "repeat(auto-fill, minmax(15rem, 1fr))",
+                  }
+                }
+              >
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      1
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      2
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      3
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      4
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      5
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew Error 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "60rem",
+        }
+      }
+    >
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                tabIndex="0"
+              >
+                <div
+                  aria-labelledby="35-search"
+                  className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="35"
+                    id="35-search"
+                  >
+                    Filter table
+                  </label>
+                  <input
+                    aria-hidden={true}
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="35"
+                    onChange={[Function]}
+                    placeholder="Enter a value"
+                    role="searchbox"
+                    tabIndex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--tile-catalog--tile-canvas--header--select"
+                    >
+                      
+                    </label>
+                    <div
+                      className="bx--select-input__wrapper"
+                      data-invalid={null}
+                    >
+                      <select
+                        className="bx--select-input"
+                        defaultValue=""
+                        id="iot--tile-catalog--tile-canvas--header--select"
+                        onChange={[Function]}
+                      />
+                      <svg
+                        aria-hidden={true}
+                        className="bx--select__arrow"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="bx--tile iot--tile-catalog--empty-tile"
+            >
+              <svg
+                aria-hidden={true}
+                focusable="false"
+                height={32}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={32}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 10a6 6 0 00-6 6v8a6 6 0 0012 0V16A6 6 0 0016 10zm-4.25 7.87h8.5v4.25h-8.5zM16 28.25A4.27 4.27 0 0111.75 24v-.13h8.5V24A4.27 4.27 0 0116 28.25zm4.25-12.13h-8.5V16a4.25 4.25 0 018.5 0zM30.66 19.21L24 13v9.1a4 4 0 008 0A3.83 3.83 0 0030.66 19.21zM28 24.35a2.25 2.25 0 01-2.25-2.25V17l3.72 3.47h0A2.05 2.05 0 0130.2 22 2.25 2.25 0 0128 24.35zM0 22.1a4 4 0 008 0V13L1.34 19.21A3.88 3.88 0 000 22.1zm2.48-1.56h0L6.25 17v5.1a2.25 2.25 0 01-4.5 0A2.05 2.05 0 012.48 20.54zM15 5.5A3.5 3.5 0 1011.5 9 3.5 3.5 0 0015 5.5zm-5.25 0A1.75 1.75 0 1111.5 7.25 1.77 1.77 0 019.75 5.5zM20.5 2A3.5 3.5 0 1024 5.5 3.5 3.5 0 0020.5 2zm0 5.25A1.75 1.75 0 1122.25 5.5 1.77 1.77 0 0120.5 7.25z"
+                />
+              </svg>
+              <p>
+                An error has occurred. Please make sure your catalog has content.
+              </p>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew Loading 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "60rem",
+        }
+      }
+    >
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                tabIndex="0"
+              >
+                <div
+                  aria-labelledby="34-search"
+                  className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="34"
+                    id="34-search"
+                  >
+                    Filter table
+                  </label>
+                  <input
+                    aria-hidden={true}
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="34"
+                    onChange={[Function]}
+                    placeholder="Enter a value"
+                    role="searchbox"
+                    tabIndex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--tile-catalog--tile-canvas--header--select"
+                    >
+                      
+                    </label>
+                    <div
+                      className="bx--select-input__wrapper"
+                      data-invalid={null}
+                    >
+                      <select
+                        className="bx--select-input"
+                        defaultValue=""
+                        id="iot--tile-catalog--tile-canvas--header--select"
+                        onChange={[Function]}
+                      />
+                      <svg
+                        aria-hidden={true}
+                        className="bx--select__arrow"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--content"
+            >
+              <div
+                className="iot--tile-catalog--grid-container"
+                style={
+                  Object {
+                    "--columns": "repeat(2, 1fr)",
+                  }
+                }
+              >
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+                <p
+                  className="bx--skeleton__text"
+                  style={
+                    Object {
+                      "width": "100%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew StatefulTileCatalog 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "60rem",
+        }
+      }
+    >
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                tabIndex="0"
+              >
+                <div
+                  aria-labelledby="38-search"
+                  className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="38"
+                    id="38-search"
+                  >
+                    Filter table
+                  </label>
+                  <input
+                    aria-hidden={true}
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="38"
+                    onChange={[Function]}
+                    placeholder="Enter a value"
+                    role="searchbox"
+                    tabIndex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--tile-catalog--tile-canvas--header--select"
+                    >
+                      
+                    </label>
+                    <div
+                      className="bx--select-input__wrapper"
+                      data-invalid={null}
+                    >
+                      <select
+                        className="bx--select-input"
+                        defaultValue="Choose from options"
+                        id="iot--tile-catalog--tile-canvas--header--select"
+                        onChange={[Function]}
+                      >
+                        <option
+                          className="bx--select-option"
+                          disabled={false}
+                          hidden={false}
+                          value="Choose from options"
+                        >
+                          Choose from options
+                        </option>
+                        <option
+                          className="bx--select-option"
+                          disabled={false}
+                          hidden={false}
+                          value="A-Z"
+                        >
+                          A-Z
+                        </option>
+                        <option
+                          className="bx--select-option"
+                          disabled={false}
+                          hidden={false}
+                          value="Z-A"
+                        >
+                          Z-A
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="bx--select__arrow"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--content"
+            >
+              <div
+                className="iot--tile-catalog--grid-container"
+                style={
+                  Object {
+                    "--columns": "repeat(4, 1fr)",
+                  }
+                }
+              >
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      1
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      2
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      3
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      4
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      5
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      6
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      7
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      8
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            >
+              <nav
+                aria-label="pagination"
+                className="bx--pagination-nav"
+              >
+                <ul
+                  className="bx--pagination-nav__list"
+                >
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-disabled="true"
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Previous page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 8L0 4 5 0z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={true}
+                      className="bx--pagination-nav__page bx--pagination-nav__page--active bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      1
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      2
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      3
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Next page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0L5 4 0 8z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew With OverflowMenu in Pagination 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "60rem",
+        }
+      }
+    >
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                tabIndex="0"
+              >
+                <div
+                  aria-labelledby="36-search"
+                  className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="36"
+                    id="36-search"
+                  >
+                    Filter table
+                  </label>
+                  <input
+                    aria-hidden={true}
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="36"
+                    onChange={[Function]}
+                    placeholder="Enter a value"
+                    role="searchbox"
+                    tabIndex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--tile-catalog--tile-canvas--header--select"
+                    >
+                      
+                    </label>
+                    <div
+                      className="bx--select-input__wrapper"
+                      data-invalid={null}
+                    >
+                      <select
+                        className="bx--select-input"
+                        defaultValue=""
+                        id="iot--tile-catalog--tile-canvas--header--select"
+                        onChange={[Function]}
+                      />
+                      <svg
+                        aria-hidden={true}
+                        className="bx--select__arrow"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--content"
+            >
+              <div
+                className="iot--tile-catalog--grid-container"
+                style={
+                  Object {
+                    "--columns": "repeat(4, 1fr)",
+                  }
+                }
+              >
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      1
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      2
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      3
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      4
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      5
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      6
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      7
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      8
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            >
+              <nav
+                aria-label="pagination"
+                className="bx--pagination-nav"
+              >
+                <ul
+                  className="bx--pagination-nav__list"
+                >
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-disabled="true"
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Previous page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 8L0 4 5 0z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={true}
+                      className="bx--pagination-nav__page bx--pagination-nav__page--active bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      1
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      2
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      3
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      4
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      5
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <div
+                      className="bx--pagination-nav__select"
+                    >
+                      <select
+                        aria-label="select page number"
+                        className="bx--pagination-nav__page bx--pagination-nav__page--select"
+                        data-page-select={true}
+                        onChange={[Function]}
+                      >
+                        <option
+                          data-page=""
+                          hidden={true}
+                          value="default"
+                        />
+                        <option
+                          data-page={6}
+                          value={6}
+                        >
+                          6
+                        </option>
+                        <option
+                          data-page={7}
+                          value={7}
+                        >
+                          7
+                        </option>
+                        <option
+                          data-page={8}
+                          value={8}
+                        >
+                          8
+                        </option>
+                        <option
+                          data-page={9}
+                          value={9}
+                        >
+                          9
+                        </option>
+                        <option
+                          data-page={10}
+                          value={10}
+                        >
+                          10
+                        </option>
+                        <option
+                          data-page={11}
+                          value={11}
+                        >
+                          11
+                        </option>
+                        <option
+                          data-page={12}
+                          value={12}
+                        >
+                          12
+                        </option>
+                      </select>
+                      <div
+                        className="bx--pagination-nav__select-icon-wrapper"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="bx--pagination-nav__select-icon"
+                          focusable="false"
+                          height="16"
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 32 32"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle
+                            cx="8"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="16"
+                            cy="16"
+                            r="2"
+                          />
+                          <circle
+                            cx="24"
+                            cy="16"
+                            r="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      13
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Next page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0L5 4 0 8z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew With Search 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "60rem",
+        }
+      }
+    >
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="bx--toolbar-action bx--toolbar-search-container-expandable"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                tabIndex="0"
+              >
+                <div
+                  aria-labelledby="37-search"
+                  className="bx--search bx--search--sm iot--tile-catalog--tile-canvas--header--search"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="37"
+                    id="37-search"
+                  >
+                    Filter table
+                  </label>
+                  <input
+                    aria-hidden={true}
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="37"
+                    onChange={[Function]}
+                    placeholder="Enter a value"
+                    role="searchbox"
+                    tabIndex="-1"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              />
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--content"
+            >
+              <div
+                className="iot--tile-catalog--grid-container"
+                style={
+                  Object {
+                    "--columns": "repeat(4, 1fr)",
+                  }
+                }
+              >
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      1
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      2
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      3
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      4
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      5
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      6
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      7
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      8
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            >
+              <nav
+                aria-label="pagination"
+                className="bx--pagination-nav"
+              >
+                <ul
+                  className="bx--pagination-nav__list"
+                >
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-disabled="true"
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Previous page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5 8L0 4 5 0z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={true}
+                      className="bx--pagination-nav__page bx--pagination-nav__page--active bx--pagination-nav__page--disabled"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      1
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      2
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      aria-current="page"
+                      aria-disabled={false}
+                      className="bx--pagination-nav__page"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        page
+                      </span>
+                      3
+                    </button>
+                  </li>
+                  <li
+                    className="bx--pagination-nav__list-item"
+                  >
+                    <button
+                      className="bx--pagination-nav__page bx--pagination-nav__page--direction"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="bx--pagination-nav__accessibility-label"
+                      >
+                        Next page
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        className="bx--pagination-nav__icon"
+                        focusable="false"
+                        height="8"
+                        preserveAspectRatio="xMidYMid meet"
+                        style={
+                          Object {
+                            "willChange": "transform",
+                          }
+                        }
+                        viewBox="0 0 5 8"
+                        width="5"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0L5 4 0 8z"
+                        />
+                      </svg>
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileCatalogNew With Sort 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "60rem",
+        }
+      }
+    >
+      <div>
+        <div
+          className="iot--tile-catalog--canvas-container"
+        >
+          <div
+            className="iot--tile-catalog--tile-canvas"
+          >
+            <div
+              className="iot--tile-catalog--tile-canvas--header"
+            >
+              <div
+                className="iot--tile-catalog--tile-canvas--header--title"
+              >
+                Product name
+              </div>
+              <div
+                className="iot--tile-catalog--tile-canvas--header--select"
+              >
+                <div
+                  className="bx--form-item"
+                >
+                  <div
+                    className="bx--select"
+                  >
+                    <label
+                      className="bx--label"
+                      htmlFor="iot--tile-catalog--tile-canvas--header--select"
+                    >
+                      
+                    </label>
+                    <div
+                      className="bx--select-input__wrapper"
+                      data-invalid={null}
+                    >
+                      <select
+                        className="bx--select-input"
+                        defaultValue="Choose from options"
+                        id="iot--tile-catalog--tile-canvas--header--select"
+                        onChange={[Function]}
+                      >
+                        <option
+                          className="bx--select-option"
+                          disabled={false}
+                          hidden={false}
+                          value="Choose from options"
+                        >
+                          Choose from options
+                        </option>
+                        <option
+                          className="bx--select-option"
+                          disabled={false}
+                          hidden={false}
+                          value="A-Z"
+                        >
+                          A-Z
+                        </option>
+                        <option
+                          className="bx--select-option"
+                          disabled={false}
+                          hidden={false}
+                          value="Most Popular"
+                        >
+                          Most Popular
+                        </option>
+                      </select>
+                      <svg
+                        aria-hidden={true}
+                        className="bx--select__arrow"
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--content"
+            >
+              <div
+                className="iot--tile-catalog--grid-container"
+                style={
+                  Object {
+                    "--columns": "repeat(4, 1fr)",
+                  }
+                }
+              >
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      1
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      2
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      3
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      4
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      5
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      6
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      7
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div
+                    className="sample-tile"
+                  >
+                    <div
+                      className="sample-tile--title"
+                    >
+                      8
+                    </div>
+                    <div
+                      className="sample-tile--content"
+                    >
+                      This is a sample product tile
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="iot--tile-catalog--tile-canvas--bottom"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/TileGallery/TileGallery.jsx
+++ b/src/components/TileGallery/TileGallery.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import TileGallerySection from './TileGallerySection';
-
 const propTypes = {
   /** Component children's to be rendered */
-  children: PropTypes.arrayOf(PropTypes.shape({ type: PropTypes.oneOf([TileGallerySection]) }))
-    .isRequired,
+  children: PropTypes.node.isRequired,
 };
 
 const defaultProps = {};

--- a/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
+++ b/src/components/TileGallery/__snapshots__/TileGallery.story.storyshot
@@ -1,0 +1,3214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileGallery Stateful TileGallery 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-header"
+        >
+          <div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  Dashboard
+                </h2>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          />
+          <div>
+            <div
+              className="extra-content"
+            >
+              <div>
+                <div
+                  aria-labelledby="gallery-search-search"
+                  className="bx--search bx--search--xl"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="gallery-search"
+                    id="gallery-search-search"
+                  >
+                    Search
+                  </label>
+                  <input
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="gallery-search"
+                    onChange={[Function]}
+                    placeholder="Search for something"
+                    role="searchbox"
+                    style={
+                      Object {
+                        "background": "#ffffff",
+                        "width": "305px",
+                      }
+                    }
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="bx--content-switcher"
+                onChange={[Function]}
+                role="tablist"
+              >
+                <button
+                  aria-selected={false}
+                  className="bx--content-switcher-btn"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="tab"
+                  tabIndex="-1"
+                >
+                  <span
+                    className="bx--content-switcher__label"
+                  >
+                    List
+                  </span>
+                </button>
+                <button
+                  aria-selected={true}
+                  className="bx--content-switcher-btn bx--content-switcher--selected"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="tab"
+                  tabIndex="0"
+                >
+                  <span
+                    className="bx--content-switcher__label"
+                  >
+                    Grid
+                  </span>
+                </button>
+              </div>
+              <button
+                className="iot--btn bx--btn bx--btn--primary"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                Create +
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="page-title-bar-content"
+        >
+          <div
+            className="tile-gallery"
+          >
+            <div
+              className="tile-gallery--section"
+            >
+              <ul
+                className="bx--accordion bx--accordion--end"
+              >
+                <li
+                  className="bx--accordion__item bx--accordion__item--active"
+                  onAnimationEnd={[Function]}
+                >
+                  <button
+                    aria-controls="accordion-item-3"
+                    aria-expanded={true}
+                    className="bx--accordion__heading"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    title="Favorites"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--accordion__arrow"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                      />
+                    </svg>
+                    <div
+                      className="bx--accordion__title"
+                    >
+                      Favorites
+                    </div>
+                  </button>
+                  <div
+                    className="bx--accordion__content"
+                    id="accordion-item-3"
+                  >
+                    <div
+                      className="tile-gallery--section--items"
+                    >
+                      <a
+                        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div>
+                          <div
+                            className="top-section"
+                          >
+                            <div
+                              className="thumbnail"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                focusable="false"
+                                height={32}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={32}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12,29a1,1,0,0,1-.92-.62L6.33,17H2V15H7a1,1,0,0,1,.92.62L12,25.28,20.06,3.65A1,1,0,0,1,21,3a1,1,0,0,1,.93.68L25.72,15H30v2H25a1,1,0,0,1-.95-.68L21,7,12.94,28.35A1,1,0,0,1,12,29Z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              className="description-card"
+                            >
+                              <span>
+                                More about your dashboard
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="content-container"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+                              />
+                            </svg>
+                            <span
+                              className="title-card"
+                            >
+                              Dashboard title
+                            </span>
+                            <div
+                              className="overflow-menu"
+                              onClick={[Function]}
+                              role="presentation"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                style={
+                                  Object {
+                                    "height": "2rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <svg
+                                  aria-label="open and close list of options"
+                                  className="bx--overflow-menu__icon"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    open and close list of options
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                      <a
+                        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div>
+                          <div
+                            className="top-section"
+                          >
+                            <div
+                              className="thumbnail"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                focusable="false"
+                                height={32}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={32}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
+                                  transform="translate(0 .005)"
+                                />
+                                <path
+                                  d="M6.854 5.375H8.854V10.333H6.854z"
+                                  transform="rotate(-45 7.86 7.856)"
+                                />
+                                <path
+                                  d="M2 15.005H7V17.005000000000003H2z"
+                                />
+                                <path
+                                  d="M5.375 23.147H10.333V25.147H5.375z"
+                                  transform="rotate(-45 7.86 24.149)"
+                                />
+                                <path
+                                  d="M15 25.005H17V30.005H15z"
+                                />
+                                <path
+                                  d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                  transform="rotate(-45 24.152 24.149)"
+                                />
+                                <path
+                                  d="M25 15.005H30V17.005000000000003H25z"
+                                />
+                                <path
+                                  d="M21.668 6.854H26.625999999999998V8.854H21.668z"
+                                  transform="rotate(-45 24.152 7.856)"
+                                />
+                                <path
+                                  d="M15 2.005H17V7.005H15z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              className="description-card"
+                            >
+                              <span>
+                                More about your dashboard
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="content-container"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+                              />
+                            </svg>
+                            <span
+                              className="title-card"
+                            >
+                              Health
+                            </span>
+                            <div
+                              className="overflow-menu"
+                              onClick={[Function]}
+                              role="presentation"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                style={
+                                  Object {
+                                    "height": "2rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <svg
+                                  aria-label="open and close list of options"
+                                  className="bx--overflow-menu__icon"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    open and close list of options
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                      <a
+                        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div>
+                          <div
+                            className="top-section"
+                          >
+                            <div
+                              className="thumbnail"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                focusable="false"
+                                height={32}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={32}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12,29a1,1,0,0,1-.92-.62L6.33,17H2V15H7a1,1,0,0,1,.92.62L12,25.28,20.06,3.65A1,1,0,0,1,21,3a1,1,0,0,1,.93.68L25.72,15H30v2H25a1,1,0,0,1-.95-.68L21,7,12.94,28.35A1,1,0,0,1,12,29Z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              className="description-card"
+                            >
+                              <span>
+                                More about your dashboard
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="content-container"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+                              />
+                            </svg>
+                            <span
+                              className="title-card"
+                            >
+                              Activity
+                            </span>
+                            <div
+                              className="overflow-menu"
+                              onClick={[Function]}
+                              role="presentation"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                style={
+                                  Object {
+                                    "height": "2rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <svg
+                                  aria-label="open and close list of options"
+                                  className="bx--overflow-menu__icon"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    open and close list of options
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div
+              className="tile-gallery--section"
+            >
+              <ul
+                className="bx--accordion bx--accordion--end"
+              >
+                <li
+                  className="bx--accordion__item bx--accordion__item--active"
+                  onAnimationEnd={[Function]}
+                >
+                  <button
+                    aria-controls="accordion-item-4"
+                    aria-expanded={true}
+                    className="bx--accordion__heading"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    title="Dashboard Category A"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--accordion__arrow"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                      />
+                    </svg>
+                    <div
+                      className="bx--accordion__title"
+                    >
+                      Dashboard Category A
+                    </div>
+                  </button>
+                  <div
+                    className="bx--accordion__content"
+                    id="accordion-item-4"
+                  >
+                    <div
+                      className="tile-gallery--section--items"
+                    >
+                      <a
+                        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div>
+                          <div
+                            className="top-section"
+                          >
+                            <div
+                              className="thumbnail"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                focusable="false"
+                                height={32}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={32}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12,29a1,1,0,0,1-.92-.62L6.33,17H2V15H7a1,1,0,0,1,.92.62L12,25.28,20.06,3.65A1,1,0,0,1,21,3a1,1,0,0,1,.93.68L25.72,15H30v2H25a1,1,0,0,1-.95-.68L21,7,12.94,28.35A1,1,0,0,1,12,29Z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              className="description-card"
+                            >
+                              <span>
+                                More about your dashboard
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="content-container"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+                              />
+                            </svg>
+                            <span
+                              className="title-card"
+                            >
+                              Dashboard title
+                            </span>
+                            <div
+                              className="overflow-menu"
+                              onClick={[Function]}
+                              role="presentation"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                style={
+                                  Object {
+                                    "height": "2rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <svg
+                                  aria-label="open and close list of options"
+                                  className="bx--overflow-menu__icon"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    open and close list of options
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                      <a
+                        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div>
+                          <div
+                            className="top-section"
+                          >
+                            <div
+                              className="thumbnail"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                focusable="false"
+                                height={32}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={32}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
+                                  transform="translate(0 .005)"
+                                />
+                                <path
+                                  d="M6.854 5.375H8.854V10.333H6.854z"
+                                  transform="rotate(-45 7.86 7.856)"
+                                />
+                                <path
+                                  d="M2 15.005H7V17.005000000000003H2z"
+                                />
+                                <path
+                                  d="M5.375 23.147H10.333V25.147H5.375z"
+                                  transform="rotate(-45 7.86 24.149)"
+                                />
+                                <path
+                                  d="M15 25.005H17V30.005H15z"
+                                />
+                                <path
+                                  d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                  transform="rotate(-45 24.152 24.149)"
+                                />
+                                <path
+                                  d="M25 15.005H30V17.005000000000003H25z"
+                                />
+                                <path
+                                  d="M21.668 6.854H26.625999999999998V8.854H21.668z"
+                                  transform="rotate(-45 24.152 7.856)"
+                                />
+                                <path
+                                  d="M15 2.005H17V7.005H15z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              className="description-card"
+                            >
+                              <span>
+                                More about your dashboard
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="content-container"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+                              />
+                            </svg>
+                            <span
+                              className="title-card"
+                            >
+                              Dashboard title
+                            </span>
+                            <div
+                              className="overflow-menu"
+                              onClick={[Function]}
+                              role="presentation"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                style={
+                                  Object {
+                                    "height": "2rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <svg
+                                  aria-label="open and close list of options"
+                                  className="bx--overflow-menu__icon"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    open and close list of options
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                      <a
+                        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div>
+                          <div
+                            className="top-section"
+                          >
+                            <div
+                              className="thumbnail"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                focusable="false"
+                                height={32}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={32}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12,29a1,1,0,0,1-.92-.62L6.33,17H2V15H7a1,1,0,0,1,.92.62L12,25.28,20.06,3.65A1,1,0,0,1,21,3a1,1,0,0,1,.93.68L25.72,15H30v2H25a1,1,0,0,1-.95-.68L21,7,12.94,28.35A1,1,0,0,1,12,29Z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              className="description-card"
+                            >
+                              <span>
+                                More about your dashboard
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="content-container"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+                              />
+                            </svg>
+                            <span
+                              className="title-card"
+                            >
+                              Dashboard title
+                            </span>
+                            <div
+                              className="overflow-menu"
+                              onClick={[Function]}
+                              role="presentation"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                style={
+                                  Object {
+                                    "height": "2rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <svg
+                                  aria-label="open and close list of options"
+                                  className="bx--overflow-menu__icon"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    open and close list of options
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileGallery TileGalleryItem - Grid 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <a
+        className="bx--tile bx--tile--clickable not-active tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+      >
+        <div>
+          <div
+            className="top-section"
+          >
+            <div
+              className="thumbnail"
+            >
+              <svg
+                aria-hidden={true}
+                description="Icon"
+                fill="black"
+                focusable="false"
+                height={50}
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 32 32"
+                width={50}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.34 19H17.65V21H6.34z"
+                  transform="rotate(-45 11.995 20.002)"
+                />
+                <path
+                  d="M17,30a1,1,0,0,1-.37-.07,1,1,0,0,1-.62-.79l-1-7,2-.28.75,5.27L21,24.52V17a1,1,0,0,1,.29-.71l4.07-4.07A8.94,8.94,0,0,0,28,5.86V4H26.14a8.94,8.94,0,0,0-6.36,2.64l-4.07,4.07A1,1,0,0,1,15,11H7.48L4.87,14.26l5.27.75-.28,2-7-1a1,1,0,0,1-.79-.62,1,1,0,0,1,.15-1l4-5A1,1,0,0,1,7,9h7.59l3.77-3.78A10.92,10.92,0,0,1,26.14,2H28a2,2,0,0,1,2,2V5.86a10.92,10.92,0,0,1-3.22,7.78L23,17.41V25a1,1,0,0,1-.38.78l-5,4A1,1,0,0,1,17,30Z"
+                />
+              </svg>
+            </div>
+            <div
+              className="description-card"
+            >
+              <span>
+                card description
+              </span>
+            </div>
+          </div>
+          <div
+            className="content-container"
+          >
+            <svg
+              aria-hidden={true}
+              fill="#42be65"
+              focusable="false"
+              height={16}
+              onClick={[Function]}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+              />
+              <path
+                d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                data-icon-path="inner-path"
+                opacity="0"
+              />
+            </svg>
+            <span
+              className="title-card"
+            >
+              Card title
+            </span>
+            <div
+              className="overflow-menu"
+              onClick={[Function]}
+              role="presentation"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="Menu"
+                className="bx--overflow-menu"
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                style={
+                  Object {
+                    "height": "2rem",
+                  }
+                }
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="open and close list of options"
+                  className="bx--overflow-menu__icon"
+                  focusable="false"
+                  height={16}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="16"
+                    cy="8"
+                    r="2"
+                  />
+                  <circle
+                    cx="16"
+                    cy="16"
+                    r="2"
+                  />
+                  <circle
+                    cx="16"
+                    cy="24"
+                    r="2"
+                  />
+                  <title>
+                    open and close list of options
+                  </title>
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileGallery TileGalleryItem - List 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <a
+        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-list-title"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+      >
+        <div>
+          <div
+            className="content-container"
+          >
+            <svg
+              aria-hidden={true}
+              fill="black"
+              focusable="false"
+              height={16}
+              onClick={[Function]}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+              />
+            </svg>
+            <span
+              className="title-card"
+            >
+              Test
+            </span>
+            <div
+              className="overflow-menu"
+              onClick={[Function]}
+              role="presentation"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="Menu"
+                className="bx--overflow-menu"
+                onClick={[Function]}
+                onClose={[Function]}
+                onKeyDown={[Function]}
+                open={false}
+                style={
+                  Object {
+                    "height": "2rem",
+                  }
+                }
+                tabIndex={0}
+              >
+                <svg
+                  aria-label="open and close list of options"
+                  className="bx--overflow-menu__icon"
+                  focusable="false"
+                  height={16}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  preserveAspectRatio="xMidYMid meet"
+                  role="img"
+                  viewBox="0 0 32 32"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <circle
+                    cx="16"
+                    cy="8"
+                    r="2"
+                  />
+                  <circle
+                    cx="16"
+                    cy="16"
+                    r="2"
+                  />
+                  <circle
+                    cx="16"
+                    cy="24"
+                    r="2"
+                  />
+                  <title>
+                    open and close list of options
+                  </title>
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="description-card"
+          >
+            <div
+              style={
+                Object {
+                  "backgroundColor": "black",
+                }
+              }
+            >
+              The first one
+            </div>
+          </div>
+        </div>
+      </a>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileGallery TileGallerySection with TileGalleryItem - i18n 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="page-title-bar"
+      >
+        <div
+          className="page-title-bar-header"
+        >
+          <div>
+            <div
+              className="page-title-bar-title"
+            >
+              <div
+                className="page-title-bar-title--text"
+              >
+                <h2>
+                  __Dashboard__
+                </h2>
+              </div>
+            </div>
+          </div>
+          <div
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          />
+          <div>
+            <div
+              className="extra-content"
+            >
+              <div>
+                <div
+                  aria-labelledby="gallery-search-search"
+                  className="bx--search bx--search--xl"
+                  role="search"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--search-magnifier"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M15,14.3L10.7,10c1.9-2.3,1.6-5.8-0.7-7.7S4.2,0.7,2.3,3S0.7,8.8,3,10.7c2,1.7,5,1.7,7,0l4.3,4.3L15,14.3z M2,6.5	C2,4,4,2,6.5,2S11,4,11,6.5S9,11,6.5,11S2,9,2,6.5z"
+                    />
+                  </svg>
+                  <label
+                    className="bx--label"
+                    htmlFor="gallery-search"
+                    id="gallery-search-search"
+                  >
+                    __Search Icon Description__
+                  </label>
+                  <input
+                    autoComplete="off"
+                    className="bx--search-input"
+                    id="gallery-search"
+                    onChange={[Function]}
+                    placeholder="__Search Placeholder__"
+                    role="searchbox"
+                    style={
+                      Object {
+                        "background": "#ffffff",
+                        "width": "305px",
+                      }
+                    }
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    aria-label="Clear search input"
+                    className="bx--search-close bx--search-close--hidden"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      focusable="false"
+                      height={20}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 32 32"
+                      width={20}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M24 9.4L22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                className="bx--content-switcher"
+                onChange={[Function]}
+                role="tablist"
+              >
+                <button
+                  aria-selected={false}
+                  className="bx--content-switcher-btn"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="tab"
+                  tabIndex="-1"
+                >
+                  <span
+                    className="bx--content-switcher__label"
+                  >
+                    __ListText__
+                  </span>
+                </button>
+                <button
+                  aria-selected={true}
+                  className="bx--content-switcher-btn bx--content-switcher--selected"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="tab"
+                  tabIndex="0"
+                >
+                  <span
+                    className="bx--content-switcher__label"
+                  >
+                    __GridText__
+                  </span>
+                </button>
+              </div>
+              <button
+                className="iot--btn bx--btn bx--btn--primary"
+                disabled={false}
+                tabIndex={0}
+                type="button"
+              >
+                __Create__
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          className="page-title-bar-content"
+        >
+          <div
+            className="tile-gallery"
+          >
+            <div
+              className="tile-gallery--section"
+            >
+              <ul
+                className="bx--accordion bx--accordion--end"
+              >
+                <li
+                  className="bx--accordion__item bx--accordion__item--active"
+                  onAnimationEnd={[Function]}
+                >
+                  <button
+                    aria-controls="accordion-item-9"
+                    aria-expanded={true}
+                    className="bx--accordion__heading"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    title="__Favorites__"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="bx--accordion__arrow"
+                      focusable="false"
+                      height={16}
+                      preserveAspectRatio="xMidYMid meet"
+                      viewBox="0 0 16 16"
+                      width={16}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                      />
+                    </svg>
+                    <div
+                      className="bx--accordion__title"
+                    >
+                      __Favorites__
+                    </div>
+                  </button>
+                  <div
+                    className="bx--accordion__content"
+                    id="accordion-item-9"
+                  >
+                    <div
+                      className="tile-gallery--section--items"
+                    >
+                      <a
+                        className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                      >
+                        <div>
+                          <div
+                            className="top-section"
+                          >
+                            <div
+                              className="thumbnail"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                focusable="false"
+                                height={32}
+                                preserveAspectRatio="xMidYMid meet"
+                                viewBox="0 0 32 32"
+                                width={32}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12,29a1,1,0,0,1-.92-.62L6.33,17H2V15H7a1,1,0,0,1,.92.62L12,25.28,20.06,3.65A1,1,0,0,1,21,3a1,1,0,0,1,.93.68L25.72,15H30v2H25a1,1,0,0,1-.95-.68L21,7,12.94,28.35A1,1,0,0,1,12,29Z"
+                                />
+                              </svg>
+                            </div>
+                            <div
+                              className="description-card"
+                            >
+                              <span>
+                                __More about your dashboard__
+                              </span>
+                            </div>
+                          </div>
+                          <div
+                            className="content-container"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              focusable="false"
+                              height={16}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M8,1L5.7,5.6L0.6,6.3l3.7,3.6L3.5,15L8,12.6l4.6,2.4l-0.9-5.1l3.7-3.6l-5.1-0.7L8,1z"
+                              />
+                            </svg>
+                            <span
+                              className="title-card"
+                            >
+                              __Dashboard title__
+                            </span>
+                            <div
+                              className="overflow-menu"
+                              onClick={[Function]}
+                              role="presentation"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                aria-label="Menu"
+                                className="bx--overflow-menu"
+                                onClick={[Function]}
+                                onClose={[Function]}
+                                onKeyDown={[Function]}
+                                open={false}
+                                style={
+                                  Object {
+                                    "height": "2rem",
+                                  }
+                                }
+                                tabIndex={0}
+                              >
+                                <svg
+                                  aria-label="__icon description__"
+                                  className="bx--overflow-menu__icon"
+                                  focusable="false"
+                                  height={16}
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  preserveAspectRatio="xMidYMid meet"
+                                  role="img"
+                                  viewBox="0 0 32 32"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <circle
+                                    cx="16"
+                                    cy="8"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="16"
+                                    r="2"
+                                  />
+                                  <circle
+                                    cx="16"
+                                    cy="24"
+                                    r="2"
+                                  />
+                                  <title>
+                                    __icon description__
+                                  </title>
+                                </svg>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileGallery TileGallerySection with TileGalleryItem Grid 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": "calc(100vw - 6rem)",
+          }
+        }
+      >
+        <div
+          className="tile-gallery--section"
+        >
+          <ul
+            className="bx--accordion bx--accordion--end"
+          >
+            <li
+              className="bx--accordion__item bx--accordion__item--active"
+              onAnimationEnd={[Function]}
+            >
+              <button
+                aria-controls="accordion-item-7"
+                aria-expanded={true}
+                className="bx--accordion__heading"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                title="Title"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="bx--accordion__arrow"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                  />
+                </svg>
+                <div
+                  className="bx--accordion__title"
+                >
+                  Title
+                </div>
+              </button>
+              <div
+                className="bx--accordion__content"
+                id="accordion-item-7"
+              >
+                <div
+                  className="tile-gallery--section--items"
+                >
+                  <a
+                    className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                  >
+                    <div>
+                      <div
+                        className="top-section"
+                      >
+                        <div
+                          className="thumbnail"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            description="Icon"
+                            fill="black"
+                            focusable="false"
+                            height={50}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 32 32"
+                            width={50}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M6.34 19H17.65V21H6.34z"
+                              transform="rotate(-45 11.995 20.002)"
+                            />
+                            <path
+                              d="M17,30a1,1,0,0,1-.37-.07,1,1,0,0,1-.62-.79l-1-7,2-.28.75,5.27L21,24.52V17a1,1,0,0,1,.29-.71l4.07-4.07A8.94,8.94,0,0,0,28,5.86V4H26.14a8.94,8.94,0,0,0-6.36,2.64l-4.07,4.07A1,1,0,0,1,15,11H7.48L4.87,14.26l5.27.75-.28,2-7-1a1,1,0,0,1-.79-.62,1,1,0,0,1,.15-1l4-5A1,1,0,0,1,7,9h7.59l3.77-3.78A10.92,10.92,0,0,1,26.14,2H28a2,2,0,0,1,2,2V5.86a10.92,10.92,0,0,1-3.22,7.78L23,17.41V25a1,1,0,0,1-.38.78l-5,4A1,1,0,0,1,17,30Z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          className="description-card"
+                        >
+                          <span>
+                            card description
+                          </span>
+                        </div>
+                      </div>
+                      <div
+                        className="content-container"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#42be65"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span
+                          className="title-card"
+                        >
+                          Card title
+                        </span>
+                        <div
+                          className="overflow-menu"
+                          onClick={[Function]}
+                          role="presentation"
+                        >
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            style={
+                              Object {
+                                "height": "2rem",
+                              }
+                            }
+                            tabIndex={0}
+                          >
+                            <svg
+                              aria-label="open and close list of options"
+                              className="bx--overflow-menu__icon"
+                              focusable="false"
+                              height={16}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                              <title>
+                                open and close list of options
+                              </title>
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                  <a
+                    className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                  >
+                    <div>
+                      <div
+                        className="top-section"
+                      >
+                        <div
+                          className="thumbnail"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            description="Icon"
+                            fill="black"
+                            focusable="false"
+                            height={50}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 32 32"
+                            width={50}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12,29a1,1,0,0,1-.92-.62L6.33,17H2V15H7a1,1,0,0,1,.92.62L12,25.28,20.06,3.65A1,1,0,0,1,21,3a1,1,0,0,1,.93.68L25.72,15H30v2H25a1,1,0,0,1-.95-.68L21,7,12.94,28.35A1,1,0,0,1,12,29Z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          className="description-card"
+                        >
+                          <span>
+                            card description
+                          </span>
+                        </div>
+                      </div>
+                      <div
+                        className="content-container"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#42be65"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span
+                          className="title-card"
+                        >
+                          Card title
+                        </span>
+                        <div
+                          className="overflow-menu"
+                          onClick={[Function]}
+                          role="presentation"
+                        >
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            style={
+                              Object {
+                                "height": "2rem",
+                              }
+                            }
+                            tabIndex={0}
+                          >
+                            <svg
+                              aria-label="open and close list of options"
+                              className="bx--overflow-menu__icon"
+                              focusable="false"
+                              height={16}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                              <title>
+                                open and close list of options
+                              </title>
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                  <a
+                    className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                  >
+                    <div>
+                      <div
+                        className="top-section"
+                      >
+                        <div
+                          className="thumbnail"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            description="Icon"
+                            fill="black"
+                            focusable="false"
+                            height={50}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 32 32"
+                            width={50}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
+                              transform="translate(0 .005)"
+                            />
+                            <path
+                              d="M6.854 5.375H8.854V10.333H6.854z"
+                              transform="rotate(-45 7.86 7.856)"
+                            />
+                            <path
+                              d="M2 15.005H7V17.005000000000003H2z"
+                            />
+                            <path
+                              d="M5.375 23.147H10.333V25.147H5.375z"
+                              transform="rotate(-45 7.86 24.149)"
+                            />
+                            <path
+                              d="M15 25.005H17V30.005H15z"
+                            />
+                            <path
+                              d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                              transform="rotate(-45 24.152 24.149)"
+                            />
+                            <path
+                              d="M25 15.005H30V17.005000000000003H25z"
+                            />
+                            <path
+                              d="M21.668 6.854H26.625999999999998V8.854H21.668z"
+                              transform="rotate(-45 24.152 7.856)"
+                            />
+                            <path
+                              d="M15 2.005H17V7.005H15z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          className="description-card"
+                        >
+                          <span>
+                            card description
+                          </span>
+                        </div>
+                      </div>
+                      <div
+                        className="content-container"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#42be65"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span
+                          className="title-card"
+                        >
+                          Card title
+                        </span>
+                        <div
+                          className="overflow-menu"
+                          onClick={[Function]}
+                          role="presentation"
+                        >
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            style={
+                              Object {
+                                "height": "2rem",
+                              }
+                            }
+                            tabIndex={0}
+                          >
+                            <svg
+                              aria-label="open and close list of options"
+                              className="bx--overflow-menu__icon"
+                              focusable="false"
+                              height={16}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                              <title>
+                                open and close list of options
+                              </title>
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div
+          className="tile-gallery--section"
+        >
+          <ul
+            className="bx--accordion bx--accordion--end"
+          >
+            <li
+              className="bx--accordion__item bx--accordion__item--active"
+              onAnimationEnd={[Function]}
+            >
+              <button
+                aria-controls="accordion-item-8"
+                aria-expanded={true}
+                className="bx--accordion__heading"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                title="More"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="bx--accordion__arrow"
+                  focusable="false"
+                  height={16}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                  />
+                </svg>
+                <div
+                  className="bx--accordion__title"
+                >
+                  More
+                </div>
+              </button>
+              <div
+                className="bx--accordion__content"
+                id="accordion-item-8"
+              >
+                <div
+                  className="tile-gallery--section--items"
+                >
+                  <a
+                    className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                  >
+                    <div>
+                      <div
+                        className="top-section"
+                      >
+                        <div
+                          className="thumbnail"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            description="Icon"
+                            fill="black"
+                            focusable="false"
+                            height={50}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 32 32"
+                            width={50}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
+                              transform="translate(0 .005)"
+                            />
+                            <path
+                              d="M6.854 5.375H8.854V10.333H6.854z"
+                              transform="rotate(-45 7.86 7.856)"
+                            />
+                            <path
+                              d="M2 15.005H7V17.005000000000003H2z"
+                            />
+                            <path
+                              d="M5.375 23.147H10.333V25.147H5.375z"
+                              transform="rotate(-45 7.86 24.149)"
+                            />
+                            <path
+                              d="M15 25.005H17V30.005H15z"
+                            />
+                            <path
+                              d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                              transform="rotate(-45 24.152 24.149)"
+                            />
+                            <path
+                              d="M25 15.005H30V17.005000000000003H25z"
+                            />
+                            <path
+                              d="M21.668 6.854H26.625999999999998V8.854H21.668z"
+                              transform="rotate(-45 24.152 7.856)"
+                            />
+                            <path
+                              d="M15 2.005H17V7.005H15z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          className="description-card"
+                        >
+                          <span>
+                            card description
+                          </span>
+                        </div>
+                      </div>
+                      <div
+                        className="content-container"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="#42be65"
+                          focusable="false"
+                          height={16}
+                          onClick={[Function]}
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 16 16"
+                          width={16}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                          />
+                          <path
+                            d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            data-icon-path="inner-path"
+                            opacity="0"
+                          />
+                        </svg>
+                        <span
+                          className="title-card"
+                        >
+                          Card title
+                        </span>
+                        <div
+                          className="overflow-menu"
+                          onClick={[Function]}
+                          role="presentation"
+                        >
+                          <button
+                            aria-expanded={false}
+                            aria-haspopup={true}
+                            aria-label="Menu"
+                            className="bx--overflow-menu"
+                            onClick={[Function]}
+                            onClose={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            style={
+                              Object {
+                                "height": "2rem",
+                              }
+                            }
+                            tabIndex={0}
+                          >
+                            <svg
+                              aria-label="open and close list of options"
+                              className="bx--overflow-menu__icon"
+                              focusable="false"
+                              height={16}
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              preserveAspectRatio="xMidYMid meet"
+                              role="img"
+                              viewBox="0 0 32 32"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <circle
+                                cx="16"
+                                cy="8"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="2"
+                              />
+                              <circle
+                                cx="16"
+                                cy="24"
+                                r="2"
+                              />
+                              <title>
+                                open and close list of options
+                              </title>
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileGallery TileGalleryViewSwitcher 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        className="bx--content-switcher"
+        onChange={[Function]}
+        role="tablist"
+      >
+        <button
+          aria-selected={true}
+          className="bx--content-switcher-btn bx--content-switcher--selected"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex="0"
+        >
+          <span
+            className="bx--content-switcher__label"
+          >
+            List
+          </span>
+        </button>
+        <button
+          aria-selected={false}
+          className="bx--content-switcher-btn"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex="-1"
+        >
+          <span
+            className="bx--content-switcher__label"
+          >
+            Grid
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TileGallery basic example  1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "width": "calc(100vw - 6rem)",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "width": "calc(100vw - 6rem)",
+          }
+        }
+      >
+        <div
+          className="tile-gallery"
+        >
+          <div
+            className="tile-gallery--section"
+          >
+            <ul
+              className="bx--accordion bx--accordion--end"
+            >
+              <li
+                className="bx--accordion__item bx--accordion__item--active"
+                onAnimationEnd={[Function]}
+              >
+                <button
+                  aria-controls="accordion-item-5"
+                  aria-expanded={true}
+                  className="bx--accordion__heading"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  title="Title"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--accordion__arrow"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                    />
+                  </svg>
+                  <div
+                    className="bx--accordion__title"
+                  >
+                    Title
+                  </div>
+                </button>
+                <div
+                  className="bx--accordion__content"
+                  id="accordion-item-5"
+                >
+                  <div
+                    className="tile-gallery--section--items"
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                    >
+                      <div>
+                        <div
+                          className="top-section"
+                        >
+                          <div
+                            className="thumbnail"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              description="Icon"
+                              fill="black"
+                              focusable="false"
+                              height={50}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={50}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M6.34 19H17.65V21H6.34z"
+                                transform="rotate(-45 11.995 20.002)"
+                              />
+                              <path
+                                d="M17,30a1,1,0,0,1-.37-.07,1,1,0,0,1-.62-.79l-1-7,2-.28.75,5.27L21,24.52V17a1,1,0,0,1,.29-.71l4.07-4.07A8.94,8.94,0,0,0,28,5.86V4H26.14a8.94,8.94,0,0,0-6.36,2.64l-4.07,4.07A1,1,0,0,1,15,11H7.48L4.87,14.26l5.27.75-.28,2-7-1a1,1,0,0,1-.79-.62,1,1,0,0,1,.15-1l4-5A1,1,0,0,1,7,9h7.59l3.77-3.78A10.92,10.92,0,0,1,26.14,2H28a2,2,0,0,1,2,2V5.86a10.92,10.92,0,0,1-3.22,7.78L23,17.41V25a1,1,0,0,1-.38.78l-5,4A1,1,0,0,1,17,30Z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            className="description-card"
+                          >
+                            <span>
+                              card description
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="content-container"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="#42be65"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span
+                            className="title-card"
+                          >
+                            Card title
+                          </span>
+                          <div
+                            className="overflow-menu"
+                            onClick={[Function]}
+                            role="presentation"
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              aria-label="Menu"
+                              className="bx--overflow-menu"
+                              onClick={[Function]}
+                              onClose={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              style={
+                                Object {
+                                  "height": "2rem",
+                                }
+                              }
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-label="open and close list of options"
+                                className="bx--overflow-menu__icon"
+                                focusable="false"
+                                height={16}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="16"
+                                  cy="8"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="16"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="24"
+                                  r="2"
+                                />
+                                <title>
+                                  open and close list of options
+                                </title>
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                    <a
+                      className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                    >
+                      <div>
+                        <div
+                          className="top-section"
+                        >
+                          <div
+                            className="thumbnail"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              description="Icon"
+                              fill="black"
+                              focusable="false"
+                              height={50}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={50}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M12,29a1,1,0,0,1-.92-.62L6.33,17H2V15H7a1,1,0,0,1,.92.62L12,25.28,20.06,3.65A1,1,0,0,1,21,3a1,1,0,0,1,.93.68L25.72,15H30v2H25a1,1,0,0,1-.95-.68L21,7,12.94,28.35A1,1,0,0,1,12,29Z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            className="description-card"
+                          >
+                            <span>
+                              card description
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="content-container"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="#42be65"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span
+                            className="title-card"
+                          >
+                            Card title
+                          </span>
+                          <div
+                            className="overflow-menu"
+                            onClick={[Function]}
+                            role="presentation"
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              aria-label="Menu"
+                              className="bx--overflow-menu"
+                              onClick={[Function]}
+                              onClose={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              style={
+                                Object {
+                                  "height": "2rem",
+                                }
+                              }
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-label="open and close list of options"
+                                className="bx--overflow-menu__icon"
+                                focusable="false"
+                                height={16}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="16"
+                                  cy="8"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="16"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="24"
+                                  r="2"
+                                />
+                                <title>
+                                  open and close list of options
+                                </title>
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                    <a
+                      className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                    >
+                      <div>
+                        <div
+                          className="top-section"
+                        >
+                          <div
+                            className="thumbnail"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              description="Icon"
+                              fill="black"
+                              focusable="false"
+                              height={50}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={50}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
+                                transform="translate(0 .005)"
+                              />
+                              <path
+                                d="M6.854 5.375H8.854V10.333H6.854z"
+                                transform="rotate(-45 7.86 7.856)"
+                              />
+                              <path
+                                d="M2 15.005H7V17.005000000000003H2z"
+                              />
+                              <path
+                                d="M5.375 23.147H10.333V25.147H5.375z"
+                                transform="rotate(-45 7.86 24.149)"
+                              />
+                              <path
+                                d="M15 25.005H17V30.005H15z"
+                              />
+                              <path
+                                d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                transform="rotate(-45 24.152 24.149)"
+                              />
+                              <path
+                                d="M25 15.005H30V17.005000000000003H25z"
+                              />
+                              <path
+                                d="M21.668 6.854H26.625999999999998V8.854H21.668z"
+                                transform="rotate(-45 24.152 7.856)"
+                              />
+                              <path
+                                d="M15 2.005H17V7.005H15z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            className="description-card"
+                          >
+                            <span>
+                              card description
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="content-container"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="#42be65"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span
+                            className="title-card"
+                          >
+                            Card title
+                          </span>
+                          <div
+                            className="overflow-menu"
+                            onClick={[Function]}
+                            role="presentation"
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              aria-label="Menu"
+                              className="bx--overflow-menu"
+                              onClick={[Function]}
+                              onClose={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              style={
+                                Object {
+                                  "height": "2rem",
+                                }
+                              }
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-label="open and close list of options"
+                                className="bx--overflow-menu__icon"
+                                focusable="false"
+                                height={16}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="16"
+                                  cy="8"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="16"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="24"
+                                  r="2"
+                                />
+                                <title>
+                                  open and close list of options
+                                </title>
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div
+            className="tile-gallery--section"
+          >
+            <ul
+              className="bx--accordion bx--accordion--end"
+            >
+              <li
+                className="bx--accordion__item bx--accordion__item--active"
+                onAnimationEnd={[Function]}
+              >
+                <button
+                  aria-controls="accordion-item-6"
+                  aria-expanded={true}
+                  className="bx--accordion__heading"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  title="More"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="bx--accordion__arrow"
+                    focusable="false"
+                    height={16}
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"
+                    />
+                  </svg>
+                  <div
+                    className="bx--accordion__title"
+                  >
+                    More
+                  </div>
+                </button>
+                <div
+                  className="bx--accordion__content"
+                  id="accordion-item-6"
+                >
+                  <div
+                    className="tile-gallery--section--items"
+                  >
+                    <a
+                      className="bx--tile bx--tile--clickable null tile-gallery-item bx--tile bx--tile--clickable tile-card-title"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                    >
+                      <div>
+                        <div
+                          className="top-section"
+                        >
+                          <div
+                            className="thumbnail"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              description="Icon"
+                              fill="black"
+                              focusable="false"
+                              height={50}
+                              preserveAspectRatio="xMidYMid meet"
+                              viewBox="0 0 32 32"
+                              width={50}
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M16,12a4,4,0,1,1-4,4,4.0045,4.0045,0,0,1,4-4m0-2a6,6,0,1,0,6,6,6,6,0,0,0-6-6Z"
+                                transform="translate(0 .005)"
+                              />
+                              <path
+                                d="M6.854 5.375H8.854V10.333H6.854z"
+                                transform="rotate(-45 7.86 7.856)"
+                              />
+                              <path
+                                d="M2 15.005H7V17.005000000000003H2z"
+                              />
+                              <path
+                                d="M5.375 23.147H10.333V25.147H5.375z"
+                                transform="rotate(-45 7.86 24.149)"
+                              />
+                              <path
+                                d="M15 25.005H17V30.005H15z"
+                              />
+                              <path
+                                d="M23.147 21.668H25.147V26.625999999999998H23.147z"
+                                transform="rotate(-45 24.152 24.149)"
+                              />
+                              <path
+                                d="M25 15.005H30V17.005000000000003H25z"
+                              />
+                              <path
+                                d="M21.668 6.854H26.625999999999998V8.854H21.668z"
+                                transform="rotate(-45 24.152 7.856)"
+                              />
+                              <path
+                                d="M15 2.005H17V7.005H15z"
+                              />
+                            </svg>
+                          </div>
+                          <div
+                            className="description-card"
+                          >
+                            <span>
+                              card description
+                            </span>
+                          </div>
+                        </div>
+                        <div
+                          className="content-container"
+                        >
+                          <svg
+                            aria-hidden={true}
+                            fill="#42be65"
+                            focusable="false"
+                            height={16}
+                            onClick={[Function]}
+                            preserveAspectRatio="xMidYMid meet"
+                            viewBox="0 0 16 16"
+                            width={16}
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M8,1C4.1,1,1,4.1,1,8c0,3.9,3.1,7,7,7s7-3.1,7-7C15,4.1,11.9,1,8,1z M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                            />
+                            <path
+                              d="M7,11L4.3,8.3l0.9-0.8L7,9.3l4-3.9l0.9,0.8L7,11z"
+                              data-icon-path="inner-path"
+                              opacity="0"
+                            />
+                          </svg>
+                          <span
+                            className="title-card"
+                          >
+                            Card title
+                          </span>
+                          <div
+                            className="overflow-menu"
+                            onClick={[Function]}
+                            role="presentation"
+                          >
+                            <button
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              aria-label="Menu"
+                              className="bx--overflow-menu"
+                              onClick={[Function]}
+                              onClose={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              style={
+                                Object {
+                                  "height": "2rem",
+                                }
+                              }
+                              tabIndex={0}
+                            >
+                              <svg
+                                aria-label="open and close list of options"
+                                className="bx--overflow-menu__icon"
+                                focusable="false"
+                                height={16}
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                preserveAspectRatio="xMidYMid meet"
+                                role="img"
+                                viewBox="0 0 32 32"
+                                width={16}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <circle
+                                  cx="16"
+                                  cy="8"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="16"
+                                  r="2"
+                                />
+                                <circle
+                                  cx="16"
+                                  cy="24"
+                                  r="2"
+                                />
+                                <title>
+                                  open and close list of options
+                                </title>
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/components/TimePickerSpinner/__snapshots__/TimePickerSpinner.story.storyshot
+++ b/src/components/TimePickerSpinner/__snapshots__/TimePickerSpinner.story.storyshot
@@ -1,0 +1,283 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TimePickerSpinner Default timeGroup to minutes 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+        }
+      }
+    >
+      <div
+        className="iot--time-picker__wrapper iot--time-picker__wrapper--with-spinner iot--time-picker__wrapper--show-underline-minutes"
+      >
+        <div
+          className="bx--form-item"
+        >
+          <div
+            className="bx--time-picker"
+          >
+            <div
+              className="bx--time-picker__input"
+            >
+              <input
+                aria-label="Pick a time"
+                className="bx--time-picker__input-field bx--text-input"
+                disabled={false}
+                id="timepicker"
+                maxLength={5}
+                onBlur={[Function]}
+                onChange={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                pattern="(1[012]|[1-9]):[0-5][0-9](\\\\s)?"
+                placeholder="hh:mm"
+                type="text"
+                value="19:33"
+              />
+            </div>
+            <div
+              className="iot--time-picker__controls"
+            >
+              <button
+                aria-atomic="true"
+                aria-label="Increment minutes"
+                aria-live="polite"
+                className="iot--time-picker__controls--btn up-icon"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                title="Increment minutes"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="up-icon"
+                  focusable="false"
+                  height={4}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 8 4"
+                  width={8}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 4L4 0 8 4z"
+                  />
+                </svg>
+              </button>
+              <button
+                aria-atomic="true"
+                aria-label="Decrement minutes"
+                aria-live="polite"
+                className="iot--time-picker__controls--btn down-icon"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                title="Decrement minutes"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="down-icon"
+                  focusable="false"
+                  height={4}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 8 4"
+                  width={8}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 0L4 4 0 0z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;
+
+exports[`Storybook Snapshot tests and console checks Storyshots Watson IoT Experimental/TimePickerSpinner With spinner 1`] = `
+<div
+  className="storybook-container"
+>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "margin": 20,
+        }
+      }
+    >
+      <div
+        className="iot--time-picker__wrapper iot--time-picker__wrapper--with-spinner"
+      >
+        <div
+          className="bx--form-item"
+        >
+          <div
+            className="bx--time-picker"
+          >
+            <div
+              className="bx--time-picker__input"
+            >
+              <input
+                aria-label="Pick a time"
+                className="bx--time-picker__input-field bx--text-input"
+                disabled={false}
+                id="timepicker"
+                maxLength={5}
+                onBlur={[Function]}
+                onChange={[Function]}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                pattern="(1[012]|[1-9]):[0-5][0-9](\\\\s)?"
+                placeholder="hh:mm"
+                type="text"
+                value="19:33"
+              />
+            </div>
+            <div
+              className="iot--time-picker__controls"
+            >
+              <button
+                aria-atomic="true"
+                aria-label="Increment hours"
+                aria-live="polite"
+                className="iot--time-picker__controls--btn up-icon"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                title="Increment hours"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="up-icon"
+                  focusable="false"
+                  height={4}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 8 4"
+                  width={8}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 4L4 0 8 4z"
+                  />
+                </svg>
+              </button>
+              <button
+                aria-atomic="true"
+                aria-label="Decrement hours"
+                aria-live="polite"
+                className="iot--time-picker__controls--btn down-icon"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                title="Decrement hours"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="down-icon"
+                  focusable="false"
+                  height={4}
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 8 4"
+                  width={8}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 0L4 4 0 0z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="info__show-button"
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#027ac5",
+        "border": "none",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="button"
+  >
+    Show Info
+  </button>
+</div>
+`;

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4462,7 +4462,7 @@ Map {
       "onSort": [Function],
       "selectedSortOption": "",
       "sortOptions": Array [],
-      "tiles": null,
+      "tiles": Array [],
       "title": "",
     },
     "propTypes": Object {

--- a/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/publicAPI.test.js.snap
@@ -4462,6 +4462,7 @@ Map {
       "onSort": [Function],
       "selectedSortOption": "",
       "sortOptions": Array [],
+      "tiles": null,
       "title": "",
     },
     "propTypes": Object {
@@ -4532,7 +4533,6 @@ Map {
             "type": "node",
           },
         ],
-        "isRequired": true,
         "type": "arrayOf",
       },
       "title": Object {
@@ -13062,25 +13062,8 @@ Map {
     "defaultProps": Object {},
     "propTypes": Object {
       "children": Object {
-        "args": Array [
-          Object {
-            "args": Array [
-              Object {
-                "type": Object {
-                  "args": Array [
-                    Array [
-                      [Function],
-                    ],
-                  ],
-                  "type": "oneOf",
-                },
-              },
-            ],
-            "type": "shape",
-          },
-        ],
         "isRequired": true,
-        "type": "arrayOf",
+        "type": "node",
       },
     },
   },


### PR DESCRIPTION
Part of #1413

**Summary**

- Re-enables snapshot testing for experimental components
- Disables snapshot testing for TileCatalogNew, SimpleList, and ListItem as they have unique key warnings that require more work to fix. Tracking with #1412 

**Change List (commits, features, bugs, etc)**

- Removed Experimental regex from `StorybookSnapshots.test.js`
- Added regex to pass testing on TileCatalogNew, SimpleList, and ListItem
- Added `labelText` prop to List stories to remove warning
- Added keys to SimpleList story action components to remove warning
- Fixed proptype in TileCatalogNew to not require the prop `tiles` to remove warning
- Added warning exception for ComboBox experimental prop to remove warning
- Added exception for HierarchyList's ref and mocked `scrollIntoView` as its not implemented in jsdom
- Fixed TileGallery propType to remove warning
- Fixed TileCatalogNew tiles function by removing 2nd argument

**Acceptance Test (how to verify the PR)**

- Run `yarn test:update` successfully
